### PR TITLE
fix(cidlink): init multicodec registry

### DIFF
--- a/linking/cid/multicodecRegistry.go
+++ b/linking/cid/multicodecRegistry.go
@@ -7,6 +7,11 @@ var (
 	multicodecEncodeTable MulticodecEncodeTable
 )
 
+func init() {
+	multicodecEncodeTable = make(MulticodecEncodeTable)
+	multicodecDecodeTable = make(MulticodecDecodeTable)
+}
+
 // RegisterMulticodecDecoder is used to register multicodec features.
 // It adjusts a global registry and may only be used at program init time;
 // it is meant to provide a plugin system, not a configuration mechanism.


### PR DESCRIPTION
I'm getting a panic on load for using go-ipld-prime in RegisterMulticodecDecoder and I assume it's cause the multicode tables aren't actually allocated.
