### PR TITLE
feat(schema/gen): make emit methods public

### DIFF
--- a/schema/gen/go/HACKME.md
+++ b/schema/gen/go/HACKME.md
@@ -31,6 +31,9 @@ It contains substantial amounts of hardcoded testcases.
 Run the tests in the `./_test` subpackage explicitly to make sure the
 generated code passes its own interface contracts and tests.
 
+If you want to try hacking together your own generated types, the easiest
+way is to use the functions used by gen_test.go -- `EmitFileHeader`, `EmitMinima`, and `EmitEntireType`
+
 The eventual plan is be able to drive this whole apparatus around via a CLI
 which consumes IPLD Schema files.
 Implementing this can come after more of the core is done.

--- a/schema/gen/go/gen.go
+++ b/schema/gen/go/gen.go
@@ -86,11 +86,95 @@ type nodebuilderGenerator interface {
 	EmitNodebuilderMethodCreateLink(io.Writer)
 }
 
-func emitFileHeader(w io.Writer) {
-	fmt.Fprintf(w, "package whee\n\n")
+// EmitFileHeader emits a baseline package header that will
+// allow a file with a generated type to compile
+func EmitFileHeader(packageName string, w io.Writer) {
+	fmt.Fprintf(w, "package %s\n\n", packageName)
 	fmt.Fprintf(w, "import (\n")
 	fmt.Fprintf(w, "\tipld \"github.com/ipld/go-ipld-prime\"\n")
 	fmt.Fprintf(w, "\t\"github.com/ipld/go-ipld-prime/impl/typed\"\n")
 	fmt.Fprintf(w, "\t\"github.com/ipld/go-ipld-prime/schema\"\n")
 	fmt.Fprintf(w, ")\n\n")
+}
+
+// EmitEntireType outputs every possible type of code generation for a
+// typedNodeGenerator
+func EmitEntireType(tg typedNodeGenerator, w io.Writer) {
+	tg.EmitNativeType(w)
+	tg.EmitNativeAccessors(w)
+	tg.EmitNativeBuilder(w)
+	tg.EmitNativeMaybe(w)
+	tg.EmitNodeType(w)
+	tg.EmitTypedNodeMethodType(w)
+	tg.EmitNodeMethodReprKind(w)
+	tg.EmitNodeMethodLookupString(w)
+	tg.EmitNodeMethodLookup(w)
+	tg.EmitNodeMethodLookupIndex(w)
+	tg.EmitNodeMethodLookupSegment(w)
+	tg.EmitNodeMethodMapIterator(w)
+	tg.EmitNodeMethodListIterator(w)
+	tg.EmitNodeMethodLength(w)
+	tg.EmitNodeMethodIsUndefined(w)
+	tg.EmitNodeMethodIsNull(w)
+	tg.EmitNodeMethodAsBool(w)
+	tg.EmitNodeMethodAsInt(w)
+	tg.EmitNodeMethodAsFloat(w)
+	tg.EmitNodeMethodAsString(w)
+	tg.EmitNodeMethodAsBytes(w)
+	tg.EmitNodeMethodAsLink(w)
+
+	tg.EmitNodeMethodNodeBuilder(w)
+	tnbg := tg.GetNodeBuilderGen()
+	tnbg.EmitNodebuilderType(w)
+	tnbg.EmitNodebuilderConstructor(w)
+	tnbg.EmitNodebuilderMethodCreateMap(w)
+	tnbg.EmitNodebuilderMethodAmendMap(w)
+	tnbg.EmitNodebuilderMethodCreateList(w)
+	tnbg.EmitNodebuilderMethodAmendList(w)
+	tnbg.EmitNodebuilderMethodCreateNull(w)
+	tnbg.EmitNodebuilderMethodCreateBool(w)
+	tnbg.EmitNodebuilderMethodCreateInt(w)
+	tnbg.EmitNodebuilderMethodCreateFloat(w)
+	tnbg.EmitNodebuilderMethodCreateString(w)
+	tnbg.EmitNodebuilderMethodCreateBytes(w)
+	tnbg.EmitNodebuilderMethodCreateLink(w)
+
+	tg.EmitTypedNodeMethodRepresentation(w)
+	rng := tg.GetRepresentationNodeGen()
+	if rng == nil { // FIXME: hack to save me from stubbing tons right now, remove when done
+		return
+	}
+	rng.EmitNodeType(w)
+	rng.EmitNodeMethodReprKind(w)
+	rng.EmitNodeMethodLookupString(w)
+	rng.EmitNodeMethodLookup(w)
+	rng.EmitNodeMethodLookupIndex(w)
+	rng.EmitNodeMethodLookupSegment(w)
+	rng.EmitNodeMethodMapIterator(w)
+	rng.EmitNodeMethodListIterator(w)
+	rng.EmitNodeMethodLength(w)
+	rng.EmitNodeMethodIsUndefined(w)
+	rng.EmitNodeMethodIsNull(w)
+	rng.EmitNodeMethodAsBool(w)
+	rng.EmitNodeMethodAsInt(w)
+	rng.EmitNodeMethodAsFloat(w)
+	rng.EmitNodeMethodAsString(w)
+	rng.EmitNodeMethodAsBytes(w)
+	rng.EmitNodeMethodAsLink(w)
+
+	rng.EmitNodeMethodNodeBuilder(w)
+	rnbg := rng.GetNodeBuilderGen()
+	rnbg.EmitNodebuilderType(w)
+	rnbg.EmitNodebuilderConstructor(w)
+	rnbg.EmitNodebuilderMethodCreateMap(w)
+	rnbg.EmitNodebuilderMethodAmendMap(w)
+	rnbg.EmitNodebuilderMethodCreateList(w)
+	rnbg.EmitNodebuilderMethodAmendList(w)
+	rnbg.EmitNodebuilderMethodCreateNull(w)
+	rnbg.EmitNodebuilderMethodCreateBool(w)
+	rnbg.EmitNodebuilderMethodCreateInt(w)
+	rnbg.EmitNodebuilderMethodCreateFloat(w)
+	rnbg.EmitNodebuilderMethodCreateString(w)
+	rnbg.EmitNodebuilderMethodCreateBytes(w)
+	rnbg.EmitNodebuilderMethodCreateLink(w)
 }

--- a/schema/gen/go/genMinima.go
+++ b/schema/gen/go/genMinima.go
@@ -1,14 +1,16 @@
 package gengo
 
 import (
+	"fmt"
 	"io"
 )
 
-func emitMinima(f io.Writer) {
+// EmitMinima emits common code shared by all types --
+// only needs to be output once per module
+func EmitMinima(packageName string, f io.Writer) {
 	// Write header and imports.
-	f.Write([]byte(`package whee
-
-import (
+	fmt.Fprintf(f, "package %s\n\n", packageName)
+	f.Write([]byte(`import (
 	ipld "github.com/ipld/go-ipld-prime"
 )
 `))

--- a/schema/gen/go/gen_test.go
+++ b/schema/gen/go/gen_test.go
@@ -1,7 +1,6 @@
 package gengo
 
 import (
-	"io"
 	"os"
 	"testing"
 
@@ -18,88 +17,8 @@ func TestNuevo(t *testing.T) {
 		return y
 	}
 
-	emitType := func(tg typedNodeGenerator, w io.Writer) {
-		tg.EmitNativeType(w)
-		tg.EmitNativeAccessors(w)
-		tg.EmitNativeBuilder(w)
-		tg.EmitNativeMaybe(w)
-		tg.EmitNodeType(w)
-		tg.EmitTypedNodeMethodType(w)
-		tg.EmitNodeMethodReprKind(w)
-		tg.EmitNodeMethodLookupString(w)
-		tg.EmitNodeMethodLookup(w)
-		tg.EmitNodeMethodLookupIndex(w)
-		tg.EmitNodeMethodLookupSegment(w)
-		tg.EmitNodeMethodMapIterator(w)
-		tg.EmitNodeMethodListIterator(w)
-		tg.EmitNodeMethodLength(w)
-		tg.EmitNodeMethodIsUndefined(w)
-		tg.EmitNodeMethodIsNull(w)
-		tg.EmitNodeMethodAsBool(w)
-		tg.EmitNodeMethodAsInt(w)
-		tg.EmitNodeMethodAsFloat(w)
-		tg.EmitNodeMethodAsString(w)
-		tg.EmitNodeMethodAsBytes(w)
-		tg.EmitNodeMethodAsLink(w)
-
-		tg.EmitNodeMethodNodeBuilder(w)
-		tnbg := tg.GetNodeBuilderGen()
-		tnbg.EmitNodebuilderType(w)
-		tnbg.EmitNodebuilderConstructor(w)
-		tnbg.EmitNodebuilderMethodCreateMap(w)
-		tnbg.EmitNodebuilderMethodAmendMap(w)
-		tnbg.EmitNodebuilderMethodCreateList(w)
-		tnbg.EmitNodebuilderMethodAmendList(w)
-		tnbg.EmitNodebuilderMethodCreateNull(w)
-		tnbg.EmitNodebuilderMethodCreateBool(w)
-		tnbg.EmitNodebuilderMethodCreateInt(w)
-		tnbg.EmitNodebuilderMethodCreateFloat(w)
-		tnbg.EmitNodebuilderMethodCreateString(w)
-		tnbg.EmitNodebuilderMethodCreateBytes(w)
-		tnbg.EmitNodebuilderMethodCreateLink(w)
-
-		tg.EmitTypedNodeMethodRepresentation(w)
-		rng := tg.GetRepresentationNodeGen()
-		if rng == nil { // FIXME: hack to save me from stubbing tons right now, remove when done
-			return
-		}
-		rng.EmitNodeType(w)
-		rng.EmitNodeMethodReprKind(w)
-		rng.EmitNodeMethodLookupString(w)
-		rng.EmitNodeMethodLookup(w)
-		rng.EmitNodeMethodLookupIndex(w)
-		rng.EmitNodeMethodLookupSegment(w)
-		rng.EmitNodeMethodMapIterator(w)
-		rng.EmitNodeMethodListIterator(w)
-		rng.EmitNodeMethodLength(w)
-		rng.EmitNodeMethodIsUndefined(w)
-		rng.EmitNodeMethodIsNull(w)
-		rng.EmitNodeMethodAsBool(w)
-		rng.EmitNodeMethodAsInt(w)
-		rng.EmitNodeMethodAsFloat(w)
-		rng.EmitNodeMethodAsString(w)
-		rng.EmitNodeMethodAsBytes(w)
-		rng.EmitNodeMethodAsLink(w)
-
-		rng.EmitNodeMethodNodeBuilder(w)
-		rnbg := rng.GetNodeBuilderGen()
-		rnbg.EmitNodebuilderType(w)
-		rnbg.EmitNodebuilderConstructor(w)
-		rnbg.EmitNodebuilderMethodCreateMap(w)
-		rnbg.EmitNodebuilderMethodAmendMap(w)
-		rnbg.EmitNodebuilderMethodCreateList(w)
-		rnbg.EmitNodebuilderMethodAmendList(w)
-		rnbg.EmitNodebuilderMethodCreateNull(w)
-		rnbg.EmitNodebuilderMethodCreateBool(w)
-		rnbg.EmitNodebuilderMethodCreateInt(w)
-		rnbg.EmitNodebuilderMethodCreateFloat(w)
-		rnbg.EmitNodebuilderMethodCreateString(w)
-		rnbg.EmitNodebuilderMethodCreateBytes(w)
-		rnbg.EmitNodebuilderMethodCreateLink(w)
-	}
-
 	f := openOrPanic("_test/minima.go")
-	emitMinima(f)
+	EmitMinima("whee", f)
 
 	tString := schema.SpawnString("String")
 	tInt := schema.SpawnInt("Int")
@@ -147,46 +66,46 @@ func TestNuevo(t *testing.T) {
 		schema.StructRepresentation_Map{},
 	)
 	f = openOrPanic("_test/tString.go")
-	emitFileHeader(f)
-	emitType(NewGeneratorForKindString(tString), f)
+	EmitFileHeader("whee", f)
+	EmitEntireType(NewGeneratorForKindString(tString), f)
 
 	f = openOrPanic("_test/tInt.go")
-	emitFileHeader(f)
-	emitType(NewGeneratorForKindInt(tInt), f)
+	EmitFileHeader("whee", f)
+	EmitEntireType(NewGeneratorForKindInt(tInt), f)
 
 	f = openOrPanic("_test/tBytes.go")
-	emitFileHeader(f)
-	emitType(NewGeneratorForKindBytes(tBytes), f)
+	EmitFileHeader("whee", f)
+	EmitEntireType(NewGeneratorForKindBytes(tBytes), f)
 
 	f = openOrPanic("_test/tLink.go")
-	emitFileHeader(f)
-	emitType(NewGeneratorForKindLink(tLink), f)
+	EmitFileHeader("whee", f)
+	EmitEntireType(NewGeneratorForKindLink(tLink), f)
 
 	f = openOrPanic("_test/tIntList.go")
-	emitFileHeader(f)
-	emitType(NewGeneratorForKindList(tIntList), f)
+	EmitFileHeader("whee", f)
+	EmitEntireType(NewGeneratorForKindList(tIntList), f)
 
 	f = openOrPanic("_test/tNullableIntList.go")
-	emitFileHeader(f)
-	emitType(NewGeneratorForKindList(tNullableIntList), f)
+	EmitFileHeader("whee", f)
+	EmitEntireType(NewGeneratorForKindList(tNullableIntList), f)
 
 	f = openOrPanic("_test/Stract.go")
-	emitFileHeader(f)
-	emitType(NewGeneratorForKindStruct(tStract), f)
+	EmitFileHeader("whee", f)
+	EmitEntireType(NewGeneratorForKindStruct(tStract), f)
 
 	f = openOrPanic("_test/Stract2.go")
-	emitFileHeader(f)
-	emitType(NewGeneratorForKindStruct(tStract2), f)
+	EmitFileHeader("whee", f)
+	EmitEntireType(NewGeneratorForKindStruct(tStract2), f)
 
 	f = openOrPanic("_test/Stract3.go")
-	emitFileHeader(f)
-	emitType(NewGeneratorForKindStruct(tStract3), f)
+	EmitFileHeader("whee", f)
+	EmitEntireType(NewGeneratorForKindStruct(tStract3), f)
 
 	f = openOrPanic("_test/Stroct.go")
-	emitFileHeader(f)
-	emitType(NewGeneratorForKindStruct(tStroct), f)
+	EmitFileHeader("whee", f)
+	EmitEntireType(NewGeneratorForKindStruct(tStroct), f)
 
 	f = openOrPanic("_test/KindsStroct.go")
-	emitFileHeader(f)
-	emitType(NewGeneratorForKindStruct(tKindsStroct), f)
+	EmitFileHeader("whee", f)
+	EmitEntireType(NewGeneratorForKindStruct(tKindsStroct), f)
 }


### PR DESCRIPTION
# Goals

I'm using some early code gen in https://github.com/ipld/go-ipld-prime-proto (DagPB for go-ipld-prime!).

Making these methods public seemed like the least intrusive way to allow a preliminary method for generating code outside this module.  I'm not asking for stability on these APIs -- just a commit in master, that go-ipld-prime-proto can be built on till things stabilize (and then it would be updated obviously)