### PR TITLE
Path clarifications

### DIFF
--- a/path.go
+++ b/path.go
@@ -97,6 +97,10 @@ func NewPathNocopy(segments []PathSegment) Path {
 // in particular, note that ".." does not mean "go up", nor does "." mean "stay here" --
 // correspondingly, there isn't anything to "clean" in the same sense as
 // 'filepath.Clean' from the standard library filesystem path packages would.
+//
+// If the provided string contains unprintable characters, or non-UTF-8
+// or non-NFC-canonicalized bytes, no remark will be made about this,
+// and those bytes will remain part of the PathSegments in the resulting Path.
 func ParsePath(pth string) Path {
 	// FUTURE: we should probably have some escaping mechanism which makes
 	//  it possible to encode a slash in a segment.  Specification needed.
@@ -119,6 +123,10 @@ func ParsePath(pth string) Path {
 // empty segments or with segments containing "/") can be encoded unambiguously.
 // For Path values containing these problematic segments, ParsePath applied
 // to the string returned from this function may return a nonequal Path value.
+//
+// No escaping for unprintable characters is provided.
+// No guarantee that the resulting string is UTF-8 nor NFC canonicalized
+// is provided unless all the constituent PathSegment had those properties.
 func (p Path) String() string {
 	l := len(p.segments)
 	if l == 0 {

--- a/path.go
+++ b/path.go
@@ -43,7 +43,7 @@ import (
 // in serialized data in the wild where an empty string is used as the key:
 // it is important we be able to correctly describe and address this!)
 //
-// A string of "/" is a valid PathSegment.
+// A string containing "/" (or even being simply "/"!) is a valid PathSegment.
 // (As with empty strings, this is unfortunate (in particular, because it
 // very much doesn't match up well with expectations popularized by UNIX-like
 // filesystems); but, as with empty strings, maps which contain such a key

--- a/path.go
+++ b/path.go
@@ -49,6 +49,12 @@ import (
 // filesystems); but, as with empty strings, maps which contain such a key
 // certainly exist, and it is important that we be able to regard them!)
 //
+// A string starting, ending, or otherwise containing the NUL (\x00) byte
+// is also a valid PathSegment.  This follows from the rule of "a string is
+// regarded as its constituent eight-bit bytes": an all-zero byte is not exceptional.
+// In golang, this doesn't pose particular difficulty, but note this would be
+// of marked concern for languages which have "C-style nul-terminated strings".
+//
 // For an IPLD Path to be represented as a string, an encoding system
 // including escaping is necessary.  At present, there is not a single
 // canonical specification for such an escaping; we expect to decide one

--- a/pathSegment.go
+++ b/pathSegment.go
@@ -51,9 +51,10 @@ type PathSegment struct {
 		we're using the first tactic.
 
 		(We also currently get away with having no extra discriminator bit
-		because empty string is not considered a valid segment,
+		because we use a signed int for indexes, and negative values aren't valid there,
 		and thus we can use it as a sentinel value.
-		This may change if the IPLD Path spec comes to other conclusions about this.)
+		(Fun note: Empty strings were originally used for this sentinel,
+		but it turns out empty strings are valid PathSegment themselves, so!))
 	*/
 
 	s string
@@ -65,13 +66,13 @@ type PathSegment struct {
 // (Note: there is currently no escaping specified for PathSegments,
 // so this is currently functionally equivalent to PathSegmentOfString.)
 func ParsePathSegment(s string) PathSegment {
-	return PathSegment{s: s}
+	return PathSegment{s: s, i: -1}
 }
 
 // PathSegmentOfString boxes a string into a PathSegment.
 // It does not attempt to parse any escaping; use ParsePathSegment for that.
 func PathSegmentOfString(s string) PathSegment {
-	return PathSegment{s: s}
+	return PathSegment{s: s, i: -1}
 }
 
 // PathSegmentOfString boxes an int into a PathSegment.
@@ -83,7 +84,7 @@ func PathSegmentOfInt(i int) PathSegment {
 // but this is considered an implementation detail that's non-semantic.
 // If it returns false, it implicitly means "containsInt", as these are the only options.
 func (ps PathSegment) containsString() bool {
-	return ps.s != ""
+	return ps.i < 0
 }
 
 // String returns the PathSegment as a string.

--- a/pathSegment.go
+++ b/pathSegment.go
@@ -15,10 +15,12 @@ import (
 // Internally, PathSegment will store either a string or an integer,
 // depending on how it was constructed,
 // and will automatically convert to the other on request.
-// (This means if two pieces of code communicate using PathSegment, one producing ints and the other expecting ints, they will work together efficiently.)
+// (This means if two pieces of code communicate using PathSegment,
+// one producing ints and the other expecting ints,
+// then they will work together efficiently.)
 // PathSegment in a Path produced by ParsePath generally have all strings internally,
-// because there is distinction possible when parsing a Path string
-// (and attempting to pre-parse all strings into ints "in case" would waste time in almost all cases).
+// because there is no distinction possible when parsing a Path string
+// (and attempting to pre-parse all strings into ints "just in case" would waste time in almost all cases).
 type PathSegment struct {
 	/*
 		A quick implementation note about the Go compiler and "union" semantics:

--- a/pathSegment.go
+++ b/pathSegment.go
@@ -6,6 +6,12 @@ import (
 
 // PathSegment can describe either a key in a map, or an index in a list.
 //
+// Create a PathSegment via either ParsePathSegment, PathSegmentOfString,
+// or PathSegmentOfInt; or, via one of the constructors of Path,
+// which will implicitly create PathSegment internally.
+// Using PathSegment's natural zero value directly is discouraged
+// (it will act like ParsePathSegment("0"), which likely not what you'd expect).
+//
 // Path segments are "stringly typed" -- they may be interpreted as either strings or ints depending on context.
 // A path segment of "123" will be used as a string when traversing a node of map kind;
 // and it will be converted to an integer when traversing a node of list kind.

--- a/pathSegment.go
+++ b/pathSegment.go
@@ -62,13 +62,13 @@ func ParsePathSegment(s string) PathSegment {
 	return PathSegment{s: s}
 }
 
-// PathSegmentOfString boxes a string into a PathSegement.
+// PathSegmentOfString boxes a string into a PathSegment.
 // It does not attempt to parse any escaping; use ParsePathSegment for that.
 func PathSegmentOfString(s string) PathSegment {
 	return PathSegment{s: s}
 }
 
-// PathSegmentOfString boxes an int into a PathSegement.
+// PathSegmentOfString boxes an int into a PathSegment.
 func PathSegmentOfInt(i int) PathSegment {
 	return PathSegment{i: i}
 }

--- a/path_test.go
+++ b/path_test.go
@@ -26,3 +26,10 @@ func TestParsePath(t *testing.T) {
 		Wish(t, ParsePath(`0/\//2`).segments, ShouldEqual, []PathSegment{{s: "0"}, {s: `\`}, {s: "2"}})
 	})
 }
+
+func TestPathSegmentZeroValue(t *testing.T) {
+	Wish(t, PathSegment{}.String(), ShouldEqual, "0")
+	i, err := PathSegment{}.Index()
+	Wish(t, err, ShouldEqual, nil)
+	Wish(t, i, ShouldEqual, 0)
+}

--- a/path_test.go
+++ b/path_test.go
@@ -8,22 +8,22 @@ import (
 
 func TestParsePath(t *testing.T) {
 	t.Run("parsing one segment", func(t *testing.T) {
-		Wish(t, ParsePath("0").segments, ShouldEqual, []PathSegment{{s: "0"}})
+		Wish(t, ParsePath("0").segments, ShouldEqual, []PathSegment{{s: "0", i: -1}})
 	})
 	t.Run("parsing three segments", func(t *testing.T) {
-		Wish(t, ParsePath("0/foo/2").segments, ShouldEqual, []PathSegment{{s: "0"}, {s: "foo"}, {s: "2"}})
+		Wish(t, ParsePath("0/foo/2").segments, ShouldEqual, []PathSegment{{s: "0", i: -1}, {s: "foo", i: -1}, {s: "2", i: -1}})
 	})
 	t.Run("eliding leading slashes", func(t *testing.T) {
-		Wish(t, ParsePath("/0/2").segments, ShouldEqual, []PathSegment{{s: "0"}, {s: "2"}})
+		Wish(t, ParsePath("/0/2").segments, ShouldEqual, []PathSegment{{s: "0", i: -1}, {s: "2", i: -1}})
 	})
 	t.Run("eliding trailing", func(t *testing.T) {
-		Wish(t, ParsePath("0/2/").segments, ShouldEqual, []PathSegment{{s: "0"}, {s: "2"}})
+		Wish(t, ParsePath("0/2/").segments, ShouldEqual, []PathSegment{{s: "0", i: -1}, {s: "2", i: -1}})
 	})
 	t.Run("eliding empty segments", func(t *testing.T) { // NOTE: a spec for string encoding might cause this to change in the future!
-		Wish(t, ParsePath("0//2").segments, ShouldEqual, []PathSegment{{s: "0"}, {s: "2"}})
+		Wish(t, ParsePath("0//2").segments, ShouldEqual, []PathSegment{{s: "0", i: -1}, {s: "2", i: -1}})
 	})
 	t.Run("escaping segments", func(t *testing.T) { // NOTE: a spec for string encoding might cause this to change in the future!
-		Wish(t, ParsePath(`0/\//2`).segments, ShouldEqual, []PathSegment{{s: "0"}, {s: `\`}, {s: "2"}})
+		Wish(t, ParsePath(`0/\//2`).segments, ShouldEqual, []PathSegment{{s: "0", i: -1}, {s: `\`, i: -1}, {s: "2", i: -1}})
 	})
 }
 

--- a/path_test.go
+++ b/path_test.go
@@ -13,13 +13,16 @@ func TestParsePath(t *testing.T) {
 	t.Run("parsing three segments", func(t *testing.T) {
 		Wish(t, ParsePath("0/foo/2").segments, ShouldEqual, []PathSegment{{s: "0"}, {s: "foo"}, {s: "2"}})
 	})
-	t.Run("eliding empty segments", func(t *testing.T) {
-		Wish(t, ParsePath("0//2").segments, ShouldEqual, []PathSegment{{s: "0"}, {s: "2"}})
-	})
 	t.Run("eliding leading slashes", func(t *testing.T) {
 		Wish(t, ParsePath("/0/2").segments, ShouldEqual, []PathSegment{{s: "0"}, {s: "2"}})
 	})
 	t.Run("eliding trailing", func(t *testing.T) {
 		Wish(t, ParsePath("0/2/").segments, ShouldEqual, []PathSegment{{s: "0"}, {s: "2"}})
+	})
+	t.Run("eliding empty segments", func(t *testing.T) { // NOTE: a spec for string encoding might cause this to change in the future!
+		Wish(t, ParsePath("0//2").segments, ShouldEqual, []PathSegment{{s: "0"}, {s: "2"}})
+	})
+	t.Run("escaping segments", func(t *testing.T) { // NOTE: a spec for string encoding might cause this to change in the future!
+		Wish(t, ParsePath(`0/\//2`).segments, ShouldEqual, []PathSegment{{s: "0"}, {s: `\`}, {s: "2"}})
 	})
 }


### PR DESCRIPTION
Several significant clarifications to Path docs.

Primarily, being committal and direct about how special values, erm... *aren't* -- namely, "/" is a valid segment, and so is empty string -- and confessing how much tricky work that makes.

Several methods are now more upfront about how much they *do not do good things* on such values.  I'd like to fix these methods, but to do that, we should formally specify an escaping system and canonical string encoding for paths.  That work should start in the IPLD Specs repo, and involve fixtures.  Once that is tackled, I will (very!) gladly start fixing these methods to operate accordingly, and get rid of all the sharp-edges warnings.

Several methods also now include comments about whether they will enforce string character encoding or normalization on their function boundaries.  They won't.  (This is certainly the norm in Go -- the stance of "string is really just bytes" is ubiquitous in the gopher community -- so it may seem not worthy of wasting docs on to other gopher readers.  However, since IPLD is all about cross-language consistency, and we may have people from other programming language ecosystems reading our docs, it seems good to be as clear and explicit as possible.)  I suspect this *will* remain the case (it's turned out tricky and work-makey to try to specify anything else; subtracting the countably-infinite domain of non-normalized strings from the countably-infinite domain of all possible byte sequences makes for some very nasty and pernicious expressibility and round-tripping issues, long story short).

Thanks to @ribasushi for the kick in the shins that these docs needed work and clarifications.  The previous docs were written a fair while ago when we knew less things less confidently about how the system and specs would evolve, so these clarifications were badly needed.
