### PR TITLE
schema fixups

### DIFF
--- a/typed/declaration/examples.ipldsch
+++ b/typed/declaration/examples.ipldsch
@@ -6,6 +6,4 @@ type ExampleWithAnonDefns struct {
 	barField nullable {String:String}
 	bazField {String : nullable String}
 	wozField {String:[nullable String]}
-} representation map (
-	fooField: alias="foo_field"
-)
+} representation map

--- a/typed/declaration/examples.ipldsch.json
+++ b/typed/declaration/examples.ipldsch.json
@@ -10,35 +10,35 @@
 			"kind": "struct",
 			"fields": {
 				"fooField": {
-					"valueType": {
-						"type": "map",
+					"type": {
+						"kind": "map",
 						"keyType": "String",
 						"valueType": "String"
 					},
 					"optional": true
 				},
 				"barField": {
-					"valueType": {
-						"type": "map",
+					"type": {
+						"kind": "map",
 						"keyType": "String",
 						"valueType": "String"
 					},
 					"nullable": true
 				},
 				"bazField": {
-					"valueType": {
-						"type": "map",
+					"type": {
+						"kind": "map",
 						"keyType": "String",
 						"valueType": "String",
 						"valueNullable": true
 					}
 				},
 				"wozField": {
-					"valueType": {
-						"type": "map",
+					"type": {
+						"kind": "map",
 						"keyType": "String",
 						"valueType": {
-							"type": "list",
+							"kind": "list",
 							"valueType": "String",
 							"valueNullable": true
 						}
@@ -46,11 +46,7 @@
 				}
 			},
 			"representation": {
-				"map": {
-					"fieldAliases": {
-						"fooField": "foo_field"
-					}
-				}
+				"map": {}
 			}
 		}
 	}

--- a/typed/declaration/schema-schema.ipldsch.json
+++ b/typed/declaration/schema-schema.ipldsch.json
@@ -37,6 +37,25 @@
 				}
 			}
 		},
+		"TypeKind": {
+			"kind": "enum",
+			"members": {
+				"bool": null,
+				"string": null,
+				"bytes": null,
+				"int": null,
+				"float": null,
+				"map": null,
+				"list": null,
+				"link": null,
+				"union": null,
+				"struct": null,
+				"enum": null
+			},
+			"representation": {
+				"string": {}
+			}
+		},
 		"RepresentationKind": {
 			"kind": "enum",
 			"members": {
@@ -48,42 +67,30 @@
 				"map": null,
 				"list": null,
 				"link": null
+			},
+			"representation": {
+				"string": {}
 			}
 		},
 		"TypeBool": {
 			"kind": "struct",
-			"fields": {},
-			"representation": {
-				"map": {}
-			}
+			"fields": {}
 		},
 		"TypeString": {
 			"kind": "struct",
-			"fields": {},
-			"representation": {
-				"map": {}
-			}
+			"fields": {}
 		},
 		"TypeBytes": {
 			"kind": "struct",
-			"fields": {},
-			"representation": {
-				"map": {}
-			}
+			"fields": {}
 		},
 		"TypeInt": {
 			"kind": "struct",
-			"fields": {},
-			"representation": {
-				"map": {}
-			}
+			"fields": {}
 		},
 		"TypeFloat": {
 			"kind": "struct",
-			"fields": {},
-			"representation": {
-				"map": {}
-			}
+			"fields": {}
 		},
 		"TypeMap": {
 			"kind": "struct",
@@ -128,15 +135,16 @@
 				}
 			}
 		},
+		"TypeLink": {
+			"kind": "struct",
+			"fields": {}
+		},
 		"TypeUnion": {
 			"kind": "struct",
 			"fields": {
 				"representation": {
 					"type": "UnionRepresentation"
 				}
-			},
-			"representation": {
-				"map": {}
 			}
 		},
 		"UnionRepresentation": {
@@ -206,9 +214,6 @@
 				"representation": {
 					"type": "StructRepresentation"
 				}
-			},
-			"representation": {
-				"map": {}
 			}
 		},
 		"StructField": {
@@ -278,9 +283,6 @@
 					},
 					"optional": true
 				}
-			},
-			"representation": {
-				"map": {}
 			}
 		},
 		"StructRepresentation_Map_FieldDetails": {
@@ -294,9 +296,6 @@
 					"type": "Any",
 					"optional": true
 				}
-			},
-			"representation": {
-				"map": {}
 			}
 		},
 		"StructRepresentation_Tuple": {
@@ -309,9 +308,6 @@
 					},
 					"optional": true
 				}
-			},
-			"representation": {
-				"map": {}
 			}
 		},
 		"TypeEnum": {
@@ -324,9 +320,6 @@
 						"valueType": "Null"
 					}
 				}
-			},
-			"representation": {
-				"map": {}
 			}
 		}
 	}


### PR DESCRIPTION
Take 2, or 3 or something. Trying to narrow down the parsing rules and the AST (not technically an AST but let's call it that until we have a better term).

My first take at this had `"representation":{"map":{}}` showing up for all structs and maps (and other things which it shouldn't have) but as I expanded into the other base types it made less sense. Do you also need `"representation":{"list":{}}` for a list type, `"representation":{"int":{}}` for an int? So I went with a rule: where there is a default representation for a type (map for struct, string for enum, list for list, bytes for bytes etc.) as described in the [schema spec PR](https://github.com/ipld/specs/pull/113/files#diff-4c579eae08dfda6617b83e88b7841e96R30), don't include it if it doesn't add anything useful.

Also, I've seen you talk about field aliases in map representations in a couple of places now but they aren't in schema-schema.ipldsch or the spec PR, are you intending these to be included now or something to expand to later?