### PR TITLE
fix(encoding): match go-ipld-cbor cid encoding

### DIFF
--- a/encoding/dagcbor/marshal.go
+++ b/encoding/dagcbor/marshal.go
@@ -127,7 +127,7 @@ func Marshal(n ipld.Node, sink shared.TokenSink) error {
 		switch lnk := v.(type) {
 		case cidlink.Link:
 			tk.Type = tok.TBytes
-			tk.Bytes = lnk.Bytes()
+			tk.Bytes = append([]byte{0}, lnk.Bytes()...)
 			tk.Tagged = true
 			tk.Tag = linkTag
 			_, err = sink.Step(&tk)

--- a/encoding/dagcbor/unmarshal.go
+++ b/encoding/dagcbor/unmarshal.go
@@ -1,6 +1,7 @@
 package dagcbor
 
 import (
+	"errors"
 	"fmt"
 	"math"
 
@@ -10,6 +11,10 @@ import (
 
 	ipld "github.com/ipld/go-ipld-prime"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+)
+
+var (
+	ErrInvalidMultibase = errors.New("invalid multibase on IPLD link")
 )
 
 // This should be identical to the general feature in the parent package,
@@ -126,7 +131,10 @@ func unmarshal(nb ipld.NodeBuilder, tokSrc shared.TokenSource, tk *tok.Token) (i
 		}
 		switch tk.Tag {
 		case linkTag:
-			elCid, err := cid.Cast(tk.Bytes)
+			if tk.Bytes[0] != 0 {
+				return nil, ErrInvalidMultibase
+			}
+			elCid, err := cid.Cast(tk.Bytes[1:])
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
go-ipld-cbor encodes a 0 byte ahead of cid bytes for multibase support - to maintain compatibility
of nodes encoded to CBOR, add this to encoder of go-ipld-prime.