### PR TITLE
Child-builder recursion; and typed unmarshal over codegen native structs.

### DIFF
--- a/encoding/dagcbor/unmarshal.go
+++ b/encoding/dagcbor/unmarshal.go
@@ -71,15 +71,13 @@ func unmarshal(nb ipld.NodeBuilder, tokSrc shared.TokenSource, tk *tok.Token) (i
 				return nil, fmt.Errorf("unexpected continuation of map elements beyond declared length")
 			}
 			k = tk.Str
-			// FUTURE: check for typed.NodeBuilder; need to specialize before recursing if so.
-			// FUTURE: similar specialization needed for bind.Node as well -- perhaps this actually needs to live on NodeBuilder.
-			v, err = Unmarshal(nb, tokSrc)
+			v, err = Unmarshal(mb.BuilderForValue(k), tokSrc)
 			if err != nil {
 				return nil, err
 			}
-			kn, err := nb.CreateString(k)
+			kn, err := mb.BuilderForKeys().CreateString(k)
 			if err != nil {
-				panic(err) // TODO: I'm no longer sure Insert should take a Node instead of string, but not recursing into reviewing that choice now.
+				return nil, fmt.Errorf("value rejected as key: %s", err)
 			}
 			if err := mb.Insert(kn, v); err != nil {
 				return nil, err
@@ -96,7 +94,7 @@ func unmarshal(nb ipld.NodeBuilder, tokSrc shared.TokenSource, tk *tok.Token) (i
 		if tk.Length == -1 {
 			expectLen = math.MaxInt32
 		}
-		observedLen := 0
+		i := 0
 		for {
 			_, err := tokSrc.Step(tk)
 			if err != nil {
@@ -104,18 +102,16 @@ func unmarshal(nb ipld.NodeBuilder, tokSrc shared.TokenSource, tk *tok.Token) (i
 			}
 			switch tk.Type {
 			case tok.TArrClose:
-				if expectLen != math.MaxInt32 && observedLen != expectLen {
+				if expectLen != math.MaxInt32 && i != expectLen {
 					return nil, fmt.Errorf("unexpected arrClose before declared length")
 				}
 				return lb.Build()
 			default:
-				observedLen++
-				if observedLen > expectLen {
+				if i >= expectLen {
 					return nil, fmt.Errorf("unexpected continuation of array elements beyond declared length")
 				}
-				// FUTURE: check for typed.NodeBuilder; need to specialize before recursing if so.
-				//  N.B. when considering optionals for tuple-represented structs, keep in mind how murky that will get here.
-				v, err := unmarshal(nb, tokSrc, tk)
+				v, err := unmarshal(lb.BuilderForValue(i), tokSrc, tk)
+				i++
 				if err != nil {
 					return nil, err
 				}

--- a/encoding/dagjson/unmarshal.go
+++ b/encoding/dagjson/unmarshal.go
@@ -78,15 +78,13 @@ func unmarshal(nb ipld.NodeBuilder, tokSrc shared.TokenSource, tk *tok.Token) (i
 				return nil, fmt.Errorf("unexpected continuation of map elements beyond declared length")
 			}
 			k = tk.Str
-			// FUTURE: check for typed.NodeBuilder; need to specialize before recursing if so.
-			// FUTURE: similar specialization needed for bind.Node as well -- perhaps this actually needs to live on NodeBuilder.
-			v, err = Unmarshal(nb, tokSrc)
+			v, err = Unmarshal(mb.BuilderForValue(k), tokSrc)
 			if err != nil {
 				return nil, err
 			}
-			kn, err := nb.CreateString(k)
+			kn, err := mb.BuilderForKeys().CreateString(k)
 			if err != nil {
-				panic(err) // TODO: I'm no longer sure Insert should take a Node instead of string, but not recursing into reviewing that choice now.
+				return nil, fmt.Errorf("value rejected as key: %s", err)
 			}
 			if err := mb.Insert(kn, v); err != nil {
 				return nil, err
@@ -103,7 +101,7 @@ func unmarshal(nb ipld.NodeBuilder, tokSrc shared.TokenSource, tk *tok.Token) (i
 		if tk.Length == -1 {
 			expectLen = math.MaxInt32
 		}
-		observedLen := 0
+		i := 0
 		for {
 			_, err := tokSrc.Step(tk)
 			if err != nil {
@@ -111,18 +109,16 @@ func unmarshal(nb ipld.NodeBuilder, tokSrc shared.TokenSource, tk *tok.Token) (i
 			}
 			switch tk.Type {
 			case tok.TArrClose:
-				if expectLen != math.MaxInt32 && observedLen != expectLen {
+				if expectLen != math.MaxInt32 && i != expectLen {
 					return nil, fmt.Errorf("unexpected arrClose before declared length")
 				}
 				return lb.Build()
 			default:
-				observedLen++
-				if observedLen > expectLen {
+				if i >= expectLen {
 					return nil, fmt.Errorf("unexpected continuation of array elements beyond declared length")
 				}
-				// FUTURE: check for typed.NodeBuilder; need to specialize before recursing if so.
-				//  N.B. when considering optionals for tuple-represented structs, keep in mind how murky that will get here.
-				v, err := unmarshal(nb, tokSrc, tk)
+				v, err := unmarshal(lb.BuilderForValue(i), tokSrc, tk)
+				i++
 				if err != nil {
 					return nil, err
 				}

--- a/impl/free/freeNodeBuilder.go
+++ b/impl/free/freeNodeBuilder.go
@@ -105,6 +105,12 @@ func (mb *mapBuilder) Build() (ipld.Node, error) {
 	mb = nil
 	return &v, nil
 }
+func (mapBuilder) BuilderForKeys() ipld.NodeBuilder {
+	return justStringNodeBuilder{}
+}
+func (mapBuilder) BuilderForValue(_ string) ipld.NodeBuilder {
+	return nodeBuilder{}
+}
 
 type listBuilder struct {
 	n Node // a wip node; initialized at construction.
@@ -131,6 +137,9 @@ func (lb *listBuilder) Build() (ipld.Node, error) {
 	v := lb.n
 	lb = nil
 	return &v, nil
+}
+func (listBuilder) BuilderForValue(_ int) ipld.NodeBuilder {
+	return nodeBuilder{}
 }
 
 func growList(l *[]ipld.Node, k int) {

--- a/impl/typed/wrapStruct.go
+++ b/impl/typed/wrapStruct.go
@@ -80,7 +80,7 @@ func (tn wrapnodeStruct) Length() int {
 }
 
 func (tn wrapnodeStruct) NodeBuilder() ipld.NodeBuilder {
-	panic("todo")
+	return wrapnodeStruct_Builder{tn.NodeBuilder(), tn.typ}
 }
 
 func (tn wrapnodeStruct) Representation() ipld.Node {
@@ -207,6 +207,18 @@ func (mb *wrapnodeStruct_MapBuilder) Build() (ipld.Node, error) {
 	return wrapnodeStruct{n, mb.typ}, nil
 }
 
-// TODO and soon the nb methods for getting child builders.
-// also those will have fun methods for handling the ability to have undefined..?
-//     no they shouldn't actually that's important -- those features really only occur in Insert methods.
+func (mb *wrapnodeStruct_MapBuilder) BuilderForKeys() ipld.NodeBuilder {
+	// Struct fields are always plain strings, so this is easy.
+	// FUTURE: we might want to have the builder immediately reject a string not in the field names enum instead of leaving that until insert?
+	//  unclear if this is necessary.  if so: one impl sufficies, just looks at TypeStruct.Field (fortunately this already computes a map internally).
+	return ipldfree.NodeBuilder() // FIXME: justStringNodeBuilder{} would be preferable but isn't exported atm.
+}
+func (mb *wrapnodeStruct_MapBuilder) BuilderForValue(k string) ipld.NodeBuilder {
+	// TODO we'll need other kinds of "wrapnode{Foo}_Builder" to finish fleshing this out.
+	_ = mb.typ.Field(k).Type().Kind() // putting together a nodebuilder from this info should be easy.
+	panic("todo: need more wrapnode builders")
+}
+
+// TODO much of this all again, but now for representations.
+// (e.g. `wrapnodeStruct_ReprMap_MapBuilder.BuilderForValue` method will do almost the same things,
+//  but will need to look up a nodebuilder from a slightly different table.)

--- a/schema/gen/go/_test/wow_test.go
+++ b/schema/gen/go/_test/wow_test.go
@@ -1,9 +1,12 @@
 package whee
 
 import (
+	"bytes"
 	"testing"
 
+	"github.com/polydawn/refmt/json"
 	"github.com/polydawn/refmt/tok"
+
 	. "github.com/warpfork/go-wish"
 
 	ipld "github.com/ipld/go-ipld-prime"
@@ -274,10 +277,6 @@ func TestGeneratedStructs(t *testing.T) {
 	})
 }
 
-/*
-soon...
-
-
 func TestStructUnmarshal(t *testing.T) {
 	t.Run("stroct", func(t *testing.T) {
 		t.Run("all fields set", func(t *testing.T) {
@@ -291,9 +290,27 @@ func TestStructUnmarshal(t *testing.T) {
 			}}
 			nb := Stroct__NodeBuilder()
 			n, err := encoding.Unmarshal(nb, tb)
-			// ... asserts ...
+
+			Require(t, err, ShouldEqual, nil)
+			Wish(t, n.ReprKind(), ShouldEqual, ipld.ReprKind_Map)
+			Wish(t, plz(n.LookupString("f1")), ShouldEqual, plz(String__NodeBuilder().CreateString("a")))
+			Wish(t, plz(n.LookupString("f2")), ShouldEqual, plz(String__NodeBuilder().CreateString("b")))
+			Wish(t, plz(n.LookupString("f3")), ShouldEqual, plz(String__NodeBuilder().CreateString("c")))
+			Wish(t, plz(n.LookupString("f4")), ShouldEqual, plz(String__NodeBuilder().CreateString("d")))
 		})
 	})
 }
 
-*/
+func BenchmarkStructUnmarshal(b *testing.B) {
+	bs := []byte(`{"f1":"a","f2":"b","f3":"c","f4":"d"}`)
+	for i := 0; i < b.N; i++ {
+		nb := Stroct__NodeBuilder()
+		n, err := encoding.Unmarshal(nb, json.NewDecoder(bytes.NewReader(bs)))
+		if err != nil {
+			panic(err)
+		}
+		sink = n
+	}
+}
+
+var sink interface{}

--- a/schema/gen/go/gen.go
+++ b/schema/gen/go/gen.go
@@ -85,7 +85,7 @@ type nodebuilderGenerator interface {
 	EmitNodebuilderMethodCreateBytes(io.Writer)
 	EmitNodebuilderMethodCreateLink(io.Writer)
 
-	// TODO we'll soon also need all the child-nb-getters here too.
+	// TODO we'll soon also need all the child-nb-getters here too. // they're hucked in the CreateMap/CreateList methods for now.
 }
 
 func emitFileHeader(w io.Writer) {


### PR DESCRIPTION
Child-builder recursion; and typed unmarshal, working over codegen'd native structs.  This is pretty cool and a sizable milestone that confirms a lot of things work as planned.

(These child-builder appearing are "at long last!" -- these methods were known to be needed for some time now, but I'd been intentionally been pushing off the implementation of it until we finally reached some *other* piece of functionality that would depend on it and force the issue.  Finally, that's happened: that issue is unmarshalling into natively-typed codegenerated nodes, and that's now.  Woo!)

(Though the current focus of this is for natively-typed codegen'd nodes, if we put further effort into reflective-bind node implementations, they'll also lean heavily on these child-builder-getters for internally tracking the correct `reflect.Type` to create new values of -- very similar to what our schema-typed things are doing, just with the Golang type system instead of our schema types.)

The child-builder getter methods more or less explain themselves. They yield a new NodeBuilder that's correctly specialized for child nodes in recursive structures.  This is necessary for both keys and values in maps, and for values in lists.  For values in lists and maps, getting the child-builder requires takes a parameter -- this is so typed nodes (namely, structs; but some unions will also lean on this) may have discriminated contents that differ per key or index.

The BuilderForValue functions are able to take primitive strings and ints as parameters rather than Node, because all uses that have discriminated results are places where complex keys are not acceptable. Therefore primitives are fine, and preferred since it avoids boxing.

The 'free' node implementation is updated to include this feature,
as are codegenerated nodes.
(The runtime wrapper typed node implementations have partial support, but stubbed methods where the path forward is clear but the implementation effort nontrivial and not currently on-priority-path.)

Unmarshalling now uses these child-builder-getters to correctly handle the passing down of constraints and typeinfo.  This addresses several TODO's that have been in the unmarshalling code for aeons -- hooray!
(Somewhat remarkably, our solution here is much better than the one proposed in those ancient TODO's -- we actually got this done *without* direct abstraction-breaking examination for typed nodes.  Nice!)

Unmarshalling tests are also in this same diff. There's even a wee little benchmark using a snippet of JSON as fixture. This is the first time we see unmarshalling and marshalling end-to-end connected with codegen'd nodes.  This is very exciting!

There's still some questions to be answered about the most correct (and most performance-friendly) place to put error handling against asks for a child NodeBuilder with an invalid key or index, which is a very real invalid state that's reachable for typed nodes that are structs.  Comments about that are inline in the diff.  We'll probably have to come back to that soon, but I'm gonna let it stew on the back burner for a bit.  Currently, panics are used, but this may not be acceptable ergonomics.

---

It's somewhat effortful to even detail how many thoughts about performance and the future optimization potentials go into this diff. Some comments I had in the area of the child-builder specialization functions included concerns on:

- where common-subexpression-elimination will and won't apply
- where inlining is possible vs facing function call stack shuffle overhead
- ... as well as how that affects common-subexpression-elimination
- ... as well as how that affects escape analysis and shifts to heap
- whether an isDiscriminated property will make any of these things better
- can BuilderForValue hang onto a builder, boxed into interface already, when appropriate?
- ... for the maps case, should amortize in a way comparable to isDiscriminated, yes?  verify.
- ... can we do that without the builder keeping another two words of memory just... around?  i don't think so.  question is if it pays for itself.
- question: do zero value no-fields structs get a bonus?  reading runtime/iface.go -- doesn't look like it.  but needs confirmation.
- ... revised statement: they do, it's just nonobvious.  iface.go doesn't have a specialization, but the mallocgc call hits a special path internally for zero, and then the typedmemmove call 'coincidentally' hits its "src == dst" short-circuit, thus also being fast.

... all in all, as many of these as possible of these concerns have been considered and this design should be optimization-friendly; some of them are bucketed into "we'll see", because we need to build nontrivial programs to see how significant the needs are, as well as to see how clever the compiler can get with what we've already done.

There are some possible alternative ways we might re-engineer the builders in the future to make them more performance-friendly. In particular, the fact that many builders carry a previous value with them in anticipation of one of the 'Amend' calls -- which is not necessarily going to be used! -- is a potential obstruction to optimization, since it makes many structures go from zero to more-than-zero size, and that hits significantly different paths in the runtime with very different performance characteristics. However, that is a bit much to change today; so the thought lives here as a note for potential future work.

Adding a `BuilderForValueIsDiscriminated() bool` method later seems still seems on the table, but since it wouldn't require substantial restructurings or headaches, can be deferred until benchmarks show us exactly how much it matters.

---

An alternative design considered that deserves a quick note: we could've added a `ChildBuilders()` method to the MapBuilder and ListBuilder, and attached the further getter methods there. This might still be viable, if we found that there are more methods involved in the future and we want to group them: it *should* always land on the zero-fields struct path, which means it can be done without hitting an expensive malloc.  However, at present this doesn't seem warranted: we don't have enough methods to make it feel important (especially after the recognition that Node variants of methods aren't needed in addition to the primitive args variants, described above).

---

Whew.

Lines of code in diff does not correlate to hours of thought required.

Glad to have this landing.  Even performance minutiae aside, there was a significant period of time where I had planned this section of the code, but kept bouncing focus to elsewhere, whilest being terrified that all these abstractions were going to shatter magnificently when it came time to do the final end-to-end unification of all this massive arc of work.  But now it's done.  And it works.  Woots!
