### PR TITLE
Minor schema fixes

### DIFF
--- a/typed/declaration/schema-schema.ipldsch
+++ b/typed/declaration/schema-schema.ipldsch
@@ -337,8 +337,8 @@ type StructField struct {
 ## time, as well as for the sake of error messaging during typechecking).
 ##
 type TypeTerm union {
-	| TypeName string
-	| InlineDefn map
+	| TypeName "string"
+	| InlineDefn "map"
 } representation kinded
 
 ## InlineDefn represents a declaration of an anonymous type of one of the simple

--- a/typed/declaration/schema-schema.ipldsch.json
+++ b/typed/declaration/schema-schema.ipldsch.json
@@ -1,12 +1,18 @@
 {
 	"schema": {
 		"TypeName": {
-			"kind": "string"
+			"kind": "string",
+			"representation": {
+				"map": {}
+			}
 		},
 		"SchemaMap": {
 			"kind": "map",
 			"keyType": "TypeName",
-			"valueType": "Type"
+			"valueType": "Type",
+			"representation": {
+				"map": {}
+			}
 		},
 		"Schema": {
 			"kind": "union",
@@ -37,6 +43,25 @@
 				}
 			}
 		},
+		"TypeKind": {
+			"kind": "enum",
+			"members": {
+				"bool": null,
+				"string": null,
+				"bytes": null,
+				"int": null,
+				"float": null,
+				"map": null,
+				"list": null,
+				"link": null,
+				"union": null,
+				"struct": null,
+				"enum": null
+			},
+			"representation": {
+				"map": {}
+			}
+		},
 		"RepresentationKind": {
 			"kind": "enum",
 			"members": {
@@ -48,6 +73,9 @@
 				"map": null,
 				"list": null,
 				"link": null
+			},
+			"representation": {
+				"map": {}
 			}
 		},
 		"TypeBool": {
@@ -128,6 +156,13 @@
 				}
 			}
 		},
+		"TypeLink": {
+			"kind": "struct",
+			"fields": {},
+			"representation": {
+				"map": {}
+			}
+		},
 		"TypeUnion": {
 			"kind": "struct",
 			"fields": {
@@ -153,12 +188,18 @@
 		"UnionRepresentation_Kinded": {
 			"kind": "map",
 			"keyType": "RepresentationKind",
-			"valueType": "TypeName"
+			"valueType": "TypeName",
+			"representation": {
+				"map": {}
+			}
 		},
 		"UnionRepresentation_Keyed": {
 			"kind": "map",
 			"keyType": "String",
-			"valueType": "TypeName"
+			"valueType": "TypeName",
+			"representation": {
+				"map": {}
+			}
 		},
 		"UnionRepresentation_Envelope": {
 			"kind": "struct",
@@ -176,6 +217,9 @@
 						"valueType": "TypeName"
 					}
 				}
+			},
+			"representation": {
+				"map": {}
 			}
 		},
 		"UnionRepresentation_Inline": {
@@ -191,6 +235,9 @@
 						"valueType": "TypeName"
 					}
 				}
+			},
+			"representation": {
+				"map": {}
 			}
 		},
 		"TypeStruct": {

--- a/typed/declaration/schema-schema.ipldsch.json
+++ b/typed/declaration/schema-schema.ipldsch.json
@@ -1,10 +1,7 @@
 {
 	"schema": {
 		"TypeName": {
-			"kind": "string",
-			"representation": {
-				"map": {}
-			}
+			"kind": "string"
 		},
 		"SchemaMap": {
 			"kind": "map",
@@ -57,9 +54,6 @@
 				"union": null,
 				"struct": null,
 				"enum": null
-			},
-			"representation": {
-				"map": {}
 			}
 		},
 		"RepresentationKind": {
@@ -73,9 +67,6 @@
 				"map": null,
 				"list": null,
 				"link": null
-			},
-			"representation": {
-				"map": {}
 			}
 		},
 		"TypeBool": {
@@ -214,7 +205,10 @@
 					"type": {
 						"kind": "map",
 						"keyType": "String",
-						"valueType": "TypeName"
+						"valueType": "TypeName",
+						"representation": {
+							"map": {}
+						}
 					}
 				}
 			},
@@ -232,7 +226,10 @@
 					"type": {
 						"kind": "map",
 						"keyType": "String",
-						"valueType": "TypeName"
+						"valueType": "TypeName",
+						"representation": {
+							"map": {}
+						}
 					}
 				}
 			},
@@ -247,7 +244,10 @@
 					"type": {
 						"kind": "map",
 						"keyType": "String",
-						"valueType": "StructField"
+						"valueType": "StructField",
+						"representation": {
+							"map": {}
+						}
 					}
 				},
 				"representation": {
@@ -321,7 +321,10 @@
 					"type": {
 						"kind": "map",
 						"keyType": "String",
-						"valueType": "StructRepresentation_Map_FieldDetails"
+						"valueType": "StructRepresentation_Map_FieldDetails",
+						"representation": {
+							"map": {}
+						}
 					},
 					"optional": true
 				}
@@ -368,7 +371,10 @@
 					"type": {
 						"kind": "map",
 						"keyType": "String",
-						"valueType": "Null"
+						"valueType": "Null",
+						"representation": {
+							"map": {}
+						}
 					}
 				}
 			},


### PR DESCRIPTION
So I wrote a parser for it and picked up a few things by passing schema-schema through it and writing JSON output. The main questionable change here is whether you want to list the default `"representation": { "map": {} }` or not. It certainly makes testing easier if they're consistent.