### PR TITLE
Schema and codegen fun

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,36 @@
+package ipld
+
+import (
+	"fmt"
+)
+
+// ErrWrongKind may be returned from functions on the Node interface when
+// a method is invoked which doesn't make sense for the Kind and/or ReprKind
+// that node concretely contains.
+//
+// For example, calling AsString on a map will return ErrWrongKind.
+// Calling TraverseField on an int will similarly return ErrWrongKind.
+type ErrWrongKind struct {
+	// MethodName is literally the string for the operation attempted, e.g.
+	// "AsString".
+	MethodName string
+
+	// ApprorpriateKind is used to describe the Kind which the erroring method
+	// would make sense for.
+	//
+	// In the case of typed nodes, this will typically refer to the 'natural'
+	// data-model kind for such a type (e.g., structs will say 'map' here).
+	AppropriateKind ReprKind
+
+	ActualKind ReprKind // FIXME okay just no, this really needs to say what it knows.
+
+	// REVIEW this is almost certainly wrong.  Maybe you need some short enums
+	//  for things like "the kinds you can traverse by name" e.g. map+struct.
+	//  And I'm really sparse for reasons not to put schema-level Kind in the root package.
+	//   All the counter-arguments are similar to the ones about Path, and they
+	//    just flat out lose when up against "errors matter".
+}
+
+func (e ErrWrongKind) Error() string {
+	return fmt.Sprintf("func called on wrong kind: %s called on a %s node, but only makes sense on %s", e.MethodName, e.ActualKind, e.AppropriateKind)
+}

--- a/errors.go
+++ b/errors.go
@@ -15,20 +15,15 @@ type ErrWrongKind struct {
 	// "AsString".
 	MethodName string
 
-	// ApprorpriateKind is used to describe the Kind which the erroring method
-	// would make sense for.
+	// ApprorpriateKind describes which ReprKinds the erroring method would
+	// make sense for.
+	AppropriateKind ReprKindSet
+
+	// ActualKind describes the ReprKind of the node the method was called on.
 	//
 	// In the case of typed nodes, this will typically refer to the 'natural'
 	// data-model kind for such a type (e.g., structs will say 'map' here).
-	AppropriateKind ReprKind
-
-	ActualKind ReprKind // FIXME okay just no, this really needs to say what it knows.
-
-	// REVIEW this is almost certainly wrong.  Maybe you need some short enums
-	//  for things like "the kinds you can traverse by name" e.g. map+struct.
-	//  And I'm really sparse for reasons not to put schema-level Kind in the root package.
-	//   All the counter-arguments are similar to the ones about Path, and they
-	//    just flat out lose when up against "errors matter".
+	ActualKind ReprKind
 }
 
 func (e ErrWrongKind) Error() string {

--- a/fluent/fluentRecover_test.go
+++ b/fluent/fluentRecover_test.go
@@ -1,12 +1,12 @@
 package fluent
 
 import (
-	"fmt"
 	"testing"
 
 	. "github.com/warpfork/go-wish"
 
-	"github.com/ipld/go-ipld-prime/impl/free"
+	ipld "github.com/ipld/go-ipld-prime"
+	ipldfree "github.com/ipld/go-ipld-prime/impl/free"
 )
 
 func TestRecover(t *testing.T) {
@@ -17,7 +17,7 @@ func TestRecover(t *testing.T) {
 				t.Fatal("should not be reached")
 			}),
 			ShouldEqual,
-			Error{fmt.Errorf("cannot traverse a node that is undefined")},
+			Error{ipld.ErrWrongKind{MethodName: "TraverseIndex", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: ipld.ReprKind_Invalid}},
 		)
 	})
 	t.Run("correct traversal should return nil", func(t *testing.T) {

--- a/impl/typed/typedNode.go
+++ b/impl/typed/typedNode.go
@@ -24,9 +24,28 @@ import (
 // components which are from different versions of a schema.  Smooth migrations
 // and zero-copy type-safe data sharing between them: We can accommodate that!
 type Node interface {
+	// typed.Node acts just like a regular Node for almost all purposes;
+	// which ReprKind it acts as is determined by the TypeKind.
+	// (Note that the representation strategy of the type does *not* affect
+	// the ReprKind of typed.Node -- rather, the representation strategy
+	// affects the `.Representation().ReprKind()`.)
+	//
+	// For example: if the `.Type().Kind()` of this node is "struct",
+	// it will act like ReprKind() == "map"
+	// (even if Type().(Struct).ReprStrategy() is "tuple").
 	ipld.Node
 
+	// Type returns a reference to the reified schema.Type value.
 	Type() schema.Type
+
+	// Representation returns an ipld.Node which sees the data in this node
+	// in its representation form.
+	//
+	// For example: if the `.Type().Kind()` of this node is "struct",
+	// `.Representation().Kind()` may vary based on its representation strategy:
+	// if the representation strategy is "map", then it will be ReprKind=="map";
+	// if the streatgy is "tuple", then it will be ReprKind=="list".
+	Representation() ipld.Node
 }
 
 // unboxing is... ugh, we probably should codegen an unbox method per concrete type.

--- a/kind.go
+++ b/kind.go
@@ -48,3 +48,31 @@ func (k ReprKind) String() string {
 		panic("invalid enumeration value!")
 	}
 }
+
+// ReprKindSet is a type with a few enumerated consts that are commonly used
+// (mostly, in error messages).
+type ReprKindSet []ReprKind
+
+var (
+	ReprKindSet_Recursive = ReprKindSet{ReprKind_Map, ReprKind_List}
+	ReprKindSet_Scalar    = ReprKindSet{ReprKind_Null, ReprKind_Bool, ReprKind_Int, ReprKind_Float, ReprKind_String, ReprKind_Bytes, ReprKind_Link}
+
+	ReprKindSet_JustMap    = ReprKindSet{ReprKind_Map}
+	ReprKindSet_JustList   = ReprKindSet{ReprKind_List}
+	ReprKindSet_JustNull   = ReprKindSet{ReprKind_Null}
+	ReprKindSet_JustBool   = ReprKindSet{ReprKind_Bool}
+	ReprKindSet_JustInt    = ReprKindSet{ReprKind_Int}
+	ReprKindSet_JustFloat  = ReprKindSet{ReprKind_Float}
+	ReprKindSet_JustString = ReprKindSet{ReprKind_String}
+	ReprKindSet_JustBytes  = ReprKindSet{ReprKind_Bytes}
+	ReprKindSet_JustLink   = ReprKindSet{ReprKind_Link}
+)
+
+func (x ReprKindSet) String() string {
+	s := ""
+	for i := 0; i < len(x)-1; i++ {
+		s += x[i].String() + " or "
+	}
+	s += x[len(x)-1].String()
+	return s
+}

--- a/schema/gen/go/_test/wow_test.go
+++ b/schema/gen/go/_test/wow_test.go
@@ -1,0 +1,39 @@
+package whee
+
+import (
+	"testing"
+
+	"github.com/polydawn/refmt/tok"
+	. "github.com/warpfork/go-wish"
+
+	ipld "github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/encoding"
+	"github.com/ipld/go-ipld-prime/fluent"
+)
+
+// TokenSourceBucket acts like a TokenSource by yielding tokens from a pre-made
+// slice; and also keeps track of how far it's been read.
+type TokenSourceBucket struct {
+	tokens []tok.Token
+	read   int
+}
+
+func (tb *TokenSourceBucket) Step(yield *tok.Token) (done bool, err error) {
+	*yield = tb.tokens[tb.read]
+	tb.read++
+	return tb.read > len(tb.tokens), nil
+}
+
+func TestScalarUnmarshal(t *testing.T) {
+	t.Run("string node", func(t *testing.T) {
+		tb := &TokenSourceBucket{tokens: []tok.Token{
+			{Type: tok.TString, Str: "zooooom"},
+		}}
+		nb := Strang__NodeBuilder{}
+		n, err := encoding.Unmarshal(nb, tb)
+		Wish(t, err, ShouldEqual, nil)
+		Wish(t, n.ReprKind(), ShouldEqual, ipld.ReprKind_String)
+		Wish(t, fluent.WrapNode(n).AsString(), ShouldEqual, "zooooom")
+		Wish(t, tb.read, ShouldEqual, 1)
+	})
+}

--- a/schema/gen/go/gen.go
+++ b/schema/gen/go/gen.go
@@ -61,7 +61,7 @@ func emitFileHeader(w io.Writer) {
 	fmt.Fprintf(w, "package whee\n\n")
 	fmt.Fprintf(w, "import (\n")
 	fmt.Fprintf(w, "\tipld \"github.com/ipld/go-ipld-prime\"\n")
-	fmt.Fprintf(w, ")\n")
+	fmt.Fprintf(w, ")\n\n")
 }
 
 // enums will have special methods

--- a/schema/gen/go/genKindString.go
+++ b/schema/gen/go/genKindString.go
@@ -2,10 +2,8 @@ package gengo
 
 import (
 	"io"
-	"text/template"
 
 	"github.com/ipld/go-ipld-prime/schema"
-	wish "github.com/warpfork/go-wish"
 )
 
 type generateKindString struct {
@@ -16,105 +14,105 @@ type generateKindString struct {
 }
 
 func (gk generateKindString) EmitNodeMethodTraverseField(w io.Writer) {
-	template.Must(template.New("").Parse("\n"+wish.Dedent(`
+	doTemplate(`
 		func ({{ .Name }}) TraverseField(key string) (ipld.Node, error) {
 			return nil, ipld.ErrWrongKind{ /* todo more content */ }
 		}
-	`))).Execute(w, gk)
+	`, w, gk)
 }
 
 func (gk generateKindString) EmitNodeMethodTraverseIndex(w io.Writer) {
-	template.Must(template.New("").Parse("\n"+wish.Dedent(`
+	doTemplate(`
 		func ({{ .Name }}) TraverseIndex(idx int) (ipld.Node, error) {
 			return nil, ipld.ErrWrongKind{ /* todo more content */ }
 		}
-	`))).Execute(w, gk)
+	`, w, gk)
 }
 
 func (gk generateKindString) EmitNodeMethodMapIterator(w io.Writer) {
-	template.Must(template.New("").Parse("\n"+wish.Dedent(`
+	doTemplate(`
 		func ({{ .Name }}) MapIterator() ipld.MapIterator {
 			return mapIteratorReject{ipld.ErrWrongKind{ /* todo more content */ }}
 		}
-	`))).Execute(w, gk)
+	`, w, gk)
 }
 
 func (gk generateKindString) EmitNodeMethodListIterator(w io.Writer) {
-	template.Must(template.New("").Parse("\n"+wish.Dedent(`
+	doTemplate(`
 		func ({{ .Name }}) ListIterator() ipld.ListIterator {
 			return listIteratorReject{ipld.ErrWrongKind{ /* todo more content */ }}
 		}
-	`))).Execute(w, gk) // REVIEW: maybe that rejection thunk should be in main package?  don't really want to flash it at folks though.  very impl detail.
+	`, w, gk) // REVIEW: maybe that rejection thunk should be in main package?  don't really want to flash it at folks though.  very impl detail.
 }
 
 func (gk generateKindString) EmitNodeMethodLength(w io.Writer) {
-	template.Must(template.New("").Parse("\n"+wish.Dedent(`
+	doTemplate(`
 		func ({{ .Name }}) Length() int {
 			return -1
 		}
-	`))).Execute(w, gk)
+	`, w, gk)
 }
 
 func (gk generateKindString) EmitNodeMethodIsNull(w io.Writer) {
-	template.Must(template.New("").Parse("\n"+wish.Dedent(`
+	doTemplate(`
 		func ({{ .Name }}) IsNull() bool {
 			return false
 		}
-	`))).Execute(w, gk)
+	`, w, gk)
 }
 
 func (gk generateKindString) EmitNodeMethodAsBool(w io.Writer) {
-	template.Must(template.New("").Parse("\n"+wish.Dedent(`
+	doTemplate(`
 		func ({{ .Name }}) AsBool() (bool, error) {
 			return false, ipld.ErrWrongKind{ /* todo more content */ }
 		}
-	`))).Execute(w, gk)
+	`, w, gk)
 }
 
 func (gk generateKindString) EmitNodeMethodAsInt(w io.Writer) {
-	template.Must(template.New("").Parse("\n"+wish.Dedent(`
+	doTemplate(`
 		func ({{ .Name }}) AsInt() (int, error) {
 			return 0, ipld.ErrWrongKind{ /* todo more content */ }
 		}
-	`))).Execute(w, gk)
+	`, w, gk)
 }
 
 func (gk generateKindString) EmitNodeMethodAsFloat(w io.Writer) {
-	template.Must(template.New("").Parse("\n"+wish.Dedent(`
+	doTemplate(`
 		func ({{ .Name }}) AsFloat() (float64, error) {
 			return 0, ipld.ErrWrongKind{ /* todo more content */ }
 		}
-	`))).Execute(w, gk)
+	`, w, gk)
 }
 
 func (gk generateKindString) EmitNodeMethodAsString(w io.Writer) {
-	template.Must(template.New("").Parse("\n"+wish.Dedent(`
+	doTemplate(`
 		func (x {{ .Name }}) AsString() (string, error) {
 			return x.x, nil
 		}
-	`))).Execute(w, gk)
+	`, w, gk)
 }
 
 func (gk generateKindString) EmitNodeMethodAsBytes(w io.Writer) {
-	template.Must(template.New("").Parse("\n"+wish.Dedent(`
+	doTemplate(`
 		func ({{ .Name }}) AsBytes() ([]byte, error) {
 			return nil, ipld.ErrWrongKind{ /* todo more content */ }
 		}
-	`))).Execute(w, gk)
+	`, w, gk)
 }
 
 func (gk generateKindString) EmitNodeMethodAsLink(w io.Writer) {
-	template.Must(template.New("").Parse("\n"+wish.Dedent(`
+	doTemplate(`
 		func ({{ .Name }}) AsLink() (ipld.Link, error) {
 			return nil, ipld.ErrWrongKind{ /* todo more content */ }
 		}
-	`))).Execute(w, gk)
+	`, w, gk)
 }
 
 func (gk generateKindString) EmitNodeMethodNodeBuilder(w io.Writer) {
-	template.Must(template.New("").Parse("\n"+wish.Dedent(`
+	doTemplate(`
 		func ({{ .Name }}) NodeBuilder() ipld.NodeBuilder {
 			return {{ .Name }}__NodeBuilder{}
 		}
-	`))).Execute(w, gk)
+	`, w, gk)
 }

--- a/schema/gen/go/genKindString.go
+++ b/schema/gen/go/genKindString.go
@@ -13,10 +13,12 @@ type generateKindString struct {
 	// FUTURE: perhaps both a global one (e.g. output package name) and a per-type one.
 }
 
+// FUTURE: quite a few of these "nope" methods can be reused widely.
+
 func (gk generateKindString) EmitNodeMethodTraverseField(w io.Writer) {
 	doTemplate(`
 		func ({{ .Name }}) TraverseField(key string) (ipld.Node, error) {
-			return nil, ipld.ErrWrongKind{ /* todo more content */ }
+			return nil, ipld.ErrWrongKind{MethodName: "TraverseField", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_String}
 		}
 	`, w, gk)
 }
@@ -24,7 +26,7 @@ func (gk generateKindString) EmitNodeMethodTraverseField(w io.Writer) {
 func (gk generateKindString) EmitNodeMethodTraverseIndex(w io.Writer) {
 	doTemplate(`
 		func ({{ .Name }}) TraverseIndex(idx int) (ipld.Node, error) {
-			return nil, ipld.ErrWrongKind{ /* todo more content */ }
+			return nil, ipld.ErrWrongKind{MethodName: "TraverseIndex", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: ipld.ReprKind_String}
 		}
 	`, w, gk)
 }
@@ -32,7 +34,7 @@ func (gk generateKindString) EmitNodeMethodTraverseIndex(w io.Writer) {
 func (gk generateKindString) EmitNodeMethodMapIterator(w io.Writer) {
 	doTemplate(`
 		func ({{ .Name }}) MapIterator() ipld.MapIterator {
-			return mapIteratorReject{ipld.ErrWrongKind{ /* todo more content */ }}
+			return mapIteratorReject{ipld.ErrWrongKind{MethodName: "MapIterator", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_String}}
 		}
 	`, w, gk)
 }
@@ -40,7 +42,7 @@ func (gk generateKindString) EmitNodeMethodMapIterator(w io.Writer) {
 func (gk generateKindString) EmitNodeMethodListIterator(w io.Writer) {
 	doTemplate(`
 		func ({{ .Name }}) ListIterator() ipld.ListIterator {
-			return listIteratorReject{ipld.ErrWrongKind{ /* todo more content */ }}
+			return listIteratorReject{ipld.ErrWrongKind{MethodName: "ListIterator", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: ipld.ReprKind_String}}
 		}
 	`, w, gk) // REVIEW: maybe that rejection thunk should be in main package?  don't really want to flash it at folks though.  very impl detail.
 }
@@ -64,7 +66,7 @@ func (gk generateKindString) EmitNodeMethodIsNull(w io.Writer) {
 func (gk generateKindString) EmitNodeMethodAsBool(w io.Writer) {
 	doTemplate(`
 		func ({{ .Name }}) AsBool() (bool, error) {
-			return false, ipld.ErrWrongKind{ /* todo more content */ }
+			return false, ipld.ErrWrongKind{MethodName: "AsBool", AppropriateKind: ipld.ReprKindSet_JustBool, ActualKind: ipld.ReprKind_String}
 		}
 	`, w, gk)
 }
@@ -72,7 +74,7 @@ func (gk generateKindString) EmitNodeMethodAsBool(w io.Writer) {
 func (gk generateKindString) EmitNodeMethodAsInt(w io.Writer) {
 	doTemplate(`
 		func ({{ .Name }}) AsInt() (int, error) {
-			return 0, ipld.ErrWrongKind{ /* todo more content */ }
+			return 0, ipld.ErrWrongKind{MethodName: "AsInt", AppropriateKind: ipld.ReprKindSet_JustInt, ActualKind: ipld.ReprKind_String}
 		}
 	`, w, gk)
 }
@@ -80,7 +82,7 @@ func (gk generateKindString) EmitNodeMethodAsInt(w io.Writer) {
 func (gk generateKindString) EmitNodeMethodAsFloat(w io.Writer) {
 	doTemplate(`
 		func ({{ .Name }}) AsFloat() (float64, error) {
-			return 0, ipld.ErrWrongKind{ /* todo more content */ }
+			return 0, ipld.ErrWrongKind{MethodName: "AsFloat", AppropriateKind: ipld.ReprKindSet_JustFloat, ActualKind: ipld.ReprKind_String}
 		}
 	`, w, gk)
 }
@@ -96,7 +98,7 @@ func (gk generateKindString) EmitNodeMethodAsString(w io.Writer) {
 func (gk generateKindString) EmitNodeMethodAsBytes(w io.Writer) {
 	doTemplate(`
 		func ({{ .Name }}) AsBytes() ([]byte, error) {
-			return nil, ipld.ErrWrongKind{ /* todo more content */ }
+			return nil, ipld.ErrWrongKind{MethodName: "AsBytes", AppropriateKind: ipld.ReprKindSet_JustBytes, ActualKind: ipld.ReprKind_String}
 		}
 	`, w, gk)
 }
@@ -104,7 +106,7 @@ func (gk generateKindString) EmitNodeMethodAsBytes(w io.Writer) {
 func (gk generateKindString) EmitNodeMethodAsLink(w io.Writer) {
 	doTemplate(`
 		func ({{ .Name }}) AsLink() (ipld.Link, error) {
-			return nil, ipld.ErrWrongKind{ /* todo more content */ }
+			return nil, ipld.ErrWrongKind{MethodName: "AsLink", AppropriateKind: ipld.ReprKindSet_JustLink, ActualKind: ipld.ReprKind_String}
 		}
 	`, w, gk)
 }

--- a/schema/gen/go/genKindString.go
+++ b/schema/gen/go/genKindString.go
@@ -110,11 +110,3 @@ func (gk generateKindString) EmitNodeMethodAsLink(w io.Writer) {
 		}
 	`, w, gk)
 }
-
-func (gk generateKindString) EmitNodeMethodNodeBuilder(w io.Writer) {
-	doTemplate(`
-		func ({{ .Name }}) NodeBuilder() ipld.NodeBuilder {
-			return {{ .Name }}__NodeBuilder{}
-		}
-	`, w, gk)
-}

--- a/schema/gen/go/genKindString.go
+++ b/schema/gen/go/genKindString.go
@@ -44,7 +44,7 @@ func (gk generateKindString) EmitNodeMethodListIterator(w io.Writer) {
 		func ({{ .Name }}) ListIterator() ipld.ListIterator {
 			return listIteratorReject{ipld.ErrWrongKind{MethodName: "ListIterator", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: ipld.ReprKind_String}}
 		}
-	`, w, gk) // REVIEW: maybe that rejection thunk should be in main package?  don't really want to flash it at folks though.  very impl detail.
+	`, w, gk)
 }
 
 func (gk generateKindString) EmitNodeMethodLength(w io.Writer) {

--- a/schema/gen/go/genKindStringReprString.go
+++ b/schema/gen/go/genKindStringReprString.go
@@ -19,3 +19,48 @@ func (gk generateKindString) EmitNodeMethodReprKind(w io.Writer) {
 		}
 	`, w, gk)
 }
+
+// FUTURE: consider breaking the nodebuilder methods down like the node methods are; a lot of the "nope" variants could be reused.
+func (gk generateKindString) EmitNodeMethodNodeBuilder(w io.Writer) {
+	doTemplate(`
+		func ({{ .Name }}) NodeBuilder() ipld.NodeBuilder {
+			return {{ .Name }}__NodeBuilder{}
+		}
+
+		type {{ .Name }}__NodeBuilder struct{}
+
+		func (nb {{ .Name }}__NodeBuilder) CreateMap() (ipld.MapBuilder, error) {
+			return nil, ipld.ErrWrongKind{MethodName: "CreateMap", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_String}
+		}
+		func (nb {{ .Name }}__NodeBuilder) AmendMap() (ipld.MapBuilder, error) {
+			return nil, ipld.ErrWrongKind{MethodName: "AmendMap", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_String}
+		}
+		func (nb {{ .Name }}__NodeBuilder) CreateList() (ipld.ListBuilder, error) {
+			return nil, ipld.ErrWrongKind{MethodName: "CreateList", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: ipld.ReprKind_String}
+		}
+		func (nb {{ .Name }}__NodeBuilder) AmendList() (ipld.ListBuilder, error) {
+			return nil, ipld.ErrWrongKind{MethodName: "AmendList", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: ipld.ReprKind_String}
+		}
+		func (nb {{ .Name }}__NodeBuilder) CreateNull() (ipld.Node, error) {
+			return nil, ipld.ErrWrongKind{MethodName: "CreateNull", AppropriateKind: ipld.ReprKindSet_JustNull, ActualKind: ipld.ReprKind_String}
+		}
+		func (nb {{ .Name }}__NodeBuilder) CreateBool(v bool) (ipld.Node, error) {
+			return nil, ipld.ErrWrongKind{MethodName: "CreateBool", AppropriateKind: ipld.ReprKindSet_JustBool, ActualKind: ipld.ReprKind_String}
+		}
+		func (nb {{ .Name }}__NodeBuilder) CreateInt(v int) (ipld.Node, error) {
+			return nil, ipld.ErrWrongKind{MethodName: "CreateInt", AppropriateKind: ipld.ReprKindSet_JustInt, ActualKind: ipld.ReprKind_String}
+		}
+		func (nb {{ .Name }}__NodeBuilder) CreateFloat(v float64) (ipld.Node, error) {
+			return nil, ipld.ErrWrongKind{MethodName: "CreateFloat", AppropriateKind: ipld.ReprKindSet_JustFloat, ActualKind: ipld.ReprKind_String}
+		}
+		func (nb {{ .Name }}__NodeBuilder) CreateString(v string) (ipld.Node, error) {
+			return {{ .Name }}{v}, nil
+		}
+		func (nb {{ .Name }}__NodeBuilder) CreateBytes(v []byte) (ipld.Node, error) {
+			return nil, ipld.ErrWrongKind{MethodName: "CreateBytes", AppropriateKind: ipld.ReprKindSet_JustBytes, ActualKind: ipld.ReprKind_String}
+		}
+		func (nb {{ .Name }}__NodeBuilder) CreateLink(v ipld.Link) (ipld.Node, error) {
+			return nil, ipld.ErrWrongKind{MethodName: "CreateLink", AppropriateKind: ipld.ReprKindSet_JustLink, ActualKind: ipld.ReprKind_String}
+		}
+	`, w, gk)
+}

--- a/schema/gen/go/genKindStringReprString.go
+++ b/schema/gen/go/genKindStringReprString.go
@@ -2,23 +2,20 @@ package gengo
 
 import (
 	"io"
-	"text/template"
-
-	wish "github.com/warpfork/go-wish"
 )
 
 func (gk generateKindString) EmitNodeType(w io.Writer) {
-	template.Must(template.New("").Parse("\n"+wish.Dedent(`
+	doTemplate(`
 		var _ ipld.Node = {{ .Name }}{}
 
 		type {{ .Name }} struct { x string }
-	`))).Execute(w, gk)
+	`, w, gk)
 }
 
 func (gk generateKindString) EmitNodeMethodReprKind(w io.Writer) {
-	template.Must(template.New("").Parse("\n"+wish.Dedent(`
+	doTemplate(`
 		func ({{ .Name }}) ReprKind() ipld.ReprKind {
 			return ipld.ReprKind_String
 		}
-	`))).Execute(w, gk)
+	`, w, gk)
 }

--- a/schema/gen/go/genKindStringReprString.go
+++ b/schema/gen/go/genKindStringReprString.go
@@ -8,7 +8,8 @@ func (gk generateKindString) EmitNodeType(w io.Writer) {
 	doTemplate(`
 		var _ ipld.Node = {{ .Name }}{}
 
-		type {{ .Name }} struct { x string }
+		type {{ .Name }} struct{ x string }
+
 	`, w, gk)
 }
 

--- a/schema/gen/go/gen_test.go
+++ b/schema/gen/go/gen_test.go
@@ -17,8 +17,7 @@ func TestNuevo(t *testing.T) {
 		}
 		return y
 	}
-	f := openOrPanic("_test/neu.go")
-	emitFileHeader(f)
+
 	emitType := func(tg typeGenerator, w io.Writer) {
 		tg.EmitNodeType(w)
 		tg.EmitNodeMethodReprKind(w)
@@ -36,5 +35,21 @@ func TestNuevo(t *testing.T) {
 		tg.EmitNodeMethodAsLink(w)
 		tg.EmitNodeMethodNodeBuilder(w)
 	}
+
+	f := openOrPanic("_test/thunks.go")
+	emitFileHeader(f)
+	doTemplate(`
+		type mapIteratorReject struct{ err error }
+		type listIteratorReject struct{ err error }
+
+		func (itr mapIteratorReject) Next() (ipld.Node, ipld.Node, error) { return nil, nil, itr.err }
+		func (itr mapIteratorReject) Done() bool                          { return false }
+
+		func (itr listIteratorReject) Next() (int, ipld.Node, error) { return -1, nil, itr.err }
+		func (itr listIteratorReject) Done() bool                    { return false }
+	`, f, nil)
+
+	f = openOrPanic("_test/tStrang.go")
+	emitFileHeader(f)
 	emitType(generateKindString{"Strang", schema.TypeString{}}, f)
 }

--- a/schema/gen/go/templateUtil.go
+++ b/schema/gen/go/templateUtil.go
@@ -1,0 +1,15 @@
+package gengo
+
+import (
+	"io"
+	"text/template"
+
+	wish "github.com/warpfork/go-wish"
+)
+
+func doTemplate(tmplstr string, w io.Writer, data interface{}) {
+	tmpl := template.Must(template.New("").Parse("\n" + wish.Dedent(tmplstr)))
+	if err := tmpl.Execute(w, data); err != nil {
+		panic(err)
+	}
+}

--- a/schema/gen/go/templateUtil.go
+++ b/schema/gen/go/templateUtil.go
@@ -8,7 +8,7 @@ import (
 )
 
 func doTemplate(tmplstr string, w io.Writer, data interface{}) {
-	tmpl := template.Must(template.New("").Parse("\n" + wish.Dedent(tmplstr)))
+	tmpl := template.Must(template.New("").Parse(wish.Dedent(tmplstr)))
 	if err := tmpl.Execute(w, data); err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Some forward progress on codegen.

This is a continuing WIP and still only demonstrates some very basic features for very basic types -- but, we do have some working demonstrations here.  And particularly excitingly, a short test that shows unmarshalling working on a generated type!

I've attempted to add some more types to the generation PoC on my local working copy, but have learned that already there's going to be more refinement needed on this approach to minimize the rate of growth in redundant code.  So this is probably going to be a good place to checkpoint before embarking on that.

Also, a new nicely-typed error was added to the main IPLD package, and the other existing node implementations refactored to use it.  So I want to merge this sooner than later, as it has effects outside the codegen and schema packages.