### PR TITLE
Selector Helpers

### DIFF
--- a/traversal/selector/utils/utils.go
+++ b/traversal/selector/utils/utils.go
@@ -1,0 +1,32 @@
+package utils
+
+import (
+	ipld "github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/fluent"
+	ipldfree "github.com/ipld/go-ipld-prime/impl/free"
+)
+
+// CreateNestedPathSelectorNode is a utility method to create a deep nested path selector
+// from a set of strings
+func CreateNestedPathSelectorNode(pathSegments []string) (ipld.Node, error) {
+	fnb := fluent.WrapNodeBuilder(ipldfree.NodeBuilder())
+	var selector ipld.Node
+	err := fluent.Recover(func() {
+		selector = createNestedPathSelectorNode(pathSegments, fnb)
+	})
+	return selector, err
+}
+
+func createNestedPathSelectorNode(pathSegments []string, fnb fluent.NodeBuilder) ipld.Node {
+	if len(pathSegments) == 0 {
+		return fnb.CreateBool(true)
+	}
+	return fnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
+		mb.Insert(
+			knb.CreateString("f"),
+			vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
+				mb.Insert(knb.CreateString(pathSegments[0]), createNestedPathSelectorNode(pathSegments[1:], vnb))
+			}),
+		)
+	})
+}

--- a/traversal/selector/utils/utils_test.go
+++ b/traversal/selector/utils/utils_test.go
@@ -1,0 +1,78 @@
+package utils_test
+
+import (
+	"testing"
+
+	. "github.com/warpfork/go-wish"
+
+	ipld "github.com/ipld/go-ipld-prime"
+	_ "github.com/ipld/go-ipld-prime/encoding/dagjson"
+	"github.com/ipld/go-ipld-prime/fluent"
+	ipldfree "github.com/ipld/go-ipld-prime/impl/free"
+	"github.com/ipld/go-ipld-prime/traversal"
+	"github.com/ipld/go-ipld-prime/traversal/selector"
+	"github.com/ipld/go-ipld-prime/traversal/selector/utils"
+)
+
+var fnb = fluent.WrapNodeBuilder(ipldfree.NodeBuilder()) // just for the other fixture building
+var (
+	middleMapNode = fnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
+		mb.Insert(knb.CreateString("foo"), vnb.CreateBool(true))
+		mb.Insert(knb.CreateString("bar"), vnb.CreateBool(false))
+		mb.Insert(knb.CreateString("nested"), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
+			mb.Insert(knb.CreateString("nonlink"), vnb.CreateString("zoo"))
+		}))
+	})
+)
+
+func TestCreateNestedSelector(t *testing.T) {
+	t.Run("when given empty slice returns a simple positional matcher", func(t *testing.T) {
+		t.Skip("Pending -- does not work in current selector context")
+		sn, err := utils.CreateNestedPathSelectorNode(nil)
+		Require(t, err, ShouldEqual, nil)
+		s, err := selector.ParseSelector(sn)
+		Require(t, err, ShouldEqual, nil)
+		err = traversal.Traverse(fnb.CreateString("x"), s, func(tp traversal.TraversalProgress, n ipld.Node) error {
+			Wish(t, n, ShouldEqual, fnb.CreateString("x"))
+			Wish(t, tp.Path.String(), ShouldEqual, ipld.Path{}.String())
+			return nil
+		})
+		Wish(t, err, ShouldEqual, nil)
+	})
+	t.Run("can create a single element path selector", func(t *testing.T) {
+		sn, err := utils.CreateNestedPathSelectorNode([]string{"foo"})
+		Require(t, err, ShouldEqual, nil)
+		s, err := selector.ParseSelector(sn)
+		Require(t, err, ShouldEqual, nil)
+		var order int
+		err = traversal.Traverse(middleMapNode, s, func(tp traversal.TraversalProgress, n ipld.Node) error {
+			switch order {
+			case 0:
+				Wish(t, n, ShouldEqual, fnb.CreateBool(true))
+				Wish(t, tp.Path.String(), ShouldEqual, "foo")
+			}
+			order++
+			return nil
+		})
+		Wish(t, err, ShouldEqual, nil)
+		Wish(t, order, ShouldEqual, 1)
+	})
+	t.Run("traverse selecting fields recursively should work", func(t *testing.T) {
+		sn, err := utils.CreateNestedPathSelectorNode([]string{"nested", "nonlink"})
+		Require(t, err, ShouldEqual, nil)
+		s, err := selector.ParseSelector(sn)
+		Require(t, err, ShouldEqual, nil)
+		var order int
+		err = traversal.Traverse(middleMapNode, s, func(tp traversal.TraversalProgress, n ipld.Node) error {
+			switch order {
+			case 0:
+				Wish(t, n, ShouldEqual, fnb.CreateString("zoo"))
+				Wish(t, tp.Path.String(), ShouldEqual, "nested/nonlink")
+			}
+			order++
+			return nil
+		})
+		Wish(t, err, ShouldEqual, nil)
+		Wish(t, order, ShouldEqual, 1)
+	})
+}


### PR DESCRIPTION
# Goals

Kick the tires on selectors implementation by creating some helper functions to create different kinds of selectors (that will probably still be useful later :)

Honestly, no need to merge unless you feel like it it -- this was mainly to prove to myself I understood how things are working. (though I could see this being a useful helper generally

# Implementation

- Create a utils package for quickly making different kinds of selectors. 
- Start with a nested path selector utility function.