### PR TITLE
WIP: Changes needed to make IPLD usable by go-graphsync

### DIFF
--- a/repose/multicodecBuiltinCbor.go
+++ b/repose/multicodecBuiltinCbor.go
@@ -23,7 +23,7 @@ func DecoderDagCbor(nb ipld.NodeBuilder, r io.Reader) (ipld.Node, error) {
 		return nb2.DecodeCbor(r)
 	}
 	// Okay, generic builder path.
-	return encoding.Unmarshal(nb, cbor.NewDecoder(r))
+	return encoding.Unmarshal(nb, cbor.NewDecoder(cbor.DecodeOptions{}, r))
 }
 
 func EncoderDagCbor(n ipld.Node, w io.Writer) error {

--- a/traversal/selector/selector.go
+++ b/traversal/selector/selector.go
@@ -1,10 +1,12 @@
 package selector
 
-import (
-	ipld "github.com/ipld/go-ipld-prime"
-)
+import ipld "github.com/ipld/go-ipld-prime"
 
 type Selector interface {
 	Explore(ipld.Node) (ipld.KeyIterator, Selector)
 	Decide(ipld.Node) bool
+}
+
+func ReifySelector(cidRootedSelector ipld.Node) (Selector, error) {
+	return nil, nil
 }


### PR DESCRIPTION
# Goals

This is a proposal for some changes that are neccessary in order to write the IPLD bridge I am using in go-graphsync -- the intent is not to merge immediately. It is more of an FYI for discussion

# Implementation

- Fix some compile problems (import cycles, etc) that prevent go-ipld-prime being used by other packages
- Add a few more proposed changes that would be needed for the neccesary go-ipld-prime functions to be written
   - Uncomment a LinkLoader being part of TraversalConfig
   - Add a proposed `ReifySelector` method that given an IPLD node that is a selector spec, returns a Selector interface

# For discussion

What I am looking for is anything that feels undoable -- if you end up fixing the import cycle in a different way, no problem. If a proposed function signature feels wildly off, that's important to understand.