### PR TITLE
Fix marshalling error

### DIFF
--- a/codec/dagcbor/marshal.go
+++ b/codec/dagcbor/marshal.go
@@ -134,6 +134,7 @@ func marshal(n ipld.Node, tk *tok.Token, sink shared.TokenSink) error {
 			tk.Tagged = true
 			tk.Tag = linkTag
 			_, err = sink.Step(tk)
+			tk.Tagged = false
 			return err
 		default:
 			return fmt.Errorf("schemafree link emission only supported by this codec for CID type links!")


### PR DESCRIPTION
# Goals

This bug manifested as an issue in Graphsync's IPLD prime upgrade where it appeared the created blockchain structure was not working. As it turns out, the issue was not the structure of nodes created but encode/decode from CBOR. I tracked it to an ErrInvalidMultibase error in decode, but eventually figured out the error was on a node that was created as bytes. Eventually, I noticed that during the NodeAssembler upgrade, we switched from marshall using a local token variable at each recursive level to a single token variable passed down the recursion tree as a pointer. Eventually, that led me to realize that once a link was encountered during traverse, tk.Tagged was set true and never unset (along with tk.Tag = linkTag). If there was a subsequent Bytes node encountered, it was written as a Link, which would later error when decoding.

# Implementation

- create a minimal repro test
- fix by just clearing the Tagged boolean after the link is written