### PR TITLE
fix(schema/gen): return value not reference

### DIFF
--- a/schema/gen/go/genKindListNode.go
+++ b/schema/gen/go/genKindListNode.go
@@ -278,7 +278,7 @@ func (gk generateNbKindList) EmitNodebuilderMethodCreateList(w io.Writer) {
 		}
 
 		func (lb *{{ .Type | mungeTypeNodeListBuilderIdent }}) Build() (ipld.Node, error) {
-			v := lb.v
+			v := *lb.v
 			lb = nil
 			return v, nil
 		}

--- a/schema/gen/go/genKindStructNode.go
+++ b/schema/gen/go/genKindStructNode.go
@@ -272,7 +272,7 @@ func (gk generateNbKindStruct) EmitNodebuilderMethodCreateMap(w io.Writer) {
 			}
 			{{- end}}
 			{{- end}}
-			v := mb.v
+			v := *mb.v
 			mb = nil
 			return v, nil
 		}


### PR DESCRIPTION
Map/List should return an actual node type, not a pointer to a node. Otherwise, breaks when nested
in other map/list type.

We use a pointer to a node when we're building nodes, for maps (so we can mod it easily I assume). However, when we actually build it, we should dereference it -- because that's the type anyone using the node expects-- and in fact things will error if you build a map inside a map.