### PR TITLE
FYC: add int, bytes, and link types to code-gen

### DIFF
--- a/schema/gen/go/genCommon.go
+++ b/schema/gen/go/genCommon.go
@@ -226,3 +226,150 @@ func (gk generateKindedRejections_Map) EmitNodeMethodAsBytes(w io.Writer) {
 func (gk generateKindedRejections_Map) EmitNodeMethodAsLink(w io.Writer) {
 	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Map}.emitNodeMethodAsLink(w)
 }
+
+// Embeddable to do all the "nope" methods at once.
+type generateKindedRejections_Int struct {
+	TypeIdent string // see doc in generateKindedRejections
+	TypeProse string // see doc in generateKindedRejections
+}
+
+func (gk generateKindedRejections_Int) EmitNodeMethodLookupString(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Int}.emitNodeMethodLookupString(w)
+}
+func (gk generateKindedRejections_Int) EmitNodeMethodLookup(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Int}.emitNodeMethodLookup(w)
+}
+func (gk generateKindedRejections_Int) EmitNodeMethodLookupIndex(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Int}.emitNodeMethodLookupIndex(w)
+}
+func (gk generateKindedRejections_Int) EmitNodeMethodLookupSegment(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Int}.emitNodeMethodLookupSegment(w)
+}
+func (gk generateKindedRejections_Int) EmitNodeMethodMapIterator(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Int}.emitNodeMethodMapIterator(w)
+}
+func (gk generateKindedRejections_Int) EmitNodeMethodListIterator(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Int}.emitNodeMethodListIterator(w)
+}
+func (gk generateKindedRejections_Int) EmitNodeMethodLength(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Int}.emitNodeMethodLength(w)
+}
+func (gk generateKindedRejections_Int) EmitNodeMethodIsUndefined(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Int}.emitNodeMethodIsUndefined(w)
+}
+func (gk generateKindedRejections_Int) EmitNodeMethodIsNull(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Int}.emitNodeMethodIsNull(w)
+}
+func (gk generateKindedRejections_Int) EmitNodeMethodAsBool(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Int}.emitNodeMethodAsBool(w)
+}
+func (gk generateKindedRejections_Int) EmitNodeMethodAsString(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Int}.emitNodeMethodAsString(w)
+}
+func (gk generateKindedRejections_Int) EmitNodeMethodAsFloat(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Int}.emitNodeMethodAsFloat(w)
+}
+func (gk generateKindedRejections_Int) EmitNodeMethodAsBytes(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Int}.emitNodeMethodAsBytes(w)
+}
+func (gk generateKindedRejections_Int) EmitNodeMethodAsLink(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Int}.emitNodeMethodAsLink(w)
+}
+
+// Embeddable to do all the "nope" methods at once.
+type generateKindedRejections_Bytes struct {
+	TypeIdent string // see doc in generateKindedRejections
+	TypeProse string // see doc in generateKindedRejections
+}
+
+func (gk generateKindedRejections_Bytes) EmitNodeMethodLookupString(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Bytes}.emitNodeMethodLookupString(w)
+}
+func (gk generateKindedRejections_Bytes) EmitNodeMethodLookup(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Bytes}.emitNodeMethodLookup(w)
+}
+func (gk generateKindedRejections_Bytes) EmitNodeMethodLookupIndex(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Bytes}.emitNodeMethodLookupIndex(w)
+}
+func (gk generateKindedRejections_Bytes) EmitNodeMethodLookupSegment(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Bytes}.emitNodeMethodLookupSegment(w)
+}
+func (gk generateKindedRejections_Bytes) EmitNodeMethodMapIterator(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Bytes}.emitNodeMethodMapIterator(w)
+}
+func (gk generateKindedRejections_Bytes) EmitNodeMethodListIterator(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Bytes}.emitNodeMethodListIterator(w)
+}
+func (gk generateKindedRejections_Bytes) EmitNodeMethodLength(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Bytes}.emitNodeMethodLength(w)
+}
+func (gk generateKindedRejections_Bytes) EmitNodeMethodIsUndefined(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Bytes}.emitNodeMethodIsUndefined(w)
+}
+func (gk generateKindedRejections_Bytes) EmitNodeMethodIsNull(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Bytes}.emitNodeMethodIsNull(w)
+}
+func (gk generateKindedRejections_Bytes) EmitNodeMethodAsBool(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Bytes}.emitNodeMethodAsBool(w)
+}
+func (gk generateKindedRejections_Bytes) EmitNodeMethodAsInt(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Bytes}.emitNodeMethodAsInt(w)
+}
+func (gk generateKindedRejections_Bytes) EmitNodeMethodAsFloat(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Bytes}.emitNodeMethodAsFloat(w)
+}
+func (gk generateKindedRejections_Bytes) EmitNodeMethodAsString(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Bytes}.emitNodeMethodAsString(w)
+}
+func (gk generateKindedRejections_Bytes) EmitNodeMethodAsLink(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Bytes}.emitNodeMethodAsLink(w)
+}
+
+// Embeddable to do all the "nope" methods at once.
+type generateKindedRejections_Link struct {
+	TypeIdent string // see doc in generateKindedRejections
+	TypeProse string // see doc in generateKindedRejections
+}
+
+func (gk generateKindedRejections_Link) EmitNodeMethodLookupString(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Link}.emitNodeMethodLookupString(w)
+}
+func (gk generateKindedRejections_Link) EmitNodeMethodLookup(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Link}.emitNodeMethodLookup(w)
+}
+func (gk generateKindedRejections_Link) EmitNodeMethodLookupIndex(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Link}.emitNodeMethodLookupIndex(w)
+}
+func (gk generateKindedRejections_Link) EmitNodeMethodLookupSegment(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Link}.emitNodeMethodLookupSegment(w)
+}
+func (gk generateKindedRejections_Link) EmitNodeMethodMapIterator(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Link}.emitNodeMethodMapIterator(w)
+}
+func (gk generateKindedRejections_Link) EmitNodeMethodListIterator(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Link}.emitNodeMethodListIterator(w)
+}
+func (gk generateKindedRejections_Link) EmitNodeMethodLength(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Link}.emitNodeMethodLength(w)
+}
+func (gk generateKindedRejections_Link) EmitNodeMethodIsUndefined(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Link}.emitNodeMethodIsUndefined(w)
+}
+func (gk generateKindedRejections_Link) EmitNodeMethodIsNull(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Link}.emitNodeMethodIsNull(w)
+}
+func (gk generateKindedRejections_Link) EmitNodeMethodAsBool(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Link}.emitNodeMethodAsBool(w)
+}
+func (gk generateKindedRejections_Link) EmitNodeMethodAsInt(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Link}.emitNodeMethodAsInt(w)
+}
+func (gk generateKindedRejections_Link) EmitNodeMethodAsFloat(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Link}.emitNodeMethodAsFloat(w)
+}
+func (gk generateKindedRejections_Link) EmitNodeMethodAsBytes(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Link}.emitNodeMethodAsBytes(w)
+}
+func (gk generateKindedRejections_Link) EmitNodeMethodAsString(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Link}.emitNodeMethodAsString(w)
+}

--- a/schema/gen/go/genCommon.go
+++ b/schema/gen/go/genCommon.go
@@ -373,3 +373,53 @@ func (gk generateKindedRejections_Link) EmitNodeMethodAsBytes(w io.Writer) {
 func (gk generateKindedRejections_Link) EmitNodeMethodAsString(w io.Writer) {
 	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Link}.emitNodeMethodAsString(w)
 }
+
+// Embeddable to do all the "nope" methods at once.
+//
+// Used for anything that "acts like" map (so, also struct).
+type generateKindedRejections_List struct {
+	TypeIdent string // see doc in generateKindedRejections
+	TypeProse string // see doc in generateKindedRejections
+}
+
+func (gk generateKindedRejections_List) EmitNodeMethodLookupString(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_List}.emitNodeMethodLookupString(w)
+}
+func (gk generateKindedRejections_List) EmitNodeMethodLookupSegment(w io.Writer) {
+	doTemplate(`
+		func (n {{ .TypeIdent }}) LookupSegment(seg ipld.PathSegment) (ipld.Node, error) {
+			idx, err := seg.Index()
+			if err != nil {
+				return nil, err
+			}
+			return n.LookupIndex(idx)
+		}
+	`, w, gk)
+}
+func (gk generateKindedRejections_List) EmitNodeMethodMapIterator(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_List}.emitNodeMethodMapIterator(w)
+}
+func (gk generateKindedRejections_List) EmitNodeMethodIsUndefined(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_List}.emitNodeMethodIsUndefined(w)
+}
+func (gk generateKindedRejections_List) EmitNodeMethodIsNull(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_List}.emitNodeMethodIsNull(w)
+}
+func (gk generateKindedRejections_List) EmitNodeMethodAsBool(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_List}.emitNodeMethodAsBool(w)
+}
+func (gk generateKindedRejections_List) EmitNodeMethodAsInt(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_List}.emitNodeMethodAsInt(w)
+}
+func (gk generateKindedRejections_List) EmitNodeMethodAsFloat(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_List}.emitNodeMethodAsFloat(w)
+}
+func (gk generateKindedRejections_List) EmitNodeMethodAsString(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_List}.emitNodeMethodAsString(w)
+}
+func (gk generateKindedRejections_List) EmitNodeMethodAsBytes(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_List}.emitNodeMethodAsBytes(w)
+}
+func (gk generateKindedRejections_List) EmitNodeMethodAsLink(w io.Writer) {
+	generateKindedRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_List}.emitNodeMethodAsLink(w)
+}

--- a/schema/gen/go/genCommonNb.go
+++ b/schema/gen/go/genCommonNb.go
@@ -160,3 +160,115 @@ func (gk genKindedNbRejections_Map) EmitNodebuilderMethodCreateBytes(w io.Writer
 func (gk genKindedNbRejections_Map) EmitNodebuilderMethodCreateLink(w io.Writer) {
 	genKindedNbRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Map}.emitNodebuilderMethodCreateLink(w)
 }
+
+// Embeddable to do all the "nope" methods at once.
+type genKindedNbRejections_Int struct {
+	TypeIdent string // see doc in generateKindedRejections
+	TypeProse string // see doc in generateKindedRejections
+}
+
+func (gk genKindedNbRejections_Int) EmitNodebuilderMethodCreateMap(w io.Writer) {
+	genKindedNbRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Int}.emitNodebuilderMethodCreateMap(w)
+}
+
+func (gk genKindedNbRejections_Int) EmitNodebuilderMethodAmendMap(w io.Writer) {
+	genKindedNbRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Int}.emitNodebuilderMethodAmendMap(w)
+}
+func (gk genKindedNbRejections_Int) EmitNodebuilderMethodCreateList(w io.Writer) {
+	genKindedNbRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Int}.emitNodebuilderMethodCreateList(w)
+}
+func (gk genKindedNbRejections_Int) EmitNodebuilderMethodAmendList(w io.Writer) {
+	genKindedNbRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Int}.emitNodebuilderMethodAmendList(w)
+}
+func (gk genKindedNbRejections_Int) EmitNodebuilderMethodCreateNull(w io.Writer) {
+	genKindedNbRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Int}.emitNodebuilderMethodCreateNull(w)
+}
+func (gk genKindedNbRejections_Int) EmitNodebuilderMethodCreateBool(w io.Writer) {
+	genKindedNbRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Int}.emitNodebuilderMethodCreateBool(w)
+}
+func (gk genKindedNbRejections_Int) EmitNodebuilderMethodCreateString(w io.Writer) {
+	genKindedNbRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Int}.emitNodebuilderMethodCreateString(w)
+}
+func (gk genKindedNbRejections_Int) EmitNodebuilderMethodCreateFloat(w io.Writer) {
+	genKindedNbRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Int}.emitNodebuilderMethodCreateFloat(w)
+}
+func (gk genKindedNbRejections_Int) EmitNodebuilderMethodCreateBytes(w io.Writer) {
+	genKindedNbRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Int}.emitNodebuilderMethodCreateBytes(w)
+}
+func (gk genKindedNbRejections_Int) EmitNodebuilderMethodCreateLink(w io.Writer) {
+	genKindedNbRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Int}.emitNodebuilderMethodCreateLink(w)
+}
+
+// Embeddable to do all the "nope" methods at once.
+type genKindedNbRejections_Bytes struct {
+	TypeIdent string // see doc in generateKindedRejections
+	TypeProse string // see doc in generateKindedRejections
+}
+
+func (gk genKindedNbRejections_Bytes) EmitNodebuilderMethodCreateMap(w io.Writer) {
+	genKindedNbRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Bytes}.emitNodebuilderMethodCreateMap(w)
+}
+func (gk genKindedNbRejections_Bytes) EmitNodebuilderMethodAmendMap(w io.Writer) {
+	genKindedNbRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Bytes}.emitNodebuilderMethodAmendMap(w)
+}
+func (gk genKindedNbRejections_Bytes) EmitNodebuilderMethodCreateList(w io.Writer) {
+	genKindedNbRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Bytes}.emitNodebuilderMethodCreateList(w)
+}
+func (gk genKindedNbRejections_Bytes) EmitNodebuilderMethodAmendList(w io.Writer) {
+	genKindedNbRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Bytes}.emitNodebuilderMethodAmendList(w)
+}
+func (gk genKindedNbRejections_Bytes) EmitNodebuilderMethodCreateNull(w io.Writer) {
+	genKindedNbRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Bytes}.emitNodebuilderMethodCreateNull(w)
+}
+func (gk genKindedNbRejections_Bytes) EmitNodebuilderMethodCreateBool(w io.Writer) {
+	genKindedNbRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Bytes}.emitNodebuilderMethodCreateBool(w)
+}
+func (gk genKindedNbRejections_Bytes) EmitNodebuilderMethodCreateInt(w io.Writer) {
+	genKindedNbRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Bytes}.emitNodebuilderMethodCreateInt(w)
+}
+func (gk genKindedNbRejections_Bytes) EmitNodebuilderMethodCreateFloat(w io.Writer) {
+	genKindedNbRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Bytes}.emitNodebuilderMethodCreateFloat(w)
+}
+func (gk genKindedNbRejections_Bytes) EmitNodebuilderMethodCreateString(w io.Writer) {
+	genKindedNbRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Bytes}.emitNodebuilderMethodCreateString(w)
+}
+func (gk genKindedNbRejections_Bytes) EmitNodebuilderMethodCreateLink(w io.Writer) {
+	genKindedNbRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Bytes}.emitNodebuilderMethodCreateLink(w)
+}
+
+// Embeddable to do all the "nope" methods at once.
+type genKindedNbRejections_Link struct {
+	TypeIdent string // see doc in generateKindedRejections
+	TypeProse string // see doc in generateKindedRejections
+}
+
+func (gk genKindedNbRejections_Link) EmitNodebuilderMethodCreateMap(w io.Writer) {
+	genKindedNbRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Link}.emitNodebuilderMethodCreateMap(w)
+}
+func (gk genKindedNbRejections_Link) EmitNodebuilderMethodAmendMap(w io.Writer) {
+	genKindedNbRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Link}.emitNodebuilderMethodAmendMap(w)
+}
+func (gk genKindedNbRejections_Link) EmitNodebuilderMethodCreateList(w io.Writer) {
+	genKindedNbRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Link}.emitNodebuilderMethodCreateList(w)
+}
+func (gk genKindedNbRejections_Link) EmitNodebuilderMethodAmendList(w io.Writer) {
+	genKindedNbRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Link}.emitNodebuilderMethodAmendList(w)
+}
+func (gk genKindedNbRejections_Link) EmitNodebuilderMethodCreateNull(w io.Writer) {
+	genKindedNbRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Link}.emitNodebuilderMethodCreateNull(w)
+}
+func (gk genKindedNbRejections_Link) EmitNodebuilderMethodCreateBool(w io.Writer) {
+	genKindedNbRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Link}.emitNodebuilderMethodCreateBool(w)
+}
+func (gk genKindedNbRejections_Link) EmitNodebuilderMethodCreateInt(w io.Writer) {
+	genKindedNbRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Link}.emitNodebuilderMethodCreateInt(w)
+}
+func (gk genKindedNbRejections_Link) EmitNodebuilderMethodCreateFloat(w io.Writer) {
+	genKindedNbRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Link}.emitNodebuilderMethodCreateFloat(w)
+}
+func (gk genKindedNbRejections_Link) EmitNodebuilderMethodCreateBytes(w io.Writer) {
+	genKindedNbRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Link}.emitNodebuilderMethodCreateBytes(w)
+}
+func (gk genKindedNbRejections_Link) EmitNodebuilderMethodCreateString(w io.Writer) {
+	genKindedNbRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Link}.emitNodebuilderMethodCreateString(w)
+}

--- a/schema/gen/go/genCommonNb.go
+++ b/schema/gen/go/genCommonNb.go
@@ -272,3 +272,37 @@ func (gk genKindedNbRejections_Link) EmitNodebuilderMethodCreateBytes(w io.Write
 func (gk genKindedNbRejections_Link) EmitNodebuilderMethodCreateString(w io.Writer) {
 	genKindedNbRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_Link}.emitNodebuilderMethodCreateString(w)
 }
+
+// Embeddable to do all the "nope" methods at once.
+type genKindedNbRejections_List struct {
+	TypeIdent string // see doc in generateKindedRejections
+	TypeProse string // see doc in generateKindedRejections
+}
+
+func (gk genKindedNbRejections_List) EmitNodebuilderMethodCreateMap(w io.Writer) {
+	genKindedNbRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_List}.emitNodebuilderMethodCreateMap(w)
+}
+func (gk genKindedNbRejections_List) EmitNodebuilderMethodAmendMap(w io.Writer) {
+	genKindedNbRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_List}.emitNodebuilderMethodAmendMap(w)
+}
+func (gk genKindedNbRejections_List) EmitNodebuilderMethodCreateNull(w io.Writer) {
+	genKindedNbRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_List}.emitNodebuilderMethodCreateNull(w)
+}
+func (gk genKindedNbRejections_List) EmitNodebuilderMethodCreateBool(w io.Writer) {
+	genKindedNbRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_List}.emitNodebuilderMethodCreateBool(w)
+}
+func (gk genKindedNbRejections_List) EmitNodebuilderMethodCreateInt(w io.Writer) {
+	genKindedNbRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_List}.emitNodebuilderMethodCreateInt(w)
+}
+func (gk genKindedNbRejections_List) EmitNodebuilderMethodCreateFloat(w io.Writer) {
+	genKindedNbRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_List}.emitNodebuilderMethodCreateFloat(w)
+}
+func (gk genKindedNbRejections_List) EmitNodebuilderMethodCreateString(w io.Writer) {
+	genKindedNbRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_List}.emitNodebuilderMethodCreateString(w)
+}
+func (gk genKindedNbRejections_List) EmitNodebuilderMethodCreateBytes(w io.Writer) {
+	genKindedNbRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_List}.emitNodebuilderMethodCreateBytes(w)
+}
+func (gk genKindedNbRejections_List) EmitNodebuilderMethodCreateLink(w io.Writer) {
+	genKindedNbRejections{gk.TypeIdent, gk.TypeProse, ipld.ReprKind_List}.emitNodebuilderMethodCreateLink(w)
+}

--- a/schema/gen/go/genKindBytes.go
+++ b/schema/gen/go/genKindBytes.go
@@ -1,0 +1,70 @@
+package gengo
+
+import (
+	"io"
+
+	"github.com/ipld/go-ipld-prime/schema"
+)
+
+func NewGeneratorForKindBytes(t schema.Type) typedNodeGenerator {
+	return generateKindBytes{
+		t.(schema.TypeBytes),
+		generateKindedRejections_Bytes{
+			mungeTypeNodeIdent(t),
+			string(t.Name()),
+		},
+	}
+}
+
+type generateKindBytes struct {
+	Type schema.TypeBytes
+	generateKindedRejections_Bytes
+	// FUTURE: probably some adjunct config data should come with here as well.
+	// FUTURE: perhaps both a global one (e.g. output package name) and a per-type one.
+}
+
+func (gk generateKindBytes) EmitNodeType(w io.Writer) {
+	doTemplate(`
+		var _ ipld.Node = {{ .Type | mungeTypeNodeIdent }}{}
+		var _ typed.Node = {{ .Type | mungeTypeNodeIdent }}{}
+
+		type {{ .Type | mungeTypeNodeIdent }} struct{ x []byte }
+
+	`, w, gk)
+}
+
+func (gk generateKindBytes) EmitTypedNodeMethodType(w io.Writer) {
+	doTemplate(`
+		func ({{ .Type | mungeTypeNodeIdent }}) Type() schema.Type {
+			return nil /*TODO:typelit*/
+		}
+	`, w, gk)
+}
+
+func (gk generateKindBytes) EmitNodeMethodReprKind(w io.Writer) {
+	doTemplate(`
+		func ({{ .Type | mungeTypeNodeIdent }}) ReprKind() ipld.ReprKind {
+			return ipld.ReprKind_Bytes
+		}
+	`, w, gk)
+}
+
+func (gk generateKindBytes) EmitNodeMethodAsBytes(w io.Writer) {
+	doTemplate(`
+		func (x {{ .Type | mungeTypeNodeIdent }}) AsBytes() ([]byte, error) {
+			return x.x, nil
+		}
+	`, w, gk)
+}
+
+func (gk generateKindBytes) EmitTypedNodeMethodRepresentation(w io.Writer) {
+	doTemplate(`
+		func ({{ .Type | mungeTypeNodeIdent }}) Representation() ipld.Node {
+			panic("TODO representation")
+		}
+	`, w, gk)
+}
+
+func (gk generateKindBytes) GetRepresentationNodeGen() nodeGenerator {
+	return nil // TODO of course
+}

--- a/schema/gen/go/genKindBytesBuilder.go
+++ b/schema/gen/go/genKindBytesBuilder.go
@@ -1,0 +1,52 @@
+package gengo
+
+import (
+	"io"
+
+	"github.com/ipld/go-ipld-prime/schema"
+)
+
+func (gk generateKindBytes) GetNodeBuilderGen() nodebuilderGenerator {
+	return generateNbKindBytes{
+		gk.Type,
+		genKindedNbRejections_Bytes{
+			mungeTypeNodebuilderIdent(gk.Type),
+			string(gk.Type.Name()) + ".Builder",
+		},
+	}
+}
+
+func (gk generateKindBytes) EmitNodeMethodNodeBuilder(w io.Writer) {
+	doTemplate(`
+		func ({{ .Type | mungeTypeNodeIdent }}) NodeBuilder() ipld.NodeBuilder {
+			return {{ .Type | mungeTypeNodebuilderIdent }}{}
+		}
+	`, w, gk)
+}
+
+type generateNbKindBytes struct {
+	Type schema.TypeBytes
+	genKindedNbRejections_Bytes
+}
+
+func (gk generateNbKindBytes) EmitNodebuilderType(w io.Writer) {
+	doTemplate(`
+		type {{ .Type | mungeTypeNodebuilderIdent }} struct{}
+	`, w, gk)
+}
+
+func (gk generateNbKindBytes) EmitNodebuilderConstructor(w io.Writer) {
+	doTemplate(`
+		func {{ .Type | mungeNodebuilderConstructorIdent }}() ipld.NodeBuilder {
+			return {{ .Type | mungeTypeNodebuilderIdent }}{}
+		}
+	`, w, gk)
+}
+
+func (gk generateNbKindBytes) EmitNodebuilderMethodCreateBytes(w io.Writer) {
+	doTemplate(`
+		func (nb {{ .Type | mungeTypeNodebuilderIdent }}) CreateBytes(v []byte) (ipld.Node, error) {
+			return {{ .Type | mungeTypeNodeIdent }}{v}, nil
+		}
+	`, w, gk)
+}

--- a/schema/gen/go/genKindInt.go
+++ b/schema/gen/go/genKindInt.go
@@ -1,0 +1,70 @@
+package gengo
+
+import (
+	"io"
+
+	"github.com/ipld/go-ipld-prime/schema"
+)
+
+func NewGeneratorForKindInt(t schema.Type) typedNodeGenerator {
+	return generateKindInt{
+		t.(schema.TypeInt),
+		generateKindedRejections_Int{
+			mungeTypeNodeIdent(t),
+			string(t.Name()),
+		},
+	}
+}
+
+type generateKindInt struct {
+	Type schema.TypeInt
+	generateKindedRejections_Int
+	// FUTURE: probably some adjunct config data should come with here as well.
+	// FUTURE: perhaps both a global one (e.g. output package name) and a per-type one.
+}
+
+func (gk generateKindInt) EmitNodeType(w io.Writer) {
+	doTemplate(`
+		var _ ipld.Node = {{ .Type | mungeTypeNodeIdent }}{}
+		var _ typed.Node = {{ .Type | mungeTypeNodeIdent }}{}
+
+		type {{ .Type | mungeTypeNodeIdent }} struct{ x int }
+
+	`, w, gk)
+}
+
+func (gk generateKindInt) EmitTypedNodeMethodType(w io.Writer) {
+	doTemplate(`
+		func ({{ .Type | mungeTypeNodeIdent }}) Type() schema.Type {
+			return nil /*TODO:typelit*/
+		}
+	`, w, gk)
+}
+
+func (gk generateKindInt) EmitNodeMethodReprKind(w io.Writer) {
+	doTemplate(`
+		func ({{ .Type | mungeTypeNodeIdent }}) ReprKind() ipld.ReprKind {
+			return ipld.ReprKind_Int
+		}
+	`, w, gk)
+}
+
+func (gk generateKindInt) EmitNodeMethodAsInt(w io.Writer) {
+	doTemplate(`
+		func (x {{ .Type | mungeTypeNodeIdent }}) AsInt() (int, error) {
+			return x.x, nil
+		}
+	`, w, gk)
+}
+
+func (gk generateKindInt) EmitTypedNodeMethodRepresentation(w io.Writer) {
+	doTemplate(`
+		func ({{ .Type | mungeTypeNodeIdent }}) Representation() ipld.Node {
+			panic("TODO representation")
+		}
+	`, w, gk)
+}
+
+func (gk generateKindInt) GetRepresentationNodeGen() nodeGenerator {
+	return nil // TODO of course
+}

--- a/schema/gen/go/genKindIntBuilder.go
+++ b/schema/gen/go/genKindIntBuilder.go
@@ -1,0 +1,52 @@
+package gengo
+
+import (
+	"io"
+
+	"github.com/ipld/go-ipld-prime/schema"
+)
+
+func (gk generateKindInt) GetNodeBuilderGen() nodebuilderGenerator {
+	return generateNbKindInt{
+		gk.Type,
+		genKindedNbRejections_Int{
+			mungeTypeNodebuilderIdent(gk.Type),
+			string(gk.Type.Name()) + ".Builder",
+		},
+	}
+}
+
+func (gk generateKindInt) EmitNodeMethodNodeBuilder(w io.Writer) {
+	doTemplate(`
+		func ({{ .Type | mungeTypeNodeIdent }}) NodeBuilder() ipld.NodeBuilder {
+			return {{ .Type | mungeTypeNodebuilderIdent }}{}
+		}
+	`, w, gk)
+}
+
+type generateNbKindInt struct {
+	Type schema.TypeInt
+	genKindedNbRejections_Int
+}
+
+func (gk generateNbKindInt) EmitNodebuilderType(w io.Writer) {
+	doTemplate(`
+		type {{ .Type | mungeTypeNodebuilderIdent }} struct{}
+	`, w, gk)
+}
+
+func (gk generateNbKindInt) EmitNodebuilderConstructor(w io.Writer) {
+	doTemplate(`
+		func {{ .Type | mungeNodebuilderConstructorIdent }}() ipld.NodeBuilder {
+			return {{ .Type | mungeTypeNodebuilderIdent }}{}
+		}
+	`, w, gk)
+}
+
+func (gk generateNbKindInt) EmitNodebuilderMethodCreateInt(w io.Writer) {
+	doTemplate(`
+		func (nb {{ .Type | mungeTypeNodebuilderIdent }}) CreateInt(v int) (ipld.Node, error) {
+			return {{ .Type | mungeTypeNodeIdent }}{v}, nil
+		}
+	`, w, gk)
+}

--- a/schema/gen/go/genKindLink.go
+++ b/schema/gen/go/genKindLink.go
@@ -1,0 +1,70 @@
+package gengo
+
+import (
+	"io"
+
+	"github.com/ipld/go-ipld-prime/schema"
+)
+
+func NewGeneratorForKindLink(t schema.Type) typedNodeGenerator {
+	return generateKindLink{
+		t.(schema.TypeLink),
+		generateKindedRejections_Link{
+			mungeTypeNodeIdent(t),
+			string(t.Name()),
+		},
+	}
+}
+
+type generateKindLink struct {
+	Type schema.TypeLink
+	generateKindedRejections_Link
+	// FUTURE: probably some adjunct config data should come with here as well.
+	// FUTURE: perhaps both a global one (e.g. output package name) and a per-type one.
+}
+
+func (gk generateKindLink) EmitNodeType(w io.Writer) {
+	doTemplate(`
+		var _ ipld.Node = {{ .Type | mungeTypeNodeIdent }}{}
+		var _ typed.Node = {{ .Type | mungeTypeNodeIdent }}{}
+
+		type {{ .Type | mungeTypeNodeIdent }} struct{ x ipld.Link }
+
+	`, w, gk)
+}
+
+func (gk generateKindLink) EmitTypedNodeMethodType(w io.Writer) {
+	doTemplate(`
+		func ({{ .Type | mungeTypeNodeIdent }}) Type() schema.Type {
+			return nil /*TODO:typelit*/
+		}
+	`, w, gk)
+}
+
+func (gk generateKindLink) EmitNodeMethodReprKind(w io.Writer) {
+	doTemplate(`
+		func ({{ .Type | mungeTypeNodeIdent }}) ReprKind() ipld.ReprKind {
+			return ipld.ReprKind_Link
+		}
+	`, w, gk)
+}
+
+func (gk generateKindLink) EmitNodeMethodAsLink(w io.Writer) {
+	doTemplate(`
+		func (x {{ .Type | mungeTypeNodeIdent }}) AsLink() (ipld.Link, error) {
+			return x.x, nil
+		}
+	`, w, gk)
+}
+
+func (gk generateKindLink) EmitTypedNodeMethodRepresentation(w io.Writer) {
+	doTemplate(`
+		func ({{ .Type | mungeTypeNodeIdent }}) Representation() ipld.Node {
+			panic("TODO representation")
+		}
+	`, w, gk)
+}
+
+func (gk generateKindLink) GetRepresentationNodeGen() nodeGenerator {
+	return nil // TODO of course
+}

--- a/schema/gen/go/genKindLinkBuilder.go
+++ b/schema/gen/go/genKindLinkBuilder.go
@@ -1,0 +1,52 @@
+package gengo
+
+import (
+	"io"
+
+	"github.com/ipld/go-ipld-prime/schema"
+)
+
+func (gk generateKindLink) GetNodeBuilderGen() nodebuilderGenerator {
+	return generateNbKindLink{
+		gk.Type,
+		genKindedNbRejections_Link{
+			mungeTypeNodebuilderIdent(gk.Type),
+			string(gk.Type.Name()) + ".Builder",
+		},
+	}
+}
+
+func (gk generateKindLink) EmitNodeMethodNodeBuilder(w io.Writer) {
+	doTemplate(`
+		func ({{ .Type | mungeTypeNodeIdent }}) NodeBuilder() ipld.NodeBuilder {
+			return {{ .Type | mungeTypeNodebuilderIdent }}{}
+		}
+	`, w, gk)
+}
+
+type generateNbKindLink struct {
+	Type schema.TypeLink
+	genKindedNbRejections_Link
+}
+
+func (gk generateNbKindLink) EmitNodebuilderType(w io.Writer) {
+	doTemplate(`
+		type {{ .Type | mungeTypeNodebuilderIdent }} struct{}
+	`, w, gk)
+}
+
+func (gk generateNbKindLink) EmitNodebuilderConstructor(w io.Writer) {
+	doTemplate(`
+		func {{ .Type | mungeNodebuilderConstructorIdent }}() ipld.NodeBuilder {
+			return {{ .Type | mungeTypeNodebuilderIdent }}{}
+		}
+	`, w, gk)
+}
+
+func (gk generateNbKindLink) EmitNodebuilderMethodCreateLink(w io.Writer) {
+	doTemplate(`
+		func (nb {{ .Type | mungeTypeNodebuilderIdent }}) CreateLink(v ipld.Link) (ipld.Node, error) {
+			return {{ .Type | mungeTypeNodeIdent }}{v}, nil
+		}
+	`, w, gk)
+}

--- a/schema/gen/go/genKindList.go
+++ b/schema/gen/go/genKindList.go
@@ -1,0 +1,139 @@
+package gengo
+
+import (
+	"io"
+
+	"github.com/ipld/go-ipld-prime/schema"
+)
+
+func NewGeneratorForKindList(t schema.Type) typedNodeGenerator {
+	return generateKindList{
+		t.(schema.TypeList),
+		generateKindedRejections_List{
+			mungeTypeNodeIdent(t),
+			string(t.Name()),
+		},
+	}
+}
+
+type generateKindList struct {
+	Type schema.TypeList
+	generateKindedRejections_List
+	// FUTURE: probably some adjunct config data should come with here as well.
+	// FUTURE: perhaps both a global one (e.g. output package name) and a per-type one.
+}
+
+func (gk generateKindList) EmitNodeType(w io.Writer) {
+	// Observe that we get a '*' if a field is *either* nullable *or* optional;
+	//  and we get an extra bool for the second cardinality +1'er if both are true.
+	doTemplate(`
+		var _ ipld.Node = {{ .Type | mungeTypeNodeIdent }}{}
+		var _ typed.Node = {{ .Type | mungeTypeNodeIdent }}{}
+
+		type {{ .Type | mungeTypeNodeIdent }} struct{
+			x []{{if .Type.ValueIsNullable}}*{{end}}{{.Type.ValueType | mungeTypeNodeIdent}}
+		}
+	`, w, gk)
+}
+
+func (gk generateKindList) EmitTypedNodeMethodType(w io.Writer) {
+	doTemplate(`
+		func ({{ .Type | mungeTypeNodeIdent }}) Type() schema.Type {
+			return nil /*TODO:typelit*/
+		}
+	`, w, gk)
+}
+
+func (gk generateKindList) EmitNodeMethodReprKind(w io.Writer) {
+	doTemplate(`
+		func ({{ .Type | mungeTypeNodeIdent }}) ReprKind() ipld.ReprKind {
+			return ipld.ReprKind_List
+		}
+	`, w, gk)
+}
+
+func (gk generateKindList) EmitNodeMethodLookupIndex(w io.Writer) {
+	doTemplate(`
+		func (x {{ .Type | mungeTypeNodeIdent }}) LookupIndex(index int) (ipld.Node, error) {
+			if index >= len(x.x) {
+				return nil, ipld.ErrNotExists{ipld.PathSegmentOfInt(index)}
+			}
+			{{- if .Type.ValueIsNullable }}
+			if x.x[index] == nil {
+				return ipld.Null, nil
+			}
+			return *x.x[index], nil
+			{{- else }}
+			return x.x[index], nil
+			{{- end }}
+		}	
+	`, w, gk)
+}
+
+func (gk generateKindList) EmitNodeMethodLookup(w io.Writer) {
+	doTemplate(`
+		func (x {{ .Type | mungeTypeNodeIdent }}) Lookup(key ipld.Node) (ipld.Node, error) {
+			ki, err := key.AsInt()
+			if err != nil {
+				return nil, ipld.ErrInvalidKey{"got " + key.ReprKind().String() + ", need Int"}
+			}
+			return x.LookupIndex(ki)
+		}
+	`, w, gk)
+}
+
+func (gk generateKindList) EmitNodeMethodListIterator(w io.Writer) {
+	doTemplate(`
+		func (x {{ .Type | mungeTypeNodeIdent }}) ListIterator() ipld.ListIterator {
+			return &{{ .Type | mungeTypeNodeItrIdent }}{&x, 0}
+		}
+
+		type {{ .Type | mungeTypeNodeItrIdent }} struct {
+			node *{{ .Type | mungeTypeNodeIdent }}
+			idx  int
+		}
+
+		func (itr *{{ .Type | mungeTypeNodeItrIdent }}) Next() (idx int, value ipld.Node, _ error)	{
+			if itr.idx >= len(itr.node.x) {
+				return 0, nil, ipld.ErrIteratorOverread{}
+			}
+			idx = itr.idx
+			{{- if .Type.ValueIsNullable }}
+			if itr.node.x[idx] == nil {
+				value = ipld.Null
+			} else {
+				value = *itr.node.x[idx]
+			}
+			{{- else }}
+			value = itr.node.x[idx]
+			{{- end }}
+			itr.idx++
+			return
+		}
+
+		func (itr *{{ .Type | mungeTypeNodeItrIdent }}) Done() bool {
+			return itr.idx >= len(itr.node.x)
+		}
+
+	`, w, gk)
+}
+
+func (gk generateKindList) EmitNodeMethodLength(w io.Writer) {
+	doTemplate(`
+		func (x {{ .Type | mungeTypeNodeIdent }}) Length() int {
+			return len(x.x)
+		}
+	`, w, gk)
+}
+
+func (gk generateKindList) EmitTypedNodeMethodRepresentation(w io.Writer) {
+	doTemplate(`
+		func (n {{ .Type | mungeTypeNodeIdent }}) Representation() ipld.Node {
+			panic("TODO representation")
+		}
+	`, w, gk)
+}
+
+func (gk generateKindList) GetRepresentationNodeGen() nodeGenerator {
+	return nil // TODO of course
+}

--- a/schema/gen/go/genKindListBuilder.go
+++ b/schema/gen/go/genKindListBuilder.go
@@ -1,0 +1,197 @@
+package gengo
+
+import (
+	"io"
+
+	"github.com/ipld/go-ipld-prime/schema"
+)
+
+func (gk generateKindList) GetNodeBuilderGen() nodebuilderGenerator {
+	return generateNbKindList{
+		gk.Type,
+		genKindedNbRejections_List{
+			mungeTypeNodebuilderIdent(gk.Type),
+			string(gk.Type.Name()) + ".Builder",
+		},
+	}
+}
+
+func (gk generateKindList) EmitNodeMethodNodeBuilder(w io.Writer) {
+	doTemplate(`
+		func ({{ .Type | mungeTypeNodeIdent }}) NodeBuilder() ipld.NodeBuilder {
+			return {{ .Type | mungeTypeNodebuilderIdent }}{}
+		}
+	`, w, gk)
+}
+
+type generateNbKindList struct {
+	Type schema.TypeList
+	genKindedNbRejections_List
+}
+
+func (gk generateNbKindList) EmitNodebuilderType(w io.Writer) {
+	doTemplate(`
+		type {{ .Type | mungeTypeNodebuilderIdent }} struct{}
+
+	`, w, gk)
+}
+
+func (gk generateNbKindList) EmitNodebuilderConstructor(w io.Writer) {
+	doTemplate(`
+		func {{ .Type | mungeNodebuilderConstructorIdent }}() ipld.NodeBuilder {
+			return {{ .Type | mungeTypeNodebuilderIdent }}{}
+		}
+	`, w, gk)
+}
+
+func (gk generateNbKindList) EmitNodebuilderMethodCreateList(w io.Writer) {
+	// Some interesting edge cases to note:
+	//  - This builder, being all about semantics and not at all about serialization,
+	//      is order-insensitive.
+	//  - We don't specially handle being given 'undef' as a value.
+	//      It just falls into the "need a typed.Node" error bucket.
+	//  - We only accept *codegenerated values* -- a typed.Node created
+	//      in the same schema universe *isn't accepted*.
+	//        REVIEW: We could try to accept those, but it might have perf/sloc costs,
+	//          and it's hard to imagine a user story that gets here.
+	//  - The has-been-set-if-required validation is fun; it only requires state
+	//     for non-optional fields, and that often gets a little hard to follow
+	//       because it gets wedged in with other logic tables around optionality.
+	// REVIEW: 'x, ok := v.({{ $field.Type.Name }})' might need some stars in it... sometimes.
+	// TODO : review the panic of `ErrNoSuchField` in `BuilderForValue` --
+	//  see the comments in the NodeBuilder interface for the open questions on this topic.
+	doTemplate(`
+		func (nb {{ .Type | mungeTypeNodebuilderIdent }}) CreateList() (ipld.ListBuilder, error) {
+			return &{{ .Type | mungeTypeNodeListBuilderIdent }}{v:&{{ .Type | mungeTypeNodeIdent }}{}}, nil
+		}
+
+		type {{ .Type | mungeTypeNodeListBuilderIdent }} struct{
+			v *{{ .Type | mungeTypeNodeIdent }}
+		}
+
+		func (lb *{{ .Type | mungeTypeNodeListBuilderIdent }}) growList(k int) {
+			oldLen := len(lb.v.x)
+			minLen := k + 1
+			if minLen > oldLen {
+				// Grow.
+				oldCap := cap(lb.v.x)
+				if minLen > oldCap {
+					// Out of cap; do whole new backing array allocation.
+					//  Growth maths are per stdlib's reflect.grow.
+					// First figure out how much growth to do.
+					newCap := oldCap
+					if newCap == 0 {
+						newCap = minLen
+					} else {
+						for minLen > newCap {
+							if minLen < 1024 {
+								newCap += newCap
+							} else {
+								newCap += newCap / 4
+							}
+						}
+					}
+					// Now alloc and copy over old.
+					newArr := make([]{{if .Type.ValueIsNullable}}*{{end}}{{.Type.ValueType | mungeTypeNodeIdent}}, minLen, newCap)
+					copy(newArr, lb.v.x)
+					lb.v.x = newArr
+				} else {
+					// Still have cap, just extend the slice.
+					lb.v.x = lb.v.x[0:minLen]
+				}
+			}
+		}
+
+		func (lb *{{ .Type | mungeTypeNodeListBuilderIdent }}) validate(v ipld.Node) error {
+			{{- if .Type.ValueIsNullable }}
+			if v.IsNull() {
+				return nil
+			}
+			{{- else}}
+			if v.IsNull() {
+				panic("type mismatch on struct field assignment: cannot assign null to non-nullable field") // FIXME need an error type for this
+			}
+			{{- end}}
+			tv, ok := v.(typed.Node)
+			if !ok {
+				panic("need typed.Node for insertion into struct") // FIXME need an error type for this
+			}
+			_, ok = v.({{ .Type.ValueType | mungeTypeNodeIdent }})
+			if !ok {
+				panic("value for type {{.Type.Name}} is type {{.Type.ValueType.Name}}; cannot assign "+tv.Type().Name()) // FIXME need an error type for this
+			}
+			return nil
+		}
+
+		func (lb *{{ .Type | mungeTypeNodeListBuilderIdent }}) unsafeSet(idx int, v ipld.Node) {
+			{{- if .Type.ValueIsNullable }}
+			if v.IsNull() {
+				lb.v.x[idx] = nil
+				return
+			}
+			{{- end}}
+			x := v.({{ .Type.ValueType | mungeTypeNodeIdent }})
+			{{- if .Type.ValueIsNullable }}
+			lb.v.x[idx] = &x
+			{{- else}}
+			lb.v.x[idx] = x
+			{{- end}}
+		}
+
+		func (lb *{{ .Type | mungeTypeNodeListBuilderIdent }}) AppendAll(vs []ipld.Node) error {
+			for _, v := range vs {
+				err := lb.validate(v)
+				if err != nil {
+					return err
+				}
+			}
+			off := len(lb.v.x)
+			new := off + len(vs)
+			lb.growList(new-1)
+			for _, v := range vs {
+				lb.unsafeSet(off, v)
+				off++
+			}
+			return nil
+		}
+
+		func (lb *{{ .Type | mungeTypeNodeListBuilderIdent }}) Append(v ipld.Node) error {
+			err := lb.validate(v)
+			if err != nil {
+				return err
+			}
+			off := len(lb.v.x)
+			lb.growList(off)
+			lb.unsafeSet(off, v)
+			return nil
+		}
+		func (lb *{{ .Type | mungeTypeNodeListBuilderIdent }}) Set(idx int, v ipld.Node) error {
+			err := lb.validate(v)
+			if err != nil {
+				return err
+			}
+			lb.growList(idx)
+			lb.unsafeSet(idx, v)
+			return nil
+		}
+
+		func (lb *{{ .Type | mungeTypeNodeListBuilderIdent }}) Build() (ipld.Node, error) {
+			v := lb.v
+			lb = nil
+			return v, nil
+		}
+
+		func (lb *{{ .Type | mungeTypeNodeListBuilderIdent }}) BuilderForValue(_ int) ipld.NodeBuilder {
+			return {{ .Type.ValueType | mungeNodebuilderConstructorIdent }}()
+		}
+
+	`, w, gk)
+}
+
+func (gk generateNbKindList) EmitNodebuilderMethodAmendList(w io.Writer) {
+	doTemplate(`
+		func (nb {{ .Type | mungeTypeNodebuilderIdent }}) AmendList() (ipld.ListBuilder, error) {
+			panic("TODO later")
+		}
+	`, w, gk)
+}

--- a/schema/gen/go/gen_test.go
+++ b/schema/gen/go/gen_test.go
@@ -101,6 +101,8 @@ func TestNuevo(t *testing.T) {
 	tInt := schema.SpawnInt("Int")
 	tBytes := schema.SpawnBytes("Bytes")
 	tLink := schema.SpawnLink("Link")
+	tIntList := schema.SpawnList("IntList", tInt, false)
+	tNullableIntList := schema.SpawnList("NullableIntList", tInt, true)
 
 	tStract := schema.SpawnStruct("Stract",
 		[]schema.StructField{schema.SpawnStructField(
@@ -135,6 +137,8 @@ func TestNuevo(t *testing.T) {
 			schema.SpawnStructField("inty", tInt, false, false),
 			schema.SpawnStructField("bytey", tBytes, false, false),
 			schema.SpawnStructField("linky", tLink, false, false),
+			schema.SpawnStructField("intListy", tIntList, false, false),
+			schema.SpawnStructField("nullableIntListy", tNullableIntList, false, false),
 		},
 		schema.StructRepresentation_Map{},
 	)
@@ -153,6 +157,14 @@ func TestNuevo(t *testing.T) {
 	f = openOrPanic("_test/tLink.go")
 	emitFileHeader(f)
 	emitType(NewGeneratorForKindLink(tLink), f)
+
+	f = openOrPanic("_test/tIntList.go")
+	emitFileHeader(f)
+	emitType(NewGeneratorForKindList(tIntList), f)
+
+	f = openOrPanic("_test/tNullableIntList.go")
+	emitFileHeader(f)
+	emitType(NewGeneratorForKindList(tNullableIntList), f)
 
 	f = openOrPanic("_test/Stract.go")
 	emitFileHeader(f)

--- a/schema/gen/go/gen_test.go
+++ b/schema/gen/go/gen_test.go
@@ -98,6 +98,10 @@ func TestNuevo(t *testing.T) {
 	emitMinima(f)
 
 	tString := schema.SpawnString("String")
+	tInt := schema.SpawnInt("Int")
+	tBytes := schema.SpawnBytes("Bytes")
+	tLink := schema.SpawnLink("Link")
+
 	tStract := schema.SpawnStruct("Stract",
 		[]schema.StructField{schema.SpawnStructField(
 			"aField", tString, false, false,
@@ -126,9 +130,29 @@ func TestNuevo(t *testing.T) {
 		schema.StructRepresentation_Map{},
 	)
 
+	tKindsStroct := schema.SpawnStruct("KindsStroct",
+		[]schema.StructField{
+			schema.SpawnStructField("inty", tInt, false, false),
+			schema.SpawnStructField("bytey", tBytes, false, false),
+			schema.SpawnStructField("linky", tLink, false, false),
+		},
+		schema.StructRepresentation_Map{},
+	)
 	f = openOrPanic("_test/tString.go")
 	emitFileHeader(f)
 	emitType(NewGeneratorForKindString(tString), f)
+
+	f = openOrPanic("_test/tInt.go")
+	emitFileHeader(f)
+	emitType(NewGeneratorForKindInt(tInt), f)
+
+	f = openOrPanic("_test/tBytes.go")
+	emitFileHeader(f)
+	emitType(NewGeneratorForKindBytes(tBytes), f)
+
+	f = openOrPanic("_test/tLink.go")
+	emitFileHeader(f)
+	emitType(NewGeneratorForKindLink(tLink), f)
 
 	f = openOrPanic("_test/Stract.go")
 	emitFileHeader(f)
@@ -145,4 +169,8 @@ func TestNuevo(t *testing.T) {
 	f = openOrPanic("_test/Stroct.go")
 	emitFileHeader(f)
 	emitType(NewGeneratorForKindStruct(tStroct), f)
+
+	f = openOrPanic("_test/KindsStroct.go")
+	emitFileHeader(f)
+	emitType(NewGeneratorForKindStruct(tKindsStroct), f)
 }

--- a/schema/tmpBuilders.go
+++ b/schema/tmpBuilders.go
@@ -13,6 +13,18 @@ func SpawnString(name TypeName) TypeString {
 	return TypeString{anyType{name, nil}}
 }
 
+func SpawnInt(name TypeName) TypeInt {
+	return TypeInt{anyType{name, nil}}
+}
+
+func SpawnBytes(name TypeName) TypeBytes {
+	return TypeBytes{anyType{name, nil}}
+}
+
+func SpawnLink(name TypeName) TypeLink {
+	return TypeLink{anyType{name, nil}}
+}
+
 func SpawnStruct(name TypeName, fields []StructField, repr StructRepresentation) TypeStruct {
 	fieldsMap := make(map[string]StructField, len(fields))
 	for _, field := range fields {

--- a/schema/tmpBuilders.go
+++ b/schema/tmpBuilders.go
@@ -25,6 +25,10 @@ func SpawnLink(name TypeName) TypeLink {
 	return TypeLink{anyType{name, nil}}
 }
 
+func SpawnList(name TypeName, typ Type, nullable bool) TypeList {
+	return TypeList{anyType{name, nil}, false, typ, nullable}
+}
+
 func SpawnStruct(name TypeName, fields []StructField, repr StructRepresentation) TypeStruct {
 	fieldsMap := make(map[string]StructField, len(fields))
 	for _, field := range fields {


### PR DESCRIPTION
# Goals

Totally selfish, I want to try to code gen protobuf nodes. I needed Link, Bytes, and Int to make it work.

# For Discussion

You do not need merge this. At the same time, it seemed like a lot of code busy work that might save you time. I get the sense you are still iterating on the core abstractions and focusing on the hardest part, but if this saves you time once you get there, here you go.