### PR TITLE
feat(selectors): support union limit type

### DIFF
--- a/traversal/selector/builder/builder.go
+++ b/traversal/selector/builder/builder.go
@@ -24,7 +24,7 @@ type SelectorSpec interface {
 // of naming, if not structure
 type SelectorSpecBuilder interface {
 	ExploreRecursiveEdge() SelectorSpec
-	ExploreRecursive(maxDepth int, sequence SelectorSpec) SelectorSpec
+	ExploreRecursive(maxDepth int, hasDepth bool, sequence SelectorSpec) SelectorSpec
 	ExploreUnion(...SelectorSpec) SelectorSpec
 	ExploreAll(next SelectorSpec) SelectorSpec
 	ExploreIndex(index int, next SelectorSpec) SelectorSpec
@@ -75,11 +75,17 @@ func (ssb *selectorSpecBuilder) ExploreRecursiveEdge() SelectorSpec {
 	}
 }
 
-func (ssb *selectorSpecBuilder) ExploreRecursive(maxDepth int, sequence SelectorSpec) SelectorSpec {
+func (ssb *selectorSpecBuilder) ExploreRecursive(maxDepth int, hasDepth bool, sequence SelectorSpec) SelectorSpec {
 	return selectorSpec{
 		ssb.fnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
 			mb.Insert(knb.CreateString(selector.SelectorKey_ExploreRecursive), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
-				mb.Insert(knb.CreateString(selector.SelectorKey_MaxDepth), vnb.CreateInt(maxDepth))
+				mb.Insert(knb.CreateString(selector.SelectorKey_Limit), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
+					if hasDepth {
+						mb.Insert(knb.CreateString(selector.SelectorKey_LimitDepth), vnb.CreateInt(maxDepth))
+					} else {
+						mb.Insert(knb.CreateString(selector.SelectorKey_LimitNone), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {}))
+					}
+				}))
 				mb.Insert(knb.CreateString(selector.SelectorKey_Sequence), sequence.Node())
 			}))
 		}),

--- a/traversal/selector/builder/builder_test.go
+++ b/traversal/selector/builder/builder_test.go
@@ -64,10 +64,28 @@ func TestBuildingSelectors(t *testing.T) {
 		Wish(t, sn, ShouldEqual, esn)
 	})
 	t.Run("ExploreRecursive builds ExploreRecursive nodes", func(t *testing.T) {
-		sn := ssb.ExploreRecursive(2, ssb.ExploreAll(ssb.ExploreRecursiveEdge())).Node()
+		sn := ssb.ExploreRecursive(2, true, ssb.ExploreAll(ssb.ExploreRecursiveEdge())).Node()
 		esn := fnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
 			mb.Insert(knb.CreateString(selector.SelectorKey_ExploreRecursive), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
-				mb.Insert(knb.CreateString(selector.SelectorKey_MaxDepth), vnb.CreateInt(2))
+				mb.Insert(knb.CreateString(selector.SelectorKey_Limit), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
+					mb.Insert(knb.CreateString(selector.SelectorKey_LimitDepth), vnb.CreateInt(2))
+				}))
+				mb.Insert(knb.CreateString(selector.SelectorKey_Sequence), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
+					mb.Insert(knb.CreateString(selector.SelectorKey_ExploreAll), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
+						mb.Insert(knb.CreateString(selector.SelectorKey_Next), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
+							mb.Insert(knb.CreateString(selector.SelectorKey_ExploreRecursiveEdge), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {}))
+						}))
+					}))
+				}))
+			}))
+		})
+		Wish(t, sn, ShouldEqual, esn)
+		sn = ssb.ExploreRecursive(0, false, ssb.ExploreAll(ssb.ExploreRecursiveEdge())).Node()
+		esn = fnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
+			mb.Insert(knb.CreateString(selector.SelectorKey_ExploreRecursive), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
+				mb.Insert(knb.CreateString(selector.SelectorKey_Limit), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
+					mb.Insert(knb.CreateString(selector.SelectorKey_LimitNone), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {}))
+				}))
 				mb.Insert(knb.CreateString(selector.SelectorKey_Sequence), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
 					mb.Insert(knb.CreateString(selector.SelectorKey_ExploreAll), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
 						mb.Insert(knb.CreateString(selector.SelectorKey_Next), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {

--- a/traversal/selector/builder/builder_test.go
+++ b/traversal/selector/builder/builder_test.go
@@ -64,7 +64,7 @@ func TestBuildingSelectors(t *testing.T) {
 		Wish(t, sn, ShouldEqual, esn)
 	})
 	t.Run("ExploreRecursive builds ExploreRecursive nodes", func(t *testing.T) {
-		sn := ssb.ExploreRecursive(2, true, ssb.ExploreAll(ssb.ExploreRecursiveEdge())).Node()
+		sn := ssb.ExploreRecursive(selector.RecursionLimitDepth(2), ssb.ExploreAll(ssb.ExploreRecursiveEdge())).Node()
 		esn := fnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
 			mb.Insert(knb.CreateString(selector.SelectorKey_ExploreRecursive), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
 				mb.Insert(knb.CreateString(selector.SelectorKey_Limit), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
@@ -80,7 +80,7 @@ func TestBuildingSelectors(t *testing.T) {
 			}))
 		})
 		Wish(t, sn, ShouldEqual, esn)
-		sn = ssb.ExploreRecursive(0, false, ssb.ExploreAll(ssb.ExploreRecursiveEdge())).Node()
+		sn = ssb.ExploreRecursive(selector.RecursionLimitNone(), ssb.ExploreAll(ssb.ExploreRecursiveEdge())).Node()
 		esn = fnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
 			mb.Insert(knb.CreateString(selector.SelectorKey_ExploreRecursive), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
 				mb.Insert(knb.CreateString(selector.SelectorKey_Limit), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {

--- a/traversal/selector/exploreRecursive.go
+++ b/traversal/selector/exploreRecursive.go
@@ -32,10 +32,51 @@ import (
 // it can easily cause very large traversals (especially if used in combination
 // with selectors like ExploreAll inside the sequence).
 type ExploreRecursive struct {
-	sequence Selector // selector for element we're interested in
-	current  Selector // selector to apply to the current node
-	depth    int
-	hasDepth bool
+	sequence Selector       // selector for element we're interested in
+	current  Selector       // selector to apply to the current node
+	limit    RecursionLimit // the limit for this recursive selector
+}
+
+// RecursionLimit_Mode is an enum that represents the type of a recursion limit
+// -- either "depth" or "none" for now
+type RecursionLimit_Mode uint8
+
+const (
+	// RecursionLimit_None means there is no recursion limit
+	RecursionLimit_None RecursionLimit_Mode = 0
+	// RecursionLimit_Depth mean recursion stops after the recursive selector
+	// is copied to a given depth
+	RecursionLimit_Depth RecursionLimit_Mode = 1
+)
+
+// RecursionLimit is a union type that captures all data about the recursion
+// limit (both its type and data specific to the type)
+type RecursionLimit struct {
+	mode  RecursionLimit_Mode
+	depth int
+}
+
+// Mode returns the type for this recursion limit
+func (rl RecursionLimit) Mode() RecursionLimit_Mode {
+	return rl.mode
+}
+
+// Depth returns the depth for a depth recursion limit, or 0 otherwise
+func (rl RecursionLimit) Depth() int {
+	if rl.mode != RecursionLimit_Depth {
+		return 0
+	}
+	return rl.depth
+}
+
+// RecursionLimitDepth returns a depth limited recursion to the given depth
+func RecursionLimitDepth(depth int) RecursionLimit {
+	return RecursionLimit{RecursionLimit_Depth, depth}
+}
+
+// RecursionLimitNone return recursion with no limit
+func RecursionLimitNone() RecursionLimit {
+	return RecursionLimit{RecursionLimit_None, 0}
 }
 
 // Interests for ExploreRecursive is empty (meaning traverse everything)
@@ -46,22 +87,25 @@ func (s ExploreRecursive) Interests() []ipld.PathSegment {
 // Explore returns the node's selector for all fields
 func (s ExploreRecursive) Explore(n ipld.Node, p ipld.PathSegment) Selector {
 	nextSelector := s.current.Explore(n, p)
-	depth := s.depth
-	hasDepth := s.hasDepth
+	limit := s.limit
 
 	if nextSelector == nil {
 		return nil
 	}
 	if !s.hasRecursiveEdge(nextSelector) {
-		return ExploreRecursive{s.sequence, nextSelector, depth, hasDepth}
+		return ExploreRecursive{s.sequence, nextSelector, limit}
 	}
-	if hasDepth {
-		if depth < 2 {
+	switch limit.mode {
+	case RecursionLimit_Depth:
+		if limit.depth < 2 {
 			return s.replaceRecursiveEdge(nextSelector, nil)
 		}
-		return ExploreRecursive{s.sequence, s.replaceRecursiveEdge(nextSelector, s.sequence), s.depth - 1, true}
+		return ExploreRecursive{s.sequence, s.replaceRecursiveEdge(nextSelector, s.sequence), RecursionLimit{RecursionLimit_Depth, limit.depth - 1}}
+	case RecursionLimit_None:
+		return ExploreRecursive{s.sequence, s.replaceRecursiveEdge(nextSelector, s.sequence), limit}
+	default:
+		panic("Unsupported recursion limit type")
 	}
-	return ExploreRecursive{s.sequence, s.replaceRecursiveEdge(nextSelector, s.sequence), 0, false}
 }
 
 func (s ExploreRecursive) hasRecursiveEdge(nextSelector Selector) bool {
@@ -132,7 +176,7 @@ func (pc ParseContext) ParseExploreRecursive(n ipld.Node) (Selector, error) {
 	if err != nil {
 		return nil, fmt.Errorf("selector spec parse rejected: limit field must be present in ExploreRecursive selector")
 	}
-	maxDepthValue, hasDepth, err := parseLimit(limitNode)
+	limit, err := parseLimit(limitNode)
 	if err != nil {
 		return nil, err
 	}
@@ -148,15 +192,15 @@ func (pc ParseContext) ParseExploreRecursive(n ipld.Node) (Selector, error) {
 	if erc.edgesFound == 0 {
 		return nil, fmt.Errorf("selector spec parse rejected: ExploreRecursive must have at least one ExploreRecursiveEdge")
 	}
-	return ExploreRecursive{selector, selector, maxDepthValue, hasDepth}, nil
+	return ExploreRecursive{selector, selector, limit}, nil
 }
 
-func parseLimit(n ipld.Node) (int, bool, error) {
+func parseLimit(n ipld.Node) (RecursionLimit, error) {
 	if n.ReprKind() != ipld.ReprKind_Map {
-		return 0, false, fmt.Errorf("selector spec parse rejected: limit in ExploreRecursive is a keyed union and thus must be a map")
+		return RecursionLimit{}, fmt.Errorf("selector spec parse rejected: limit in ExploreRecursive is a keyed union and thus must be a map")
 	}
 	if n.Length() != 1 {
-		return 0, false, fmt.Errorf("selector spec parse rejected: limit in ExploreRecursive is a keyed union and thus must be a single-entry map")
+		return RecursionLimit{}, fmt.Errorf("selector spec parse rejected: limit in ExploreRecursive is a keyed union and thus must be a single-entry map")
 	}
 	kn, v, _ := n.MapIterator().Next()
 	kstr, _ := kn.AsString()
@@ -164,12 +208,12 @@ func parseLimit(n ipld.Node) (int, bool, error) {
 	case SelectorKey_LimitDepth:
 		maxDepthValue, err := v.AsInt()
 		if err != nil {
-			return 0, false, fmt.Errorf("selector spec parse rejected: limit field of type depth must be a number in ExploreRecursive selector")
+			return RecursionLimit{}, fmt.Errorf("selector spec parse rejected: limit field of type depth must be a number in ExploreRecursive selector")
 		}
-		return maxDepthValue, true, nil
+		return RecursionLimit{RecursionLimit_Depth, maxDepthValue}, nil
 	case SelectorKey_LimitNone:
-		return 0, false, nil
+		return RecursionLimit{RecursionLimit_None, 0}, nil
 	default:
-		return 0, false, fmt.Errorf("selector spec parse rejected: %q is not a known member of the limit union in ExploreRecursive", kstr)
+		return RecursionLimit{}, fmt.Errorf("selector spec parse rejected: %q is not a known member of the limit union in ExploreRecursive", kstr)
 	}
 }

--- a/traversal/selector/exploreRecursive_test.go
+++ b/traversal/selector/exploreRecursive_test.go
@@ -130,7 +130,7 @@ func TestParseExploreRecursive(t *testing.T) {
 		})
 		s, err := ParseContext{}.ParseExploreRecursive(sn)
 		Wish(t, err, ShouldEqual, nil)
-		Wish(t, s, ShouldEqual, ExploreRecursive{ExploreAll{ExploreRecursiveEdge{}}, ExploreAll{ExploreRecursiveEdge{}}, 2, true})
+		Wish(t, s, ShouldEqual, ExploreRecursive{ExploreAll{ExploreRecursiveEdge{}}, ExploreAll{ExploreRecursiveEdge{}}, RecursionLimit{RecursionLimit_Depth, 2}})
 	})
 
 	t.Run("parsing map node with sequence field with valid selector node and limit type none should parse", func(t *testing.T) {
@@ -148,7 +148,7 @@ func TestParseExploreRecursive(t *testing.T) {
 		})
 		s, err := ParseContext{}.ParseExploreRecursive(sn)
 		Wish(t, err, ShouldEqual, nil)
-		Wish(t, s, ShouldEqual, ExploreRecursive{ExploreAll{ExploreRecursiveEdge{}}, ExploreAll{ExploreRecursiveEdge{}}, 0, false})
+		Wish(t, s, ShouldEqual, ExploreRecursive{ExploreAll{ExploreRecursiveEdge{}}, ExploreAll{ExploreRecursiveEdge{}}, RecursionLimit{RecursionLimit_None, 0}})
 	})
 
 }
@@ -181,7 +181,7 @@ func TestExploreRecursiveExplore(t *testing.T) {
 	t.Run("exploring should traverse until we get to maxDepth", func(t *testing.T) {
 		parentsSelector := ExploreAll{recursiveEdge}
 		subTree := ExploreFields{map[string]Selector{"Parents": parentsSelector}, []ipld.PathSegment{ipld.PathSegmentOfString("Parents")}}
-		rs = ExploreRecursive{subTree, subTree, maxDepth, true}
+		rs = ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_Depth, maxDepth}}
 		nodeString := `{
 			"Parents": [
 				{
@@ -202,24 +202,24 @@ func TestExploreRecursiveExplore(t *testing.T) {
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, maxDepth, true})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfInt(0))
 		rn, err = rn.LookupIndex(0)
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, maxDepth - 1, true})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("Parents"))
 
 		rn, err = rn.LookupString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, maxDepth - 1, true})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfInt(0))
 		rn, err = rn.LookupIndex(0)
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, maxDepth - 2, true})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_Depth, maxDepth - 2}})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, maxDepth - 2, true})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 2}})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfInt(0))
 		rn, err = rn.LookupIndex(0)
@@ -230,7 +230,7 @@ func TestExploreRecursiveExplore(t *testing.T) {
 	t.Run("exploring should traverse indefinitely if no depth specified", func(t *testing.T) {
 		parentsSelector := ExploreAll{recursiveEdge}
 		subTree := ExploreFields{map[string]Selector{"Parents": parentsSelector}, []ipld.PathSegment{ipld.PathSegmentOfString("Parents")}}
-		rs = ExploreRecursive{subTree, subTree, 0, false}
+		rs = ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_None, 0}}
 		nodeString := `{
 			"Parents": [
 				{
@@ -251,38 +251,38 @@ func TestExploreRecursiveExplore(t *testing.T) {
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, 0, false})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_None, 0}})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfInt(0))
 		rn, err = rn.LookupIndex(0)
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, 0, false})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_None, 0}})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, 0, false})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_None, 0}})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfInt(0))
 		rn, err = rn.LookupIndex(0)
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, 0, false})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_None, 0}})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, 0, false})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_None, 0}})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfInt(0))
 		rn, err = rn.LookupIndex(0)
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, 0, false})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_None, 0}})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, 0, false})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_None, 0}})
 		Wish(t, err, ShouldEqual, nil)
 	})
 
 	t.Run("exploring should continue till we get to selector that returns nil on explore", func(t *testing.T) {
 		parentsSelector := ExploreIndex{recursiveEdge, [1]ipld.PathSegment{ipld.PathSegmentOfInt(1)}}
 		subTree := ExploreFields{map[string]Selector{"Parents": parentsSelector}, []ipld.PathSegment{ipld.PathSegmentOfString("Parents")}}
-		rs = ExploreRecursive{subTree, subTree, maxDepth, true}
+		rs = ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_Depth, maxDepth}}
 		nodeString := `{
 			"Parents": {
 			}
@@ -292,7 +292,7 @@ func TestExploreRecursiveExplore(t *testing.T) {
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, maxDepth, true})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfInt(0))
 		Wish(t, rs, ShouldEqual, nil)
@@ -302,13 +302,13 @@ func TestExploreRecursiveExplore(t *testing.T) {
 		sideSelector := ExploreAll{recursiveEdge}
 		subTree := ExploreFields{map[string]Selector{
 			"Parents": parentsSelector,
-			"Side":    ExploreRecursive{sideSelector, sideSelector, maxDepth, true},
+			"Side":    ExploreRecursive{sideSelector, sideSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}},
 		}, []ipld.PathSegment{
 			ipld.PathSegmentOfString("Parents"),
 			ipld.PathSegmentOfString("Side"),
 		},
 		}
-		s := ExploreRecursive{subTree, subTree, maxDepth, true}
+		s := ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_Depth, maxDepth}}
 		nodeString := `{
 			"Parents": [
 				{
@@ -339,15 +339,15 @@ func TestExploreRecursiveExplore(t *testing.T) {
 		rs = s
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, maxDepth, true})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfInt(0))
 		rn, err = rn.LookupIndex(0)
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, maxDepth - 1, true})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, maxDepth - 1, true})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}})
 		Wish(t, err, ShouldEqual, nil)
 
 		// traverse down top level Side tree (nested recursion)
@@ -355,15 +355,15 @@ func TestExploreRecursiveExplore(t *testing.T) {
 		rs = s
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("Side"))
 		rn, err = rn.LookupString("Side")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, maxDepth, true}, maxDepth, true})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}}, RecursionLimit{RecursionLimit_Depth, maxDepth}})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("real"))
 		rn, err = rn.LookupString("real")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, maxDepth - 1, true}, maxDepth, true})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}}, RecursionLimit{RecursionLimit_Depth, maxDepth}})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("apple"))
 		rn, err = rn.LookupString("apple")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, maxDepth - 2, true}, maxDepth, true})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 2}}, RecursionLimit{RecursionLimit_Depth, maxDepth}})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("sauce"))
 		rn, err = rn.LookupString("sauce")
@@ -375,29 +375,29 @@ func TestExploreRecursiveExplore(t *testing.T) {
 		rs = s
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, maxDepth, true})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfInt(0))
 		rn, err = rn.LookupIndex(0)
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, maxDepth - 1, true})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("Side"))
 		rn, err = rn.LookupString("Side")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, maxDepth, true}, maxDepth - 1, true})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}}, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("cheese"))
 		rn, err = rn.LookupString("cheese")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, maxDepth - 1, true}, maxDepth - 1, true})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}}, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("whiz"))
 		rn, err = rn.LookupString("whiz")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, maxDepth - 2, true}, maxDepth - 1, true})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 2}}, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}})
 		Wish(t, err, ShouldEqual, nil)
 	})
 	t.Run("exploring should work with explore union and recursion", func(t *testing.T) {
 		parentsSelector := ExploreUnion{[]Selector{ExploreAll{Matcher{}}, ExploreIndex{recursiveEdge, [1]ipld.PathSegment{ipld.PathSegmentOfInt(0)}}}}
 		subTree := ExploreFields{map[string]Selector{"Parents": parentsSelector}, []ipld.PathSegment{ipld.PathSegmentOfString("Parents")}}
-		rs = ExploreRecursive{subTree, subTree, maxDepth, true}
+		rs = ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_Depth, maxDepth}}
 		nodeString := `{
 			"Parents": [
 				{
@@ -418,20 +418,20 @@ func TestExploreRecursiveExplore(t *testing.T) {
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, maxDepth, true})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfInt(0))
 		rn, err = rn.LookupIndex(0)
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreUnion{[]Selector{Matcher{}, subTree}}, maxDepth - 1, true})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreUnion{[]Selector{Matcher{}, subTree}}, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("Parents"))
 
 		rn, err = rn.LookupString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, maxDepth - 1, true})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfInt(0))
 		rn, err = rn.LookupIndex(0)
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreUnion{[]Selector{Matcher{}, subTree}}, maxDepth - 2, true})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreUnion{[]Selector{Matcher{}, subTree}}, RecursionLimit{RecursionLimit_Depth, maxDepth - 2}})
 		Wish(t, err, ShouldEqual, nil)
 	})
 }

--- a/traversal/selector/exploreRecursive_test.go
+++ b/traversal/selector/exploreRecursive_test.go
@@ -21,33 +21,74 @@ func TestParseExploreRecursive(t *testing.T) {
 	})
 	t.Run("parsing map node without sequence field should error", func(t *testing.T) {
 		sn := fnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
-			mb.Insert(knb.CreateString(SelectorKey_MaxDepth), vnb.CreateInt(2))
+			mb.Insert(knb.CreateString(SelectorKey_Limit), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
+				mb.Insert(knb.CreateString(SelectorKey_LimitDepth), vnb.CreateInt(2))
+			}))
 		})
 		_, err := ParseContext{}.ParseExploreRecursive(sn)
 		Wish(t, err, ShouldEqual, fmt.Errorf("selector spec parse rejected: sequence field must be present in ExploreRecursive selector"))
 	})
-	t.Run("parsing map node without maxDepth field should error", func(t *testing.T) {
+	t.Run("parsing map node without limit field should error", func(t *testing.T) {
 		sn := fnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
 			mb.Insert(knb.CreateString(SelectorKey_Sequence), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
 				mb.Insert(knb.CreateString(SelectorKey_Matcher), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {}))
 			}))
 		})
 		_, err := ParseContext{}.ParseExploreRecursive(sn)
-		Wish(t, err, ShouldEqual, fmt.Errorf("selector spec parse rejected: maxDepth field must be present in ExploreRecursive selector"))
+		Wish(t, err, ShouldEqual, fmt.Errorf("selector spec parse rejected: limit field must be present in ExploreRecursive selector"))
 	})
-	t.Run("parsing map node with maxDepth field that is not an int should error", func(t *testing.T) {
+	t.Run("parsing map node with limit field that is not a map should fail", func(t *testing.T) {
 		sn := fnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
-			mb.Insert(knb.CreateString(SelectorKey_MaxDepth), vnb.CreateString("cheese"))
+			mb.Insert(knb.CreateString(SelectorKey_Limit), vnb.CreateString("cheese"))
 			mb.Insert(knb.CreateString(SelectorKey_Sequence), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
 				mb.Insert(knb.CreateString(SelectorKey_Matcher), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {}))
 			}))
 		})
 		_, err := ParseContext{}.ParseExploreRecursive(sn)
-		Wish(t, err, ShouldEqual, fmt.Errorf("selector spec parse rejected: maxDepth field must be a number in ExploreRecursive selector"))
+		Wish(t, err, ShouldEqual, fmt.Errorf("selector spec parse rejected: limit in ExploreRecursive is a keyed union and thus must be a map"))
+	})
+	t.Run("parsing map node with limit field that is not a single entry map should fail", func(t *testing.T) {
+		sn := fnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
+			mb.Insert(knb.CreateString(SelectorKey_Limit), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
+				mb.Insert(knb.CreateString(SelectorKey_LimitDepth), vnb.CreateInt(2))
+				mb.Insert(knb.CreateString(SelectorKey_LimitNone), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {}))
+			}))
+			mb.Insert(knb.CreateString(SelectorKey_Sequence), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
+				mb.Insert(knb.CreateString(SelectorKey_Matcher), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {}))
+			}))
+		})
+		_, err := ParseContext{}.ParseExploreRecursive(sn)
+		Wish(t, err, ShouldEqual, fmt.Errorf("selector spec parse rejected: limit in ExploreRecursive is a keyed union and thus must be a single-entry map"))
+	})
+	t.Run("parsing map node with limit field that does not have a known key should fail", func(t *testing.T) {
+		sn := fnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
+			mb.Insert(knb.CreateString(SelectorKey_Limit), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
+				mb.Insert(knb.CreateString("applesauce"), vnb.CreateInt(2))
+			}))
+			mb.Insert(knb.CreateString(SelectorKey_Sequence), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
+				mb.Insert(knb.CreateString(SelectorKey_Matcher), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {}))
+			}))
+		})
+		_, err := ParseContext{}.ParseExploreRecursive(sn)
+		Wish(t, err, ShouldEqual, fmt.Errorf("selector spec parse rejected: \"applesauce\" is not a known member of the limit union in ExploreRecursive"))
+	})
+	t.Run("parsing map node with limit field of type depth that is not an int should error", func(t *testing.T) {
+		sn := fnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
+			mb.Insert(knb.CreateString(SelectorKey_Limit), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
+				mb.Insert(knb.CreateString(SelectorKey_LimitDepth), vnb.CreateString("cheese"))
+			}))
+			mb.Insert(knb.CreateString(SelectorKey_Sequence), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
+				mb.Insert(knb.CreateString(SelectorKey_Matcher), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {}))
+			}))
+		})
+		_, err := ParseContext{}.ParseExploreRecursive(sn)
+		Wish(t, err, ShouldEqual, fmt.Errorf("selector spec parse rejected: limit field of type depth must be a number in ExploreRecursive selector"))
 	})
 	t.Run("parsing map node with sequence field with invalid selector node should return child's error", func(t *testing.T) {
 		sn := fnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
-			mb.Insert(knb.CreateString(SelectorKey_MaxDepth), vnb.CreateInt(2))
+			mb.Insert(knb.CreateString(SelectorKey_Limit), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
+				mb.Insert(knb.CreateString(SelectorKey_LimitDepth), vnb.CreateInt(2))
+			}))
 			mb.Insert(knb.CreateString(SelectorKey_Sequence), vnb.CreateInt(0))
 		})
 		_, err := ParseContext{}.ParseExploreRecursive(sn)
@@ -55,7 +96,9 @@ func TestParseExploreRecursive(t *testing.T) {
 	})
 	t.Run("parsing map node with sequence field with valid selector w/o ExploreRecursiveEdge should not parse", func(t *testing.T) {
 		sn := fnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
-			mb.Insert(knb.CreateString(SelectorKey_MaxDepth), vnb.CreateInt(2))
+			mb.Insert(knb.CreateString(SelectorKey_Limit), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
+				mb.Insert(knb.CreateString(SelectorKey_LimitDepth), vnb.CreateInt(2))
+			}))
 			mb.Insert(knb.CreateString(SelectorKey_Sequence), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
 				mb.Insert(knb.CreateString(SelectorKey_ExploreAll), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
 					mb.Insert(knb.CreateString(SelectorKey_Next), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
@@ -74,7 +117,9 @@ func TestParseExploreRecursive(t *testing.T) {
 	})
 	t.Run("parsing map node with sequence field with valid selector node should parse", func(t *testing.T) {
 		sn := fnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
-			mb.Insert(knb.CreateString(SelectorKey_MaxDepth), vnb.CreateInt(2))
+			mb.Insert(knb.CreateString(SelectorKey_Limit), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
+				mb.Insert(knb.CreateString(SelectorKey_LimitDepth), vnb.CreateInt(2))
+			}))
 			mb.Insert(knb.CreateString(SelectorKey_Sequence), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
 				mb.Insert(knb.CreateString(SelectorKey_ExploreAll), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
 					mb.Insert(knb.CreateString(SelectorKey_Next), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
@@ -85,7 +130,25 @@ func TestParseExploreRecursive(t *testing.T) {
 		})
 		s, err := ParseContext{}.ParseExploreRecursive(sn)
 		Wish(t, err, ShouldEqual, nil)
-		Wish(t, s, ShouldEqual, ExploreRecursive{ExploreAll{ExploreRecursiveEdge{}}, ExploreAll{ExploreRecursiveEdge{}}, 2})
+		Wish(t, s, ShouldEqual, ExploreRecursive{ExploreAll{ExploreRecursiveEdge{}}, ExploreAll{ExploreRecursiveEdge{}}, 2, true})
+	})
+
+	t.Run("parsing map node with sequence field with valid selector node and limit type none should parse", func(t *testing.T) {
+		sn := fnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
+			mb.Insert(knb.CreateString(SelectorKey_Limit), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
+				mb.Insert(knb.CreateString(SelectorKey_LimitNone), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {}))
+			}))
+			mb.Insert(knb.CreateString(SelectorKey_Sequence), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
+				mb.Insert(knb.CreateString(SelectorKey_ExploreAll), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
+					mb.Insert(knb.CreateString(SelectorKey_Next), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {
+						mb.Insert(knb.CreateString(SelectorKey_ExploreRecursiveEdge), vnb.CreateMap(func(mb fluent.MapBuilder, knb fluent.NodeBuilder, vnb fluent.NodeBuilder) {}))
+					}))
+				}))
+			}))
+		})
+		s, err := ParseContext{}.ParseExploreRecursive(sn)
+		Wish(t, err, ShouldEqual, nil)
+		Wish(t, s, ShouldEqual, ExploreRecursive{ExploreAll{ExploreRecursiveEdge{}}, ExploreAll{ExploreRecursiveEdge{}}, 0, false})
 	})
 
 }
@@ -118,7 +181,7 @@ func TestExploreRecursiveExplore(t *testing.T) {
 	t.Run("exploring should traverse until we get to maxDepth", func(t *testing.T) {
 		parentsSelector := ExploreAll{recursiveEdge}
 		subTree := ExploreFields{map[string]Selector{"Parents": parentsSelector}, []ipld.PathSegment{ipld.PathSegmentOfString("Parents")}}
-		rs = ExploreRecursive{subTree, subTree, maxDepth}
+		rs = ExploreRecursive{subTree, subTree, maxDepth, true}
 		nodeString := `{
 			"Parents": [
 				{
@@ -139,34 +202,87 @@ func TestExploreRecursiveExplore(t *testing.T) {
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, maxDepth})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, maxDepth, true})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfInt(0))
 		rn, err = rn.LookupIndex(0)
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, maxDepth - 1})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, maxDepth - 1, true})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("Parents"))
 
 		rn, err = rn.LookupString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, maxDepth - 1})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, maxDepth - 1, true})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfInt(0))
 		rn, err = rn.LookupIndex(0)
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, maxDepth - 2})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, maxDepth - 2, true})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, maxDepth - 2})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, maxDepth - 2, true})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfInt(0))
 		rn, err = rn.LookupIndex(0)
 		Wish(t, rs, ShouldEqual, nil)
 		Wish(t, err, ShouldEqual, nil)
 	})
+
+	t.Run("exploring should traverse indefinitely if no depth specified", func(t *testing.T) {
+		parentsSelector := ExploreAll{recursiveEdge}
+		subTree := ExploreFields{map[string]Selector{"Parents": parentsSelector}, []ipld.PathSegment{ipld.PathSegmentOfString("Parents")}}
+		rs = ExploreRecursive{subTree, subTree, 0, false}
+		nodeString := `{
+			"Parents": [
+				{
+					"Parents": [
+						{
+							"Parents": [
+								{
+									"Parents": []
+								}
+							]
+						}
+					]
+				}
+			]
+		}
+		`
+		rn, err := dagjson.Decoder(ipldfree.NodeBuilder(), bytes.NewBufferString(nodeString))
+		Wish(t, err, ShouldEqual, nil)
+		rs = rs.Explore(rn, ipld.PathSegmentOfString("Parents"))
+		rn, err = rn.LookupString("Parents")
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, 0, false})
+		Wish(t, err, ShouldEqual, nil)
+		rs = rs.Explore(rn, ipld.PathSegmentOfInt(0))
+		rn, err = rn.LookupIndex(0)
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, 0, false})
+		Wish(t, err, ShouldEqual, nil)
+		rs = rs.Explore(rn, ipld.PathSegmentOfString("Parents"))
+		rn, err = rn.LookupString("Parents")
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, 0, false})
+		Wish(t, err, ShouldEqual, nil)
+		rs = rs.Explore(rn, ipld.PathSegmentOfInt(0))
+		rn, err = rn.LookupIndex(0)
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, 0, false})
+		Wish(t, err, ShouldEqual, nil)
+		rs = rs.Explore(rn, ipld.PathSegmentOfString("Parents"))
+		rn, err = rn.LookupString("Parents")
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, 0, false})
+		Wish(t, err, ShouldEqual, nil)
+		rs = rs.Explore(rn, ipld.PathSegmentOfInt(0))
+		rn, err = rn.LookupIndex(0)
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, 0, false})
+		Wish(t, err, ShouldEqual, nil)
+		rs = rs.Explore(rn, ipld.PathSegmentOfString("Parents"))
+		rn, err = rn.LookupString("Parents")
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, 0, false})
+		Wish(t, err, ShouldEqual, nil)
+	})
+
 	t.Run("exploring should continue till we get to selector that returns nil on explore", func(t *testing.T) {
 		parentsSelector := ExploreIndex{recursiveEdge, [1]ipld.PathSegment{ipld.PathSegmentOfInt(1)}}
 		subTree := ExploreFields{map[string]Selector{"Parents": parentsSelector}, []ipld.PathSegment{ipld.PathSegmentOfString("Parents")}}
-		rs = ExploreRecursive{subTree, subTree, maxDepth}
+		rs = ExploreRecursive{subTree, subTree, maxDepth, true}
 		nodeString := `{
 			"Parents": {
 			}
@@ -176,7 +292,7 @@ func TestExploreRecursiveExplore(t *testing.T) {
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, maxDepth})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, maxDepth, true})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfInt(0))
 		Wish(t, rs, ShouldEqual, nil)
@@ -186,13 +302,13 @@ func TestExploreRecursiveExplore(t *testing.T) {
 		sideSelector := ExploreAll{recursiveEdge}
 		subTree := ExploreFields{map[string]Selector{
 			"Parents": parentsSelector,
-			"Side":    ExploreRecursive{sideSelector, sideSelector, maxDepth},
+			"Side":    ExploreRecursive{sideSelector, sideSelector, maxDepth, true},
 		}, []ipld.PathSegment{
 			ipld.PathSegmentOfString("Parents"),
 			ipld.PathSegmentOfString("Side"),
 		},
 		}
-		s := ExploreRecursive{subTree, subTree, maxDepth}
+		s := ExploreRecursive{subTree, subTree, maxDepth, true}
 		nodeString := `{
 			"Parents": [
 				{
@@ -223,15 +339,15 @@ func TestExploreRecursiveExplore(t *testing.T) {
 		rs = s
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, maxDepth})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, maxDepth, true})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfInt(0))
 		rn, err = rn.LookupIndex(0)
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, maxDepth - 1})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, maxDepth - 1, true})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, maxDepth - 1})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, maxDepth - 1, true})
 		Wish(t, err, ShouldEqual, nil)
 
 		// traverse down top level Side tree (nested recursion)
@@ -239,15 +355,15 @@ func TestExploreRecursiveExplore(t *testing.T) {
 		rs = s
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("Side"))
 		rn, err = rn.LookupString("Side")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, maxDepth}, maxDepth})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, maxDepth, true}, maxDepth, true})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("real"))
 		rn, err = rn.LookupString("real")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, maxDepth - 1}, maxDepth})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, maxDepth - 1, true}, maxDepth, true})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("apple"))
 		rn, err = rn.LookupString("apple")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, maxDepth - 2}, maxDepth})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, maxDepth - 2, true}, maxDepth, true})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("sauce"))
 		rn, err = rn.LookupString("sauce")
@@ -259,29 +375,29 @@ func TestExploreRecursiveExplore(t *testing.T) {
 		rs = s
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, maxDepth})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, maxDepth, true})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfInt(0))
 		rn, err = rn.LookupIndex(0)
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, maxDepth - 1})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, maxDepth - 1, true})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("Side"))
 		rn, err = rn.LookupString("Side")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, maxDepth}, maxDepth - 1})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, maxDepth, true}, maxDepth - 1, true})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("cheese"))
 		rn, err = rn.LookupString("cheese")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, maxDepth - 1}, maxDepth - 1})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, maxDepth - 1, true}, maxDepth - 1, true})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("whiz"))
 		rn, err = rn.LookupString("whiz")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, maxDepth - 2}, maxDepth - 1})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, maxDepth - 2, true}, maxDepth - 1, true})
 		Wish(t, err, ShouldEqual, nil)
 	})
 	t.Run("exploring should work with explore union and recursion", func(t *testing.T) {
 		parentsSelector := ExploreUnion{[]Selector{ExploreAll{Matcher{}}, ExploreIndex{recursiveEdge, [1]ipld.PathSegment{ipld.PathSegmentOfInt(0)}}}}
 		subTree := ExploreFields{map[string]Selector{"Parents": parentsSelector}, []ipld.PathSegment{ipld.PathSegmentOfString("Parents")}}
-		rs = ExploreRecursive{subTree, subTree, maxDepth}
+		rs = ExploreRecursive{subTree, subTree, maxDepth, true}
 		nodeString := `{
 			"Parents": [
 				{
@@ -302,20 +418,20 @@ func TestExploreRecursiveExplore(t *testing.T) {
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, maxDepth})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, maxDepth, true})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfInt(0))
 		rn, err = rn.LookupIndex(0)
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreUnion{[]Selector{Matcher{}, subTree}}, maxDepth - 1})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreUnion{[]Selector{Matcher{}, subTree}}, maxDepth - 1, true})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("Parents"))
 
 		rn, err = rn.LookupString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, maxDepth - 1})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, maxDepth - 1, true})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfInt(0))
 		rn, err = rn.LookupIndex(0)
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreUnion{[]Selector{Matcher{}, subTree}}, maxDepth - 2})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreUnion{[]Selector{Matcher{}, subTree}}, maxDepth - 2, true})
 		Wish(t, err, ShouldEqual, nil)
 	})
 }

--- a/traversal/selector/fieldKeys.go
+++ b/traversal/selector/fieldKeys.go
@@ -16,7 +16,9 @@ const (
 	SelectorKey_Start                = "^"
 	SelectorKey_End                  = "$"
 	SelectorKey_Sequence             = ":>"
-	SelectorKey_MaxDepth             = "d"
+	SelectorKey_Limit                = "l"
+	SelectorKey_LimitDepth           = "depth"
+	SelectorKey_LimitNone            = "none"
 	SelectorKey_StopAt               = "!"
 	SelectorKey_Condition            = "&"
 	// not filling conditional keys since it's not complete

--- a/traversal/walk_test.go
+++ b/traversal/walk_test.go
@@ -113,7 +113,7 @@ func TestWalkMatching(t *testing.T) {
 		Wish(t, order, ShouldEqual, 2)
 	})
 	t.Run("traversing across nodes should work", func(t *testing.T) {
-		ss := ssb.ExploreRecursive(3, ssb.ExploreUnion(
+		ss := ssb.ExploreRecursive(3, true, ssb.ExploreUnion(
 			ssb.Matcher(),
 			ssb.ExploreAll(ssb.ExploreRecursiveEdge()),
 		))
@@ -195,7 +195,7 @@ func TestWalkMatching(t *testing.T) {
 	t.Run("multiple layers of link traversal should work", func(t *testing.T) {
 		ss := ssb.ExploreFields(func(efsb builder.ExploreFieldsSpecBuilder) {
 			efsb.Insert("linkedList", ssb.ExploreAll(ssb.Matcher()))
-			efsb.Insert("linkedMap", ssb.ExploreRecursive(3, ssb.ExploreFields(func(efsb builder.ExploreFieldsSpecBuilder) {
+			efsb.Insert("linkedMap", ssb.ExploreRecursive(3, true, ssb.ExploreFields(func(efsb builder.ExploreFieldsSpecBuilder) {
 				efsb.Insert("foo", ssb.Matcher())
 				efsb.Insert("nonlink", ssb.Matcher())
 				efsb.Insert("alink", ssb.Matcher())

--- a/traversal/walk_test.go
+++ b/traversal/walk_test.go
@@ -113,7 +113,7 @@ func TestWalkMatching(t *testing.T) {
 		Wish(t, order, ShouldEqual, 2)
 	})
 	t.Run("traversing across nodes should work", func(t *testing.T) {
-		ss := ssb.ExploreRecursive(3, true, ssb.ExploreUnion(
+		ss := ssb.ExploreRecursive(selector.RecursionLimitDepth(3), ssb.ExploreUnion(
 			ssb.Matcher(),
 			ssb.ExploreAll(ssb.ExploreRecursiveEdge()),
 		))
@@ -195,7 +195,7 @@ func TestWalkMatching(t *testing.T) {
 	t.Run("multiple layers of link traversal should work", func(t *testing.T) {
 		ss := ssb.ExploreFields(func(efsb builder.ExploreFieldsSpecBuilder) {
 			efsb.Insert("linkedList", ssb.ExploreAll(ssb.Matcher()))
-			efsb.Insert("linkedMap", ssb.ExploreRecursive(3, true, ssb.ExploreFields(func(efsb builder.ExploreFieldsSpecBuilder) {
+			efsb.Insert("linkedMap", ssb.ExploreRecursive(selector.RecursionLimitDepth(3), ssb.ExploreFields(func(efsb builder.ExploreFieldsSpecBuilder) {
 				efsb.Insert("foo", ssb.Matcher())
 				efsb.Insert("nonlink", ssb.Matcher())
 				efsb.Insert("alink", ssb.Matcher())


### PR DESCRIPTION
# Goals

Support https://github.com/ipld/specs/pull/207, now merged

# Implementation

In explore recursive, internally use a depth parameter and a hasDepth boolean. For limit type depth, depth = depth limit & hasDepth = true. For limit type none, depth = n/a & hasDepth = false