### PR TITLE
More complete selector traversal

### DIFF
--- a/encoding/dagcbor/roundtrip_test.go
+++ b/encoding/dagcbor/roundtrip_test.go
@@ -43,3 +43,19 @@ func TestRoundtrip(t *testing.T) {
 		Wish(t, n2, ShouldEqual, n)
 	})
 }
+
+func TestRoundtripSimple(t *testing.T) {
+	simple := fnb.CreateString("applesauce")
+	t.Run("encoding", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := Encoder(simple, &buf)
+		Wish(t, err, ShouldEqual, nil)
+		Wish(t, buf.String(), ShouldEqual, `japplesauce`)
+	})
+	t.Run("decoding", func(t *testing.T) {
+		buf := bytes.NewBufferString(`japplesauce`)
+		simple2, err := Decoder(ipldfree.NodeBuilder(), buf)
+		Wish(t, err, ShouldEqual, nil)
+		Wish(t, simple2, ShouldEqual, simple)
+	})
+}

--- a/encoding/dagcbor/unmarshal.go
+++ b/encoding/dagcbor/unmarshal.go
@@ -24,7 +24,10 @@ var (
 func Unmarshal(nb ipld.NodeBuilder, tokSrc shared.TokenSource) (ipld.Node, error) {
 	var tk tok.Token
 	done, err := tokSrc.Step(&tk)
-	if done || err != nil {
+	if err != nil {
+		return nil, err
+	}
+	if done && !tk.Type.IsValue() {
 		return nil, err
 	}
 	return unmarshal(nb, tokSrc, &tk)

--- a/encoding/dagjson/multicodec.go
+++ b/encoding/dagjson/multicodec.go
@@ -37,7 +37,7 @@ func Decoder(nb ipld.NodeBuilder, r io.Reader) (ipld.Node, error) {
 	for {
 		_, err := r.Read(buf[:])
 		switch buf[0] {
-		case ' ', '\t', '\r', '\n': // continue
+		case ' ', 0x0, '\t', '\r', '\n': // continue
 		default:
 			return n, fmt.Errorf("unexpected content after end of json object")
 		}

--- a/encoding/dagjson/roundtrip_test.go
+++ b/encoding/dagjson/roundtrip_test.go
@@ -59,3 +59,19 @@ func TestRoundtrip(t *testing.T) {
 		Wish(t, n2, ShouldEqual, n)
 	})
 }
+
+func TestRoundtripSimple(t *testing.T) {
+	simple := fnb.CreateString("applesauce")
+	t.Run("encoding", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := Encoder(simple, &buf)
+		Wish(t, err, ShouldEqual, nil)
+		Wish(t, buf.String(), ShouldEqual, `"applesauce"`)
+	})
+	t.Run("decoding", func(t *testing.T) {
+		buf := bytes.NewBufferString(`"applesauce"`)
+		simple2, err := Decoder(ipldfree.NodeBuilder(), buf)
+		Wish(t, err, ShouldEqual, nil)
+		Wish(t, simple2, ShouldEqual, simple)
+	})
+}

--- a/encoding/dagjson/unmarshal.go
+++ b/encoding/dagjson/unmarshal.go
@@ -19,7 +19,10 @@ import (
 func Unmarshal(nb ipld.NodeBuilder, tokSrc shared.TokenSource) (ipld.Node, error) {
 	var tk tok.Token
 	done, err := tokSrc.Step(&tk)
-	if done || err != nil {
+	if err != nil {
+		return nil, err
+	}
+	if done && !tk.Type.IsValue() {
 		return nil, err
 	}
 	return unmarshal(nb, tokSrc, &tk)

--- a/encoding/unmarshal.go
+++ b/encoding/unmarshal.go
@@ -30,7 +30,10 @@ import (
 func Unmarshal(nb ipld.NodeBuilder, tokSrc shared.TokenSource) (ipld.Node, error) {
 	var tk tok.Token
 	done, err := tokSrc.Step(&tk)
-	if done || err != nil {
+	if err != nil {
+		return nil, err
+	}
+	if done && !tk.Type.IsValue() {
 		return nil, err
 	}
 	return unmarshal(nb, tokSrc, &tk)

--- a/traversal/traverse.go
+++ b/traversal/traverse.go
@@ -69,6 +69,9 @@ func (tp TraversalProgress) traverseAll(n ipld.Node, s selector.Selector, fn Adv
 			tpNext := tp
 			tpNext.Path = tp.Path.AppendSegment(ps.String())
 			if v.ReprKind() == ipld.ReprKind_Link {
+				lnk, _ := v.AsLink()
+				tpNext.LastBlock.Path = tpNext.Path
+				tpNext.LastBlock.Link = lnk
 				v, err = tpNext.loadLink(v, n)
 				if err != nil {
 					return err
@@ -96,6 +99,9 @@ func (tp TraversalProgress) traverseSelective(n ipld.Node, attn []selector.PathS
 			tpNext := tp
 			tpNext.Path = tp.Path.AppendSegment(ps.String())
 			if v.ReprKind() == ipld.ReprKind_Link {
+				lnk, _ := v.AsLink()
+				tpNext.LastBlock.Path = tpNext.Path
+				tpNext.LastBlock.Link = lnk
 				v, err = tpNext.loadLink(v, n)
 				if err != nil {
 					return err

--- a/traversal/traverse.go
+++ b/traversal/traverse.go
@@ -52,66 +52,87 @@ func (tp TraversalProgress) traverseInformatively(n ipld.Node, s selector.Select
 	}
 	attn := s.Interests()
 	if attn == nil {
-		for itr := selector.NewSegmentIterator(n); !itr.Done(); {
-			ps, v, err := itr.Next()
+		return tp.traverseAll(n, s, fn)
+	}
+	return tp.traverseSelective(n, attn, s, fn)
+
+}
+
+func (tp TraversalProgress) traverseAll(n ipld.Node, s selector.Selector, fn AdvVisitFn) error {
+	for itr := selector.NewSegmentIterator(n); !itr.Done(); {
+		ps, v, err := itr.Next()
+		if err != nil {
+			return err
+		}
+		sNext := s.Explore(n, ps)
+		if sNext != nil {
+			tpNext := tp
+			tpNext.Path = tp.Path.AppendSegment(ps.String())
+			if v.ReprKind() == ipld.ReprKind_Link {
+				v, err = tpNext.loadLink(v, n)
+				if err != nil {
+					return err
+				}
+			}
+
+			err = tpNext.traverseInformatively(v, sNext, fn)
 			if err != nil {
 				return err
-			}
-			sNext := s.Explore(n, ps)
-			if sNext != nil {
-				err = tp.traverseChild(n, v, ps, sNext, fn)
-				if err != nil {
-					return err
-				}
-			}
-		}
-	} else {
-		for _, ps := range attn {
-			// TODO: Probably not the most efficient way to be doing this...
-			v, err := n.TraverseField(ps.String())
-			if err != nil {
-				continue
-			}
-			sNext := s.Explore(n, ps)
-			if sNext != nil {
-				err = tp.traverseChild(n, v, ps, sNext, fn)
-				if err != nil {
-					return err
-				}
 			}
 		}
 	}
 	return nil
 }
 
-func (tp TraversalProgress) traverseChild(n ipld.Node, v ipld.Node, ps selector.PathSegment, sNext selector.Selector, fn AdvVisitFn) error {
-	var err error
-	tpNext := tp
-	tpNext.Path = tp.Path.AppendSegment(ps.String())
-	if v.ReprKind() == ipld.ReprKind_Link {
-		lnk, _ := v.AsLink()
-		// Assemble the LinkContext in case the Loader or NBChooser want it.
-		lnkCtx := ipld.LinkContext{
-			LinkPath:   tpNext.Path,
-			LinkNode:   v,
-			ParentNode: n,
-		}
-		// Load link!
-		v, err = lnk.Load(
-			tpNext.Cfg.Ctx,
-			lnkCtx,
-			tpNext.Cfg.LinkNodeBuilderChooser(lnk, lnkCtx),
-			tpNext.Cfg.LinkLoader,
-		)
+func (tp TraversalProgress) traverseSelective(n ipld.Node, attn []selector.PathSegment, s selector.Selector, fn AdvVisitFn) error {
+	for _, ps := range attn {
+		// TODO: Probably not the most efficient way to be doing this...
+		v, err := n.TraverseField(ps.String())
 		if err != nil {
-			return fmt.Errorf("error traversing node at %q: could not load link %q: %s", tpNext.Path, lnk, err)
+			continue
 		}
-	}
+		sNext := s.Explore(n, ps)
+		if sNext != nil {
+			tpNext := tp
+			tpNext.Path = tp.Path.AppendSegment(ps.String())
+			if v.ReprKind() == ipld.ReprKind_Link {
+				v, err = tpNext.loadLink(v, n)
+				if err != nil {
+					return err
+				}
+			}
 
-	if err := tpNext.traverseInformatively(v, sNext, fn); err != nil {
-		return err
+			err = tpNext.traverseInformatively(v, sNext, fn)
+			if err != nil {
+				return err
+			}
+		}
 	}
 	return nil
+}
+
+func (tp TraversalProgress) loadLink(v ipld.Node, parent ipld.Node) (ipld.Node, error) {
+	lnk, err := v.AsLink()
+	if err != nil {
+		return nil, err
+	}
+	// Assemble the LinkContext in case the Loader or NBChooser want it.
+	lnkCtx := ipld.LinkContext{
+		LinkPath:   tp.Path,
+		LinkNode:   v,
+		ParentNode: parent,
+	}
+	// Load link!
+	v, err = lnk.Load(
+		tp.Cfg.Ctx,
+		lnkCtx,
+		tp.Cfg.LinkNodeBuilderChooser(lnk, lnkCtx),
+		tp.Cfg.LinkLoader,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error traversing node at %q: could not load link %q: %s", tp.Path, lnk, err)
+	}
+	return v, nil
 }
 
 func (tp TraversalProgress) TraverseTransform(n ipld.Node, s selector.Selector, fn TransformFn) (ipld.Node, error) {

--- a/traversal/traverse_test.go
+++ b/traversal/traverse_test.go
@@ -145,6 +145,9 @@ func TestTraverse(t *testing.T) {
 			case 4:
 				Wish(t, n, ShouldEqual, fnb.CreateString("alpha"))
 				Wish(t, tp.Path.String(), ShouldEqual, "nested/alink")
+				Wish(t, tp.LastBlock.Path.String(), ShouldEqual, "nested/alink")
+				Wish(t, tp.LastBlock.Link.String(), ShouldEqual, leafAlphaLnk.String())
+
 			case 5:
 				Wish(t, n, ShouldEqual, fnb.CreateString("zoo"))
 				Wish(t, tp.Path.String(), ShouldEqual, "nested/nonlink")
@@ -170,12 +173,18 @@ func TestTraverse(t *testing.T) {
 			case 0:
 				Wish(t, n, ShouldEqual, fnb.CreateString("alpha"))
 				Wish(t, tp.Path.String(), ShouldEqual, "0")
+				Wish(t, tp.LastBlock.Path.String(), ShouldEqual, "0")
+				Wish(t, tp.LastBlock.Link.String(), ShouldEqual, leafAlphaLnk.String())
 			case 1:
 				Wish(t, n, ShouldEqual, fnb.CreateString("alpha"))
 				Wish(t, tp.Path.String(), ShouldEqual, "1")
+				Wish(t, tp.LastBlock.Path.String(), ShouldEqual, "1")
+				Wish(t, tp.LastBlock.Link.String(), ShouldEqual, leafAlphaLnk.String())
 			case 2:
 				Wish(t, n, ShouldEqual, fnb.CreateString("beta"))
 				Wish(t, tp.Path.String(), ShouldEqual, "2")
+				Wish(t, tp.LastBlock.Path.String(), ShouldEqual, "2")
+				Wish(t, tp.LastBlock.Link.String(), ShouldEqual, leafBetaLnk.String())
 			}
 			order++
 			return nil
@@ -206,24 +215,38 @@ func TestTraverse(t *testing.T) {
 			case 0:
 				Wish(t, n, ShouldEqual, fnb.CreateString("alpha"))
 				Wish(t, tp.Path.String(), ShouldEqual, "linkedList/0")
+				Wish(t, tp.LastBlock.Path.String(), ShouldEqual, "linkedList/0")
+				Wish(t, tp.LastBlock.Link.String(), ShouldEqual, leafAlphaLnk.String())
 			case 1:
 				Wish(t, n, ShouldEqual, fnb.CreateString("alpha"))
 				Wish(t, tp.Path.String(), ShouldEqual, "linkedList/1")
+				Wish(t, tp.LastBlock.Path.String(), ShouldEqual, "linkedList/1")
+				Wish(t, tp.LastBlock.Link.String(), ShouldEqual, leafAlphaLnk.String())
 			case 2:
 				Wish(t, n, ShouldEqual, fnb.CreateString("beta"))
 				Wish(t, tp.Path.String(), ShouldEqual, "linkedList/2")
+				Wish(t, tp.LastBlock.Path.String(), ShouldEqual, "linkedList/2")
+				Wish(t, tp.LastBlock.Link.String(), ShouldEqual, leafBetaLnk.String())
 			case 3:
 				Wish(t, n, ShouldEqual, fnb.CreateString("alpha"))
 				Wish(t, tp.Path.String(), ShouldEqual, "linkedList/3")
+				Wish(t, tp.LastBlock.Path.String(), ShouldEqual, "linkedList/3")
+				Wish(t, tp.LastBlock.Link.String(), ShouldEqual, leafAlphaLnk.String())
 			case 4:
 				Wish(t, n, ShouldEqual, fnb.CreateBool(true))
 				Wish(t, tp.Path.String(), ShouldEqual, "linkedMap/foo")
+				Wish(t, tp.LastBlock.Path.String(), ShouldEqual, "linkedMap")
+				Wish(t, tp.LastBlock.Link.String(), ShouldEqual, middleMapNodeLnk.String())
 			case 5:
 				Wish(t, n, ShouldEqual, fnb.CreateString("zoo"))
 				Wish(t, tp.Path.String(), ShouldEqual, "linkedMap/nested/nonlink")
+				Wish(t, tp.LastBlock.Path.String(), ShouldEqual, "linkedMap")
+				Wish(t, tp.LastBlock.Link.String(), ShouldEqual, middleMapNodeLnk.String())
 			case 6:
 				Wish(t, n, ShouldEqual, fnb.CreateString("alpha"))
 				Wish(t, tp.Path.String(), ShouldEqual, "linkedMap/nested/alink")
+				Wish(t, tp.LastBlock.Path.String(), ShouldEqual, "linkedMap/nested/alink")
+				Wish(t, tp.LastBlock.Link.String(), ShouldEqual, leafAlphaLnk.String())
 			}
 			order++
 			return nil


### PR DESCRIPTION
# Goals

Improve selector traversal you can cross link boundaries and more effectively traverse over lists and limited cardinality selectors

# Implementation

- Fix a bug in decoding of simple nodes to/from json/cbor -- this came up when I tried to use the link loader with some of the fixture data that wasn't otherwise used in the focus test
- Add link loading to traverseInformatively -- mostly just copied from Focus
- Modify iterator in traverseInformatively -- uses a new "SegmentIterator" concept that basically traverses by PathSegment, abstracting out the underlying ListIterator/MapIterator based on node type -- see selector.go
- factor out a traverseChild method for DRI and cause otherwise the traverseInformatively method would be even longer than it already is (though, I wonder if this is the best place to factor out a function cause it's inside the loop)

# For discussion

The basic goal here was to get to basically feature complete on selectors... even if there's probably some tech debt in here. I will go back and fix previous PRs and rebase on top of them shortly.