### PR TITLE
Schema schema!

### DIFF
--- a/typed/declaration/examples.ipldsch
+++ b/typed/declaration/examples.ipldsch
@@ -1,0 +1,11 @@
+
+type ExampleWithNullable map {String : nullable String}
+
+type ExampleWithAnonDefns struct {
+	fooField optional {String:String}
+	barField nullable {String:String}
+	bazField {String : nullable String}
+	wozField {String:[nullable String]}
+} representation map (
+	fooField: alias="foo_field"
+)

--- a/typed/declaration/examples.ipldsch.json
+++ b/typed/declaration/examples.ipldsch.json
@@ -13,20 +13,16 @@
 					"valueType": {
 						"type": "map",
 						"keyType": "String",
-						"valueType": "String",
-						"valueNullable": false
+						"valueType": "String"
 					},
-					"optional": true,
-					"nullable": false
+					"optional": true
 				},
 				"barField": {
 					"valueType": {
 						"type": "map",
 						"keyType": "String",
-						"valueType": "String",
-						"valueNullable": false
+						"valueType": "String"
 					},
-					"optional": false,
 					"nullable": true
 				},
 				"bazField": {
@@ -35,9 +31,7 @@
 						"keyType": "String",
 						"valueType": "String",
 						"valueNullable": true
-					},
-					"optional": false,
-					"nullable": false
+					}
 				},
 				"wozField": {
 					"valueType": {
@@ -47,11 +41,8 @@
 							"type": "list",
 							"valueType": "String",
 							"valueNullable": true
-						},
-						"valueNullable": false
-					},
-					"optional": false,
-					"nullable": false
+						}
+					}
 				}
 			},
 			"representation": {

--- a/typed/declaration/examples.ipldsch.json
+++ b/typed/declaration/examples.ipldsch.json
@@ -1,0 +1,66 @@
+{
+	"schema": {
+		"ExampleWithNullable": {
+			"kind": "map",
+			"keyType": "String",
+			"valueType": "String",
+			"valueNullable": true
+		},
+		"ExampleWithAnonDefns": {
+			"kind": "struct",
+			"fields": {
+				"fooField": {
+					"valueType": {
+						"type": "map",
+						"keyType": "String",
+						"valueType": "String",
+						"valueNullable": false
+					},
+					"optional": true,
+					"nullable": false
+				},
+				"barField": {
+					"valueType": {
+						"type": "map",
+						"keyType": "String",
+						"valueType": "String",
+						"valueNullable": false
+					},
+					"optional": false,
+					"nullable": true
+				},
+				"bazField": {
+					"valueType": {
+						"type": "map",
+						"keyType": "String",
+						"valueType": "String",
+						"valueNullable": true
+					},
+					"optional": false,
+					"nullable": false
+				},
+				"wozField": {
+					"valueType": {
+						"type": "map",
+						"keyType": "String",
+						"valueType": {
+							"type": "list",
+							"valueType": "String",
+							"valueNullable": true
+						},
+						"valueNullable": false
+					},
+					"optional": false,
+					"nullable": false
+				}
+			},
+			"representation": {
+				"map": {
+					"fieldAliases": {
+						"fooField": "foo_field"
+					}
+				}
+			}
+		}
+	}
+}

--- a/typed/declaration/schema-schema.ipldsch
+++ b/typed/declaration/schema-schema.ipldsch
@@ -46,7 +46,7 @@ type SchemaMap map {TypeName:Type}
 ## }
 ## ```
 ##
-type Schema union = {
+type Schema union {
 	| SchemaMap "schema"
 } representation keyed
 
@@ -75,7 +75,7 @@ type Schema union = {
 ## }
 ## ```
 ##
-type Type union = {
+type Type union {
 	| TypeBool "bool"
 	| TypeString "string"
 	| TypeBytes "bytes"
@@ -88,3 +88,122 @@ type Type union = {
 	| TypeStruct "struct"
 	| TypeEnum "enum"
 } representation inline "type"
+
+## TypeKind enumerates all the major kinds of type.
+## Notice this enum's members are the same as the set of strings used as
+## discriminants in the Type union.
+##
+## TODO: not actually sure we'll need to declare this.  Only usage is
+## in the Type union representation details?
+type TypeKind enum {
+	| "bool"
+	| "string"
+	| "bytes"
+	| "int"
+	| "float"
+	| "map"
+	| "list"
+	| "link"
+	| "union"
+	| "struct"
+	| "enum"
+}
+
+## RepresentationKind is similar to TypeKind, but includes only those concepts
+## which exist at the IPLD *Data Model* level.
+##
+## In other words, structs, unions, and enumerations are not present:
+## those concepts are introduced in the IPLD Schema system, and when serialized,
+## all of them must be transformable to one of these representation kinds
+## (e.g. a "struct" TypeKind will usually be transformed to a "map"
+## RepresentationKind; "enum" TypeKind are always "string" RepresentationKind;
+## and so on.)
+##
+## RepresentationKind strings are sometimes used to to indicate part of the
+## definition in the details of Type; for example, they're used describing
+## some of the detailed behaviors of a "kinded"-style union type.
+type RepresentationKind enum {
+	| "bool"
+	| "string"
+	| "bytes"
+	| "int"
+	| "float"
+	| "map"
+	| "list"
+	| "link"
+}
+
+## TypeBool describes a simple boolean type.
+## It has no details.
+##
+type TypeBool struct {}
+
+## TypeString describes a simple string type.
+## It has no details.
+##
+type TypeString struct {}
+
+## TypeBytes describes a simple byte array type.
+## It has no details.
+##
+type TypeBytes struct {}
+
+## TypeInt describes a simple integer numeric type.
+## It has no details.
+##
+type TypeInt struct {}
+
+## TypeFloat describes a simple floating point numeric type.
+## It has no details.
+##
+type TypeFloat struct {}
+
+## TypeMap describes a key-value map.
+## The keys and values of the map have some specific type of their own.
+##
+type TypeMap struct {
+	# TODO
+}
+
+## TypeList describes a list.
+## The values of the list have some specific type of their own.
+##
+type TypeList struct {
+	# TODO
+}
+
+## TypeLink describes a hash linking to another object (a CID).
+##
+## REVIEW: this currently has no details... but possibly it should have a
+## type hint for what we expect when resolving the link?
+##
+type TypeLink struct {}
+
+## TypeUnion describes a union (sometimes called a "sum type", or
+## more verbosely, a "discriminated union").
+## A union is a type that can have a value of several different types, but
+## unlike maps or structs, in a union only one of those values may be present
+## at a time.
+##
+## Unions can be defined as representing in several different ways: "keyed",
+## "envelop", or "inline" are all representations that become a map (some
+## literature may describe this as "tagged" style unions), and a fourth style,
+## "kinded" unions, may actually be any of the other representation kinds!
+##
+type TypeUnion struct {
+	members UnionContent
+}
+
+type UnionContent union {
+	# TODO
+} representation keyed
+
+## TypeStruct
+type TypeStruct struct {
+	# TODO
+}
+
+## TypeEnum
+type TypeEnum struct {
+	# TODO
+}

--- a/typed/declaration/schema-schema.ipldsch
+++ b/typed/declaration/schema-schema.ipldsch
@@ -270,7 +270,8 @@ type TypeStruct struct {
 	# TODO
 }
 
-## TypeEnum
+## TypeEnum describes a type which has a known, pre-defined set of possible
+## values.  Each of the values must be representable a string.
 type TypeEnum struct {
-	# TODO
+	members {String:Null}
 }

--- a/typed/declaration/schema-schema.ipldsch
+++ b/typed/declaration/schema-schema.ipldsch
@@ -269,33 +269,81 @@ type UnionRepresentation_Inline struct {
 }
 
 ## TypeStruct describes a type which has a group of fields of varying Type.
-## Each field has a name (and typically, the struct will be represented as a
-## map, which uses these names as the map keys).
+## Each field has a name, which is used to access its value, similarly to
+## accessing values in a map.
+##
+## The most typical representation of a struct is as a map, in which case field
+## names also serve as the the map keys (though this is a default, and details
+## of this representation may be configured; and other representation strategies
+## also exist).
+##
 type TypeStruct struct {
 	fields {String:StructField}
 	representation StructRepresentation
 }
 
+## StructField describes the properties of each field declared by a TypeStruct.
+##
+## StructField contains properties similar to TypeMap -- namely, it describes
+## a content type (as a TypeTerm -- it supports inline definitions) -- and
+## has a boolean property for whether or not the value is permitted to be null.
+##
+## In addition, StructField also has a property called "optional".
+## An "optional" field is one which is permitted to be absent entirely.
+## This is distinct from "nullable": a field can be optional=false and
+## nullable=true, in which case it's an error if the key is missing entirely,
+## but null is of course valid.  Conversely, if a field is optional=true and
+## nullable=false, it's an error if the field is present and assigned null, but
+## fine for a map to be missing a key of the field's name entirely and still be
+## recognized as this struct.
+## (The specific behavior of optionals may vary per StructRepresentation.)
+##
 type StructField struct {
-	valueType TypeTerm
+	type TypeTerm
 	optional optional Bool
 	nullable optional Bool
 }
 
+## TypeTerm is a union of either TypeName or an InlineDefn.  It's used for the
+## value type in the recursive types (maps, lists, and the fields of structs),
+## which allows the use of InlineDefn in any of those positions.
+##
+## TypeTerm is simply a TypeName if the kind of data is a string; this is the
+## simple case.
+##
+## Note that TypeTerm isn't used to describe *keys* in the recursive types that
+## have them (maps, structs) -- recursive types in keys would not lend itself
+## well to serialization!
+## TypeTerm also isn't used to describe members in Unions -- this is a choice
+## aimed to limit syntactical complexity (both at type definition authoring
+## time, as well as for the sake of error messaging during typechecking).
+##
 type TypeTerm union {
 	| TypeName string
 	| InlineDefn map
 } representation kinded
 
+## InlineDefn represents a declaration of an anonymous type of one of the simple
+## recursive kinds (e.g. map or list) which is found "inline" in another type's
+## definition.  It's the more complex option of the TypeTerm union.
+##
+## Note that the representation of this union -- `representation inline "kind"`
+## -- as well as the keywords for its members -- align exactly with those
+## in the Type union.  Technically, this isn't a necessary property (in that
+## nothing would break if that sameness was violated) but it's awfully nice for
+## sanity; what we're saying here is that the representation of the types in an
+## InlineDefn should look *exactly the same* as the top-level Types... it's just
+## that we're restricted to a subset of the members.
+##
 type InlineDefn union {
 	| TypeMap "map"
 	| TypeList "list"
-} representation keyed
+} representation inline "kind"
 
 type StructRepresentation union {
 	| StructRepresentation_Map "map"
 	| StructRepresentation_Tuple "tuple"
-}
+} representation keyed
 type StructRepresentation_Map struct {
 	fieldAliases optional {String:String}
 }

--- a/typed/declaration/schema-schema.ipldsch
+++ b/typed/declaration/schema-schema.ipldsch
@@ -188,8 +188,11 @@ type TypeLink struct {}
 ## Unions can be defined as representing in several different ways: see
 ## the documentation on the UnionRepresentation type for details.
 ##
+## The set of types which the union can contain are specified in a map
+## inside the representation field.  (The key type of the map varies per
+## representation strategy, so it's not possible to keep on this type directly.)
+##
 type TypeUnion struct {
-	members {TypeName} # FIXME: this is clearly a set; I don't know what to make the map value.
 	representation UnionRepresentation
 }
 

--- a/typed/declaration/schema-schema.ipldsch
+++ b/typed/declaration/schema-schema.ipldsch
@@ -23,7 +23,7 @@ type TypeName string
 ##
 ## ```
 ## {
-##   "TypeFoo": {
+##   "MyFooType": {
 ##     "type": "string"
 ##   }
 ## }
@@ -34,12 +34,12 @@ type SchemaMap map {TypeName:Type}
 ## Schema is a single-member union, which can be used in serialization
 ## to make a form of "nominative type declaration".
 ##
-## A complete Schema might look like this:
+## A complete (if quite short) Schema might look like this:
 ##
 ## ```
 ## {
 ##   "schema": {
-##     "TypeFoo": {
+##     "MyFooType": {
 ##       "type": "string"
 ##     }
 ##   }

--- a/typed/declaration/schema-schema.ipldsch
+++ b/typed/declaration/schema-schema.ipldsch
@@ -265,9 +265,30 @@ type UnionRepresentation_Inline struct {
 	discriminantTable map {String:TypeName}
 }
 
-## TypeStruct
+## TypeStruct describes a type which has a group of fields of varying Type.
+## Each field has a name (and typically, the struct will be represented as a
+## map, which uses these names as the map keys).
 type TypeStruct struct {
-	# TODO
+	fields {String:StructField}
+	representation StructRepresentation
+}
+
+type StructField struct {
+	content TypeTerm
+	optional Bool
+}
+
+type TypeTerm = TODO
+
+type StructRepresentation union {
+	| StructRepresentation_Map "map"
+	| StructRepresentation_Tuple "tuple"
+}
+type StructRepresentation_Map struct {
+	fieldAliases optional {String:String}
+}
+type StructRepresentation_Tuple struct {
+	fieldOrder optional [String]
 }
 
 ## TypeEnum describes a type which has a known, pre-defined set of possible

--- a/typed/declaration/schema-schema.ipldsch
+++ b/typed/declaration/schema-schema.ipldsch
@@ -87,7 +87,7 @@ type Type union {
 	| TypeUnion "union"
 	| TypeStruct "struct"
 	| TypeEnum "enum"
-} representation inline "type"
+} representation inline "kind"
 
 ## TypeKind enumerates all the major kinds of type.
 ## Notice this enum's members are the same as the set of strings used as

--- a/typed/declaration/schema-schema.ipldsch
+++ b/typed/declaration/schema-schema.ipldsch
@@ -185,18 +185,82 @@ type TypeLink struct {}
 ## unlike maps or structs, in a union only one of those values may be present
 ## at a time.
 ##
-## Unions can be defined as representing in several different ways: "keyed",
-## "envelop", or "inline" are all representations that become a map (some
-## literature may describe this as "tagged" style unions), and a fourth style,
-## "kinded" unions, may actually be any of the other representation kinds!
+## Unions can be defined as representing in several different ways: see
+## the documentation on the UnionRepresentation type for details.
 ##
 type TypeUnion struct {
-	members UnionContent
+	members {TypeName} # FIXME: this is clearly a set; I don't know what to make the map value.
+	representation UnionRepresentation
 }
 
-type UnionContent union {
-	# TODO
+## UnionRepresentation is a union of all the distinct ways a TypeUnion's values
+## can be mapped onto a serialized format for the IPLD Data Model.
+##
+## There are "keyed", "envelop", and "inline" strategies, which are all ways
+## to produce representations in a map format (some literature may describe
+## this as "tagged" style unions), and a fourth style, "kinded" unions, may
+## actually encode itself as any of the other representation kinds!
+##
+## Note: Unions can be used to produce a "nominative" style of type declarations
+## -- yes, even given that IPLD Schema systems are natively "structural" typing!
+##
+type UnionRepresentation union {
+	| UnionRepresentation_Kinded "kinded"
+	| UnionRepresentation_Keyed "keyed"
+	| UnionRepresentation_Envelope "envelope"
+	| UnionRepresentation_Inline "inline"
 } representation keyed
+
+## "Kinded" union representations describe a bidirectional mapping between
+## a RepresentationKind and a Type (referenced by name) which should be the
+## union member decoded when one sees this RepresentationKind.
+##
+## The referenced type must of course produce the RepresentationKind it's
+## matched with!
+type UnionRepresentation_Kinded map {RepresentationKind:TypeName}
+
+## "Keyed" union representations will encode as a map, where the map has
+## exactly one entry, the key string of which will be used to look up the name
+## of the Type; and the value should be the content, and be of that Type.
+##
+## Note: when writing a new protocol, it may be wise to prefer keyed unions
+## over the other styles wherever possible; keyed unions tend to have good
+## performance characteristics, as they have most "mechanical sympathy" with
+## parsing and deserialization implementation order.
+type UnionRepresentation_Keyed map {String:TypeName}
+
+## "Envelope" union representations will encode as a map, where the map has
+## exactly two entries: the two keys should be of the exact strings specified
+## for this envelope representation.  The value for the discriminator key
+## should be one of the strings in the discriminant table.  The value for
+## the content key should be the content, and be of the Type matching the
+## lookup in the discriminant table.
+type UnionRepresentation_Envelope struct {
+	discriminatorKey String
+	contentKey String
+	discriminantTable map {String:TypeName}
+}
+
+## "Inline" union representations require that all of their members encode
+## as a map, and encode their type info into the same map as the member data.
+## Thus, the map for an inline union may have any number of entries: it is
+## however many fields the member value has, plus one (for the discriminant).
+##
+## All members of an inline union must be struct types and must encode to
+## the map RepresentationKind.  Other types which encode to map (such as map
+## types themselves!) cannot be used: the potential for content values with
+## with keys overlapping with the discriminatorKey would result in undefined
+## behavior!  Similarly, the member struct types may not have fields which
+## have names that collide with the discriminatorKey.
+##
+## When designing a new protocol, use inline unions sparringly; despite
+## appearing simple, they have the most edge cases of any kind of union
+## representation, and their implementation is generally the most complex and
+## is difficult to optimize deserialization to support.
+type UnionRepresentation_Inline struct {
+	discriminatorKey String
+	discriminantTable map {String:TypeName}
+}
 
 ## TypeStruct
 type TypeStruct struct {

--- a/typed/declaration/schema-schema.ipldsch
+++ b/typed/declaration/schema-schema.ipldsch
@@ -164,7 +164,7 @@ type TypeFloat struct {}
 type TypeMap struct {
 	keyType TypeName # additionally, the referenced type must be reprkind==string.
 	valueType TypeTerm
-	valueNullable Bool
+	valueNullable optional Bool
 }
 
 ## TypeList describes a list.
@@ -172,7 +172,7 @@ type TypeMap struct {
 ##
 type TypeList struct {
 	valueType TypeTerm
-	valueNullable Bool
+	valueNullable optional Bool
 }
 
 ## TypeLink describes a hash linking to another object (a CID).
@@ -278,8 +278,8 @@ type TypeStruct struct {
 
 type StructField struct {
 	valueType TypeTerm
-	optional Bool
-	nullable Bool
+	optional optional Bool
+	nullable optional Bool
 }
 
 type TypeTerm union {

--- a/typed/declaration/schema-schema.ipldsch
+++ b/typed/declaration/schema-schema.ipldsch
@@ -164,6 +164,7 @@ type TypeFloat struct {}
 type TypeMap struct {
 	keyType TypeName # additionally, the referenced type must be reprkind==string.
 	valueType TypeTerm
+	valueNullable Bool
 }
 
 ## TypeList describes a list.
@@ -171,6 +172,7 @@ type TypeMap struct {
 ##
 type TypeList struct {
 	valueType TypeTerm
+	valueNullable Bool
 }
 
 ## TypeLink describes a hash linking to another object (a CID).
@@ -275,11 +277,20 @@ type TypeStruct struct {
 }
 
 type StructField struct {
-	content TypeTerm
+	valueType TypeTerm
 	optional Bool
+	nullable Bool
 }
 
-type TypeTerm = TODO
+type TypeTerm union {
+	| TypeName string
+	| InlineDefn map
+} representation kinded
+
+type InlineDefn union {
+	| TypeMap "map"
+	| TypeList "list"
+} representation keyed
 
 type StructRepresentation union {
 	| StructRepresentation_Map "map"

--- a/typed/declaration/schema-schema.ipldsch
+++ b/typed/declaration/schema-schema.ipldsch
@@ -1,0 +1,90 @@
+## -----
+## This is the schema describing the schema declarations for IPLD Schemas.
+## Yes, it's self-describing! :)
+## -----
+
+## Type names are a simple alias of string.
+##
+## There are some additional rules that should be applied:
+##   - Type names should by convention begin with a capital letter;
+##   - Type names must be all printable characters (no whitespace);
+##   - Type names must not contain punctuation (dashes, dots, etc).
+##
+## Type names are strings meant for human consumption at a local scope.
+## When making a Schema, note that the TypeName is the key of the map:
+## a TypeName must be unique within the Schema.
+##
+type TypeName string
+
+## SchemaMap is a complete set of types;
+## it is simply a map of TypeName to detailed declaration of that Type.
+##
+## A simple schema map with one type might look like this:
+##
+## ```
+## {
+##   "TypeFoo": {
+##     "type": "string"
+##   }
+## }
+## ```
+##
+type SchemaMap map {TypeName:Type}
+
+## Schema is a single-member union, which can be used in serialization
+## to make a form of "nominative type declaration".
+##
+## A complete Schema might look like this:
+##
+## ```
+## {
+##   "schema": {
+##     "TypeFoo": {
+##       "type": "string"
+##     }
+##   }
+## }
+## ```
+##
+type Schema union = {
+	| SchemaMap "schema"
+} representation keyed
+
+## The types of Type are a union.
+##
+## The Type union is serialized using "inline" union representation,
+## which means all of its members have map representations, and there will be
+## an entry in that map called "type" which contains the union discriminator.
+##
+## Some of the kinds of type are so simple the union discriminator is the only
+## content at all, e.g. strings:
+##
+## ```
+## {
+##   "type": "string"
+## }
+## ```
+##
+## Other types have more content.  Consider this example of a map type:
+##
+## ```
+## {
+##   "type": "map",
+##   "keyType": "String",
+##   "valueType": "Int"
+## }
+## ```
+##
+type Type union = {
+	| TypeBool "bool"
+	| TypeString "string"
+	| TypeBytes "bytes"
+	| TypeInt "int"
+	| TypeFloat "float"
+	| TypeMap "map"
+	| TypeList "list"
+	| TypeLink "link"
+	| TypeUnion "union"
+	| TypeStruct "struct"
+	| TypeEnum "enum"
+} representation inline "type"

--- a/typed/declaration/schema-schema.ipldsch
+++ b/typed/declaration/schema-schema.ipldsch
@@ -162,14 +162,15 @@ type TypeFloat struct {}
 ## The keys and values of the map have some specific type of their own.
 ##
 type TypeMap struct {
-	# TODO
+	keyType TypeName # additionally, the referenced type must be reprkind==string.
+	valueType TypeTerm
 }
 
 ## TypeList describes a list.
 ## The values of the list have some specific type of their own.
 ##
 type TypeList struct {
-	# TODO
+	valueType TypeTerm
 }
 
 ## TypeLink describes a hash linking to another object (a CID).
@@ -241,7 +242,7 @@ type UnionRepresentation_Keyed map {String:TypeName}
 type UnionRepresentation_Envelope struct {
 	discriminatorKey String
 	contentKey String
-	discriminantTable map {String:TypeName}
+	discriminantTable {String:TypeName}
 }
 
 ## "Inline" union representations require that all of their members encode
@@ -262,7 +263,7 @@ type UnionRepresentation_Envelope struct {
 ## is difficult to optimize deserialization to support.
 type UnionRepresentation_Inline struct {
 	discriminatorKey String
-	discriminantTable map {String:TypeName}
+	discriminantTable {String:TypeName}
 }
 
 ## TypeStruct describes a type which has a group of fields of varying Type.

--- a/typed/declaration/schema-schema.ipldsch.json
+++ b/typed/declaration/schema-schema.ipldsch.json
@@ -5,7 +5,7 @@
 		},
 		"SchemaMap": {
 			"kind": "map",
-			"keyType": "String",
+			"keyType": "TypeName",
 			"valueType": "Type"
 		},
 		"Schema": {
@@ -48,6 +48,252 @@
 				"map": null,
 				"list": null,
 				"link": null
+			}
+		},
+		"TypeBool": {
+			"kind": "struct",
+			"fields": {},
+			"representation": {
+				"map": {}
+			}
+		},
+		"TypeString": {
+			"kind": "struct",
+			"fields": {},
+			"representation": {
+				"map": {}
+			}
+		},
+		"TypeBytes": {
+			"kind": "struct",
+			"fields": {},
+			"representation": {
+				"map": {}
+			}
+		},
+		"TypeInt": {
+			"kind": "struct",
+			"fields": {},
+			"representation": {
+				"map": {}
+			}
+		},
+		"TypeFloat": {
+			"kind": "struct",
+			"fields": {},
+			"representation": {
+				"map": {}
+			}
+		},
+		"TypeMap": {
+			"kind": "struct",
+			"fields": {
+				"keyType": {
+					"type": "TypeName"
+				},
+				"valueType": {
+					"type": "TypeTerm"
+				},
+				"valueNullable": {
+					"type": "Bool",
+					"optional": true
+				}
+			},
+			"representation": {
+				"map": {}
+			}
+		},
+		"TypeList": {
+			"kind": "struct",
+			"fields": {
+				"valueType": {
+					"type": "TypeTerm"
+				},
+				"valueNullable": {
+					"type": "Bool",
+					"optional": true
+				}
+			},
+			"representation": {
+				"map": {}
+			}
+		},
+		"TypeUnion": {
+			"kind": "struct",
+			"fields": {
+				"representation": {
+					"type": "UnionRepresentation"
+				}
+			},
+			"representation": {
+				"map": {}
+			}
+		},
+		"UnionRepresentation": {
+			"kind": "union",
+			"representation": {
+				"keyed": {
+					"kinded": "UnionRepresentation_Kinded",
+					"keyed": "UnionRepresentation_Keyed",
+					"envelope": "UnionRepresentation_Envelope",
+					"inline": "UnionRepresentation_Inline"
+				}
+			}
+		},
+		"UnionRepresentation_Kinded": {
+			"kind": "map",
+			"keyType": "RepresentationKind",
+			"valueType": "TypeName"
+		},
+		"UnionRepresentation_Keyed": {
+			"kind": "map",
+			"keyType": "String",
+			"valueType": "TypeName"
+		},
+		"UnionRepresentation_Envelope": {
+			"kind": "struct",
+			"fields": {
+				"discriminatorKey": {
+					"type": "String"
+				},
+				"contentKey": {
+					"type": "String"
+				},
+				"discriminantTable": {
+					"type": {
+						"kind": "map",
+						"keyType": "String",
+						"valueType": "TypeName"
+					}
+				}
+			}
+		},
+		"UnionRepresentation_Inline": {
+			"kind": "struct",
+			"fields": {
+				"discriminatorKey": {
+					"type": "String"
+				},
+				"discriminantTable": {
+					"type": {
+						"kind": "map",
+						"keyType": "String",
+						"valueType": "TypeName"
+					}
+				}
+			}
+		},
+		"TypeStruct": {
+			"kind": "struct",
+			"fields": {
+				"fields": {
+					"type": {
+						"kind": "map",
+						"keyType": "String",
+						"valueType": "StructField"
+					}
+				},
+				"representation": {
+					"type": "StructRepresentation"
+				}
+			},
+			"representation": {
+				"map": {}
+			}
+		},
+		"StructField": {
+			"kind": "struct",
+			"fields": {
+				"type": {
+					"type": "TypeTerm"
+				},
+				"optional": {
+					"type": "Bool",
+					"optional": true
+				},
+				"nullable": {
+					"type": "Bool",
+					"optional": true
+				}
+			},
+			"representation": {
+				"map": {}
+			}
+		},
+		"TypeTerm": {
+			"kind": "union",
+			"representation": {
+				"kinded": {
+					"string": "TypeName",
+					"map": "InlineDefn"
+				}
+			}
+		},
+		"InlineDefn": {
+			"kind": "union",
+			"representation": {
+				"inline": {
+					"discriminatorKey": "kind",
+					"discriminantTable": {
+						"map": "TypeMap",
+						"list": "TypeList"
+					}
+				}
+			}
+		},
+		"StructRepresentation": {
+			"kind": "union",
+			"representation": {
+				"keyed": {
+					"map": "StructRepresentation_Map",
+					"tuple": "StructRepresentation_Tuple"
+				}
+			}
+		},
+		"StructRepresentation_Map": {
+			"kind": "struct",
+			"fields": {
+				"fieldAliases": {
+					"type": {
+						"kind": "map",
+						"keyType": "String",
+						"valueType": "String"
+					},
+					"optional": true
+				}
+			},
+			"representation": {
+				"map": {}
+			}
+		},
+		"StructRepresentation_Tuple": {
+			"kind": "struct",
+			"fields": {
+				"fieldOrder": {
+					"type": {
+						"kind": "list",
+						"valueType": "String"
+					},
+					"optional": true
+				}
+			},
+			"representation": {
+				"map": {}
+			}
+		},
+		"TypeEnum": {
+			"kind": "struct",
+			"fields": {
+				"members": {
+					"type": {
+						"kind": "map",
+						"keyType": "String",
+						"valueType": "Null"
+					}
+				}
+			},
+			"representation": {
+				"map": {}
 			}
 		}
 	}

--- a/typed/declaration/schema-schema.ipldsch.json
+++ b/typed/declaration/schema-schema.ipldsch.json
@@ -1,37 +1,39 @@
 {
-	"TypeName": {
-		"kind": "string"
-	},
-	"SchemaMap": {
-		"kind": "map",
-		"keyType": "String",
-		"valueType": "Type"
-	},
-	"Schema": {
-		"kind": "union",
-		"representation": {
-			"keyed": {
-				"schema": "SchemaMap"
+	"schema": {
+		"TypeName": {
+			"kind": "string"
+		},
+		"SchemaMap": {
+			"kind": "map",
+			"keyType": "String",
+			"valueType": "Type"
+		},
+		"Schema": {
+			"kind": "union",
+			"representation": {
+				"keyed": {
+					"schema": "SchemaMap"
+				}
 			}
-		}
-	},
-	"Type": {
-		"kind": "union",
-		"representation": {
-			"inline": {
-				"discriminatorKey": "kind",
-				"discriminantTable": {
-					"bool": "TypeBool",
-					"string": "TypeString",
-					"bytes": "TypeBytes",
-					"int": "TypeInt",
-					"float": "TypeFloat",
-					"map": "TypeMap",
-					"list": "TypeList",
-					"link": "TypeLink",
-					"union": "TypeUnion",
-					"struct": "TypeStruct",
-					"enum": "TypeEnum"
+		},
+		"Type": {
+			"kind": "union",
+			"representation": {
+				"inline": {
+					"discriminatorKey": "kind",
+					"discriminantTable": {
+						"bool": "TypeBool",
+						"string": "TypeString",
+						"bytes": "TypeBytes",
+						"int": "TypeInt",
+						"float": "TypeFloat",
+						"map": "TypeMap",
+						"list": "TypeList",
+						"link": "TypeLink",
+						"union": "TypeUnion",
+						"struct": "TypeStruct",
+						"enum": "TypeEnum"
+					}
 				}
 			}
 		}

--- a/typed/declaration/schema-schema.ipldsch.json
+++ b/typed/declaration/schema-schema.ipldsch.json
@@ -36,6 +36,19 @@
 					}
 				}
 			}
+		},
+		"RepresentationKind": {
+			"kind": "enum",
+			"members": {
+				"bool": null,
+				"string": null,
+				"bytes": null,
+				"int": null,
+				"float": null,
+				"map": null,
+				"list": null,
+				"link": null
+			}
 		}
 	}
 }

--- a/typed/declaration/schema-schema.ipldsch.json
+++ b/typed/declaration/schema-schema.ipldsch.json
@@ -1,0 +1,39 @@
+{
+	"TypeName": {
+		"kind": "string"
+	},
+	"SchemaMap": {
+		"kind": "map",
+		"keyType": "String",
+		"valueType": "Type"
+	},
+	"Schema": {
+		"kind": "union",
+		"representation": {
+			"keyed": {
+				"schema": "SchemaMap"
+			}
+		}
+	},
+	"Type": {
+		"kind": "union",
+		"representation": {
+			"inline": {
+				"discriminatorKey": "kind",
+				"discriminantTable": {
+					"bool": "TypeBool",
+					"string": "TypeString",
+					"bytes": "TypeBytes",
+					"int": "TypeInt",
+					"float": "TypeFloat",
+					"map": "TypeMap",
+					"list": "TypeList",
+					"link": "TypeLink",
+					"union": "TypeUnion",
+					"struct": "TypeStruct",
+					"enum": "TypeEnum"
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
The title should say it all -- herein we have a self-describing schema :)

There's a lot of commits in between the start and this result, almost all with long commit messages that are worth reading if you want to follow the intermediate decision making in detail.  I won't reproduce all of them here -- the commit log exists, in its wonderful decentralized form -- just want to draw the reader's attention to the fact there is in fact text there, and it's meant for consumption.

Short highlights:

- This is a schema!
  - [There's already some docs in another file over at `doc/schema.md`](https://github.com/ipld/go-ipld-prime/blob/schema-schema/doc/schema.md).
- It's designed around "structural typing" -- being aimed at serial data, that is our defacto reality.
  - (But take note: you can get "nominative typing"-style behaviors by using Unions!)
- The basic kinds of types are those from the IPLD Data Model -- strings, ints, bytes, maps, lists, etc.
- We add "struct" (product types) and "union" and "enum" (sum types) kinds to the mix in addition to the IPLD Data Model kinds.
  - These all define "representation" properties -- which bidirectionally map them into one of the basic Data Model kinds.
- There are limits around nullability and optionality of fields.  The defaults are conservative: nulls are *not* allowed and all fields in structs are *required* unless otherwise declared.

Included in these files are two sets of examples:

1) a short example (using mostly anonymous nested types, to prove those out)
2) the schema itself!

... and each in two formats:

1) a JSON document, conforming to the schema schema
2) an equivalent DSL (which as you can see tends to be much, much shorter).

The DSL-form schema schema file contains a large amount of docs; **read those for the meat of what's going on here**.  (The actual declarations are only about 112 lines; so that's another 220 or so of pure docs.)

We should probably add fields for "`documentation optional String`" to each of the types (or, hey, speaking of which, maybe a mixin system for when lots of types have the same property like that?); I didn't do so here, mostly because it wouldn't be a pleasant effect on the readability of the JSON files.

---

There was a jaunt in the middle where a couple of different formats for representing nullable and optional fields were trialed; the ones that weren't selected have been merge-ignored.  This image shows how each of the options would've shaken out:

![schema-side-by-side2](https://user-images.githubusercontent.com/627638/51480344-187fc180-1d91-11e9-8d68-fbebd8dc4dfe.png)

Long story short, I went for the representation that yields the document which is both shortest and least-deeply-nested.  (It's also a particularly amusing image for showing how compact the DSL can be compared to the fully-normalized JSON equivalent.)  See the per-commit messages for additional detail.

---

A great deal of the implementation for wiring this up to real working code is already present in the `typed/system` package.  The first take on coding `typed/declaration` is currently out of sync with where this schema doc came to rest, and needs updating (specifically, to support TypeTerm and recursive inline definitions), but should be short work.

The real dream, of course, would be to take this schema; run codegen on it, to get nice native types in golang code which match the schema semantics... and use those as essentially the entirety of all the AST code of the `typed/declaration` package.  But that'd be a bit of a bootstrapping cycle issue ;) so we'll have to do a *little* more turning of the crank manually to get this all landed.