### PR TITLE
Codegen of unions, and their keyed representations

### DIFF
--- a/nodeBuilder.go
+++ b/nodeBuilder.go
@@ -88,6 +88,11 @@ type MapAssembler interface {
 	// (Design note: a string is sufficient for the parameter here rather than
 	// a full Node, because the only cases where the value types vary are also
 	// cases where the keys may not be complex.)
+	//
+	// FIXME: define a "nopePrototype" -- structs and unions need some way to say that the given 'k' isn't acceptable at all.
+	//  I'm not sure when that thing gets to brass tacks about erroring either though!  The NewBuilder method can't either.
+	//  Maybe we should choose between this panicking (right away, no "nopePrototype"), or adding an error return to it.
+	//   (We don't call this all that much since the NodeAssembler restructuring; maybe an annoying error return is fine.)
 	ValuePrototype(k string) NodePrototype
 }
 

--- a/nodeBuilder.go
+++ b/nodeBuilder.go
@@ -84,15 +84,12 @@ type MapAssembler interface {
 	// For plain maps (that is, not structs or unions masquerading as maps),
 	// the empty string can be used as a parameter, and the returned NodePrototype
 	// can be assumed applicable for all values.
-	// Using an empty string for a struct or union will return a nil NodePrototype.
+	// Using an empty string for a struct or union will return nil,
+	// as will using any string which isn't a field or member of those types.
+	//
 	// (Design note: a string is sufficient for the parameter here rather than
 	// a full Node, because the only cases where the value types vary are also
 	// cases where the keys may not be complex.)
-	//
-	// FIXME: define a "nopePrototype" -- structs and unions need some way to say that the given 'k' isn't acceptable at all.
-	//  I'm not sure when that thing gets to brass tacks about erroring either though!  The NewBuilder method can't either.
-	//  Maybe we should choose between this panicking (right away, no "nopePrototype"), or adding an error return to it.
-	//   (We don't call this all that much since the NodeAssembler restructuring; maybe an annoying error return is fine.)
 	ValuePrototype(k string) NodePrototype
 }
 

--- a/schema/errors.go
+++ b/schema/errors.go
@@ -4,6 +4,21 @@ import (
 	"fmt"
 )
 
+// TODO: errors in this package remain somewhat slapdash.
+//
+//  - ipld.ErrUnmatchable is used as a catch-all in some places, and contains who-knows-what values wrapped in the Reason field.
+//    - sometimes this wraps things like strconv errors... and on the one hand, i'm kinda okay with that; on the other, maybe saying a bit more with types before getting to that kind of shrug would be nice.
+//  - we probably want to use `Type` values, right?
+//    - or do we: because then we probably need a `Repr bool` next to it, or lots of messages would be nonsensical.
+//    - this is *currently* problematic because we don't actually generate type info consts yet.  Hopefully soon; but the pain, meanwhile, is... substantial.
+//      - "substantial" is an understatement.  it makes incremental development almost impossible because stringifying error reports turn into nil pointer crashes!
+//    - other ipld-wide errors like `ipld.ErrWrongKind` *sometimes* refer to a TypeName... but don't *have* to, because they also arise at the merely-datamodel level; what would we do with these?
+//      - it's undesirable (not to mention intensely forbidden for import cycle reasons) for those error types to refer to schema.Type.
+//        - if we must have TypeName treated stringily in some cases, is it really useful to use full type info in other cases -- inconsistently?
+//    - regardless of where we end up with this, some sort of an embed for helping deal with munging and printing this would probably be wise.
+//  - generally, whether you should expect an "ipld.Err*" or a "schema.Err*" from various methods is quite unclear.
+//  - it's possible that we should wrap *all* schema-level errors in a single "ipld.ErrSchemaNoMatch" error of some kind, to fix the above.  as yet undecided.
+
 // ErrNoSuchField may be returned from lookup functions on the Node
 // interface when a field is requested which doesn't exist, or from Insert
 // on a MapBuilder when a key doesn't match a field name in the structure.
@@ -18,4 +33,25 @@ func (e ErrNoSuchField) Error() string {
 		return fmt.Sprintf("no such field: {typeinfomissing}.%s", e.FieldName)
 	}
 	return fmt.Sprintf("no such field: %s.%s", e.Type.Name(), e.FieldName)
+}
+
+// ErrNotUnionStructure means data was fed into a union assembler that can't match the union.
+//
+// This could have one of several reasons, which are explained in the detail text:
+//
+//   - there are too many entries in the map;
+//   - the keys of critical entries aren't found;
+//   - keys are found that aren't any of the expected critical keys;
+//   - etc.
+//
+// TypeName is currently a string... see comments at the top of this file for
+// remarks on the issues we need to address about these identifiers in errors in general.
+type ErrNotUnionStructure struct {
+	TypeName string
+
+	Detail string
+}
+
+func (e ErrNotUnionStructure) Error() string {
+	return fmt.Sprintf("cannot match schema: union structure constraints for %s caused rejection: %s", e.TypeName, e.Detail)
 }

--- a/schema/gen/go/HACKME_wip.md
+++ b/schema/gen/go/HACKME_wip.md
@@ -31,3 +31,81 @@ the existing allowNull), and another for both (for "nullable optional" fields).
 Every NodeAssembler would then have to support that, just as they each support allowNull now.
 
 I think the above design is valid, but it's not implemented nor tested yet.
+
+
+### AssignNode optimality
+
+The AssignNode methods we generate currently do pretty blithe things with large structures:
+they iterate over the given node, and hurl entries into the assembler's AssignKey and AssignValue methods.
+
+This isn't always optimal.
+For any structure that is more efficient when fed info in an ideal order, we might want to take account of that.
+
+For example, unions with representation mode "inline" are a stellar example of this:
+if the discriminant key comes first, they can work *much, much* more efficiently.
+By contrast, if the discriminant key shows up late in the object, it is necessary to
+have buffered *all the other* data, then backtrack to handle it once the discriminant is found and parsed.
+
+At best, this probably means iterating once, plucking out the discriminant entry,
+and then *getting a new iterator* that starts from the beginning (which shifts
+the buffer problem to the Node we're consuming data from).
+
+Even more irritatingly: since NodeAssembler has to accept entries in any order
+if it is to accept information streamingly from codecs, the NodeAssembler
+*also* has to be ready to do the buffering work...
+TODO ouch what are the ValueAssembler going to yield for dealing with children?
+TODO we have to hand out dummy ValueAssembler types that buffer... a crazy amount of stuff.  (Reinvent refmt.Tok??  argh.)  cannot avoid???
+TODO this means where errors arise from will be nuts: you cant say if anything is wrong until you figure out the discriminant.  then we replay everything?  your errors for deeper stuff will appear... uh... midway, from a random AssembleValue finishing that happens to be for the discriminant.  that is not pleasant.
+
+... let's leave that thought aside: suffice to say, some assemblers are *really*
+not happy or performant if they have to accept things in unpleasant orderings.
+
+So.
+
+We should flip all this on its head.  The AssignNode methods should lean in
+on the knowledge they have about the structure they're building, and assume
+that the Node we're copying content from supports random access:
+pluck the fields that we care most about out first with direct lookups,
+and only use iteration to cover the remaining data that the new structure
+doesn't care about the ordering of.
+
+Perhaps this only matters for certain styles of unions.
+
+
+### sidenote about codec interfaces
+
+Perhaps we should get used to the idea of codec packages offering two styles of methods:
+
+- `UnmarshalIntoAssembler(io.Reader, ipld.NodeAssembler) error`
+	- this is for when you have opinions about what kind of in-memory format should be used
+- `Unmarshal(io.Reader) (ipld.Node, error)`
+	- this is for when you want to let the codec pick.
+
+We might actually end up preferring the latter in a fair number of cases.
+
+Looking at this inline union ordering situation described above:
+the best path through that (other than saying "don't fking use inline unions,
+and if you do, put the discriminant in the first fking entry or gtfo") would probably be
+to do a cbor (or whatever) unmarshal that produces the half-deserialized skip-list nodes
+(which are specialized to the cbor format rather than general purpose, but we want that in this story)...
+and those can then claim to do random access, thereby letting them take on the "buffering".
+This approach would let the serialization-specialized nodes take on the work,
+rather than forcing the union's NodeAssembler to do buffer at a higher level...
+which is good because doing that buffering in a structured way at a higher level
+is actually more work and causes more memory fragmentation and allocations.
+
+Whew.
+
+I have not worked out what this implies for multicodecs or other muxes that do compositions of codecs.
+
+
+### enums of union keys
+
+It's extremely common to have an enum that is the discrimant values of a union.
+
+We should make a schema syntax for that.
+
+We tend to generate such an enum in codegen anyway, for various purposes.
+Might as well let people name it outright too, if they have the slightest desire to do so.
+
+(Doesn't apply to kinded unions.)

--- a/schema/gen/go/HACKME_wip.md
+++ b/schema/gen/go/HACKME_wip.md
@@ -113,10 +113,14 @@ Might as well let people name it outright too, if they have the slightest desire
 
 ### can reset methods be replaced with duff's device?
 
-Yes.  I'm not even sure why we haven't done that; they were written that way on purpose.
+Yes.  Well, sort of.  Okay, no.
 
-Although on second thought, see the following section about new-alloc child assemblers;
-it raises some challenges.
+It's close!  Assemblers were all written such that their zero values are ready to go.
+
+However, there's a couple of situations where you *wouldn't* want to blithely zero everything:
+for example, if an assembler has to do some allocations, but they're reusable,
+you wouldn't want to turn those other objects into garbage by zeroing the pointer to them.
+See the following section about new-alloc child assemblers for an example of this.
 
 
 ### what's up with new-alloc child assemblers?
@@ -142,5 +146,6 @@ There's a couple things to think about with these:
   - For unions, there's a question of if we should hold onto each child assembler, or just the most recent; that's a choice we could make and tune.
     If the answer is "most recent only", we could even crank down the resident size by use of more interfaces instead of concrete types (at the cost of some other runtime performance debufs, most likely).
 
-// this last bit seems to imply that maybe union assemblers should always have ca fields, it's just a question of if they should be pointers or not.
-// we could also do them as a single shared interface: it *is* a nodeassembler iface already, after all, so it can be done without even introducing more types.  would involve casts (at least two, I think) and/or non-inlinable calls, though.
+We've chosen to discard the possibility of duff's device as an assembler resetting implementation.
+As a result, we don't have to do proactive 'w'-nil'ing in places we might otherwise have to.
+And union assemblers hold on to all child assembler types they've ever needed.

--- a/schema/gen/go/README.md
+++ b/schema/gen/go/README.md
@@ -92,8 +92,8 @@ Legend:
 | feature                        | accessors | builders |
 |:-------------------------------|:---------:|:--------:|
 | unions                         |    ...    |    ...   |
-| ... type level                 |     ✘     |     ✘    |
-| ... keyed representation       |     ✘     |     ✘    |
+| ... type level                 |     ✔     |     ✔    |
+| ... keyed representation       |     ✔     |     ✔    |
 | ... envelope representation    |     ✘     |     ✘    |
 | ... kinded representation      |     ✘     |     ✘    |
 | ... inline representation      |     ✘     |     ✘    |

--- a/schema/gen/go/genStruct.go
+++ b/schema/gen/go/genStruct.go
@@ -272,28 +272,7 @@ func (g structBuilderGenerator) EmitNodeAssemblerType(w io.Writer) {
 	`, w, g.AdjCfg, g)
 }
 func (g structBuilderGenerator) EmitNodeAssemblerMethodBeginMap(w io.Writer) {
-	// We currently disregard sizeHint.  It's not relevant to us.
-	//  We could check it strictly and emit errors; presently, we don't.
-	// This method contains a branch to support MaybeUsesPtr because new memory may need to be allocated.
-	//  This allocation only happens if the 'w' ptr is nil, which means we're being used on a Maybe;
-	//  otherwise, the 'w' ptr should already be set, and we fill that memory location without allocating, as usual.
-	doTemplate(`
-		func (na *_{{ .Type | TypeSymbol }}__Assembler) BeginMap(int) (ipld.MapAssembler, error) {
-			switch *na.m {
-			case schema.Maybe_Value, schema.Maybe_Null:
-				panic("invalid state: cannot assign into assembler that's already finished")
-			case midvalue:
-				panic("invalid state: it makes no sense to 'begin' twice on the same assembler!")
-			}
-			*na.m = midvalue
-			{{- if .Type | MaybeUsesPtr }}
-			if na.w == nil {
-				na.w = &_{{ .Type | TypeSymbol }}{}
-			}
-			{{- end}}
-			return na, nil
-		}
-	`, w, g.AdjCfg, g)
+	emitNodeAssemblerMethodBeginMap_strictoid(w, g.AdjCfg, g)
 }
 func (g structBuilderGenerator) EmitNodeAssemblerMethodAssignNull(w io.Writer) {
 	emitNodeAssemblerMethodAssignNull_recursive(w, g.AdjCfg, g)

--- a/schema/gen/go/genStructReprMap.go
+++ b/schema/gen/go/genStructReprMap.go
@@ -324,28 +324,7 @@ func (g structReprMapReprBuilderGenerator) EmitNodeAssemblerType(w io.Writer) {
 	`, w, g.AdjCfg, g)
 }
 func (g structReprMapReprBuilderGenerator) EmitNodeAssemblerMethodBeginMap(w io.Writer) {
-	// We currently disregard sizeHint.  It's not relevant to us.
-	//  We could check it strictly and emit errors; presently, we don't.
-	// This method contains a branch to support MaybeUsesPtr because new memory may need to be allocated.
-	//  This allocation only happens if the 'w' ptr is nil, which means we're being used on a Maybe;
-	//  otherwise, the 'w' ptr should already be set, and we fill that memory location without allocating, as usual.
-	doTemplate(`
-		func (na *_{{ .Type | TypeSymbol }}__ReprAssembler) BeginMap(int) (ipld.MapAssembler, error) {
-			switch *na.m {
-			case schema.Maybe_Value, schema.Maybe_Null:
-				panic("invalid state: cannot assign into assembler that's already finished")
-			case midvalue:
-				panic("invalid state: it makes no sense to 'begin' twice on the same assembler!")
-			}
-			*na.m = midvalue
-			{{- if .Type | MaybeUsesPtr }}
-			if na.w == nil {
-				na.w = &_{{ .Type | TypeSymbol }}{}
-			}
-			{{- end}}
-			return na, nil
-		}
-	`, w, g.AdjCfg, g)
+	emitNodeAssemblerMethodBeginMap_strictoid(w, g.AdjCfg, g)
 }
 func (g structReprMapReprBuilderGenerator) EmitNodeAssemblerMethodAssignNull(w io.Writer) {
 	emitNodeAssemblerMethodAssignNull_recursive(w, g.AdjCfg, g)

--- a/schema/gen/go/genUnion.go
+++ b/schema/gen/go/genUnion.go
@@ -589,7 +589,7 @@ func (g unionBuilderGenerator) emitMapAssemblerMethods(w io.Writer) {
 				return _{{ $member | TypeSymbol }}__Prototype{}
 			{{- end}}
 			default:
-				panic("FIXME oh dear the possibility of this method erroring was not accounted for yet")
+				return nil
 			}
 		}
 	`, w, g.AdjCfg, g)

--- a/schema/gen/go/genUnion.go
+++ b/schema/gen/go/genUnion.go
@@ -41,12 +41,12 @@ func (g unionGenerator) EmitNativeType(w io.Writer) {
 	// The interface *mostly* isn't used... except for in the return type of a speciated function which can be used to do golang-native type switches.
 	doTemplate(`
 		type _{{ .Type | TypeSymbol }} struct {
-			{{- with (eq (.AdjCfg.UnionMemlayout .Type) "embedAll") }}
-			{{- range $member := .Type.Members }}
-			x_{{ $member.Name }} _{{ $member | TypeSymbol }}
+			{{- if (eq (.AdjCfg.UnionMemlayout .Type) "embedAll") }}
+			tag uint
+			{{- range $i, $member := .Type.Members }}
+			x{{ $i }} _{{ $member | TypeSymbol }}
 			{{- end}}
-			{{- end}}
-			{{- with (eq (.AdjCfg.UnionMemlayout .Type) "interface") }}
+			{{- else if (eq (.AdjCfg.UnionMemlayout .Type) "interface") }}
 			x _{{ .Type | TypeSymbol }}__iface
 			{{- end}}
 		}
@@ -57,7 +57,179 @@ func (g unionGenerator) EmitNativeType(w io.Writer) {
 		}
 
 		{{- range $member := .Type.Members }}
-		func (_{{ $member | TypeSymbol }}) _{{ .dot.Type | TypeSymbol }}__member() {}
+		func (_{{ $member | TypeSymbol }}) _{{ dot.Type | TypeSymbol }}__member() {}
 		{{- end}}
 	`, w, g.AdjCfg, g)
+}
+
+func (g unionGenerator) EmitNativeAccessors(w io.Writer) {
+	doTemplate(`
+		func (n _{{ .Type | TypeSymbol }}) AsInterface() _{{ .Type | TypeSymbol }}__iface {
+			{{- if (eq (.AdjCfg.UnionMemlayout .Type) "embedAll") }}
+			switch n.tag {
+			{{- range $i, $member := .Type.Members }}
+			case {{ $i }}:
+				return &n.x{{ $i }}
+			{{- end}}
+			default:
+				panic("invalid union state; how did you create this object?")
+			}
+			{{- else if (eq (.AdjCfg.UnionMemlayout .Type) "interface") }}
+			return n.x
+			{{- end}}
+		}
+	`, w, g.AdjCfg, g)
+}
+
+func (g unionGenerator) EmitNativeBuilder(w io.Writer) {
+	// Unclear as yet what should go here.
+}
+
+func (g unionGenerator) EmitNativeMaybe(w io.Writer) {
+	emitNativeMaybe(w, g.AdjCfg, g)
+}
+
+// --- type info --->
+
+func (g unionGenerator) EmitTypeConst(w io.Writer) {
+	doTemplate(`
+		// TODO EmitTypeConst
+	`, w, g.AdjCfg, g)
+}
+
+// --- TypedNode interface satisfaction --->
+
+func (g unionGenerator) EmitTypedNodeMethodType(w io.Writer) {
+	doTemplate(`
+		func ({{ .Type | TypeSymbol }}) Type() schema.Type {
+			return nil /*TODO:typelit*/
+		}
+	`, w, g.AdjCfg, g)
+}
+
+func (g unionGenerator) EmitTypedNodeMethodRepresentation(w io.Writer) {
+	emitTypicalTypedNodeMethodRepresentation(w, g.AdjCfg, g)
+}
+
+// --- Node interface satisfaction --->
+
+func (g unionGenerator) EmitNodeType(w io.Writer) {
+	// No additional types needed.  Methods all attach to the native type.
+
+	// We do, however, want some constants for our member names;
+	//  they'll make iterators able to work faster.  So let's emit those.
+	// These are a bit perplexing, because they're... type names.
+	//  However, oddly enough, we don't have type names available *as nodes* anywhere else centrally available,
+	//   so... we generate some values for them here with scoped identifers and get on with it.
+	//    Maybe this could be elided with future work.
+	doTemplate(`
+		var (
+			{{- range $member := .Type.Members }}
+			memberName__{{ dot.Type | TypeSymbol }}_{{ $member.Name }} = _String{"{{ $member.Name }}"}
+			{{- end }}
+		)
+	`, w, g.AdjCfg, g)
+}
+
+func (g unionGenerator) EmitNodeTypeAssertions(w io.Writer) {
+	emitNodeTypeAssertions_typical(w, g.AdjCfg, g)
+}
+
+func (g unionGenerator) EmitNodeMethodLookupByString(w io.Writer) {
+	doTemplate(`
+		func (n {{ .Type | TypeSymbol }}) LookupByString(key string) (ipld.Node, error) {
+			switch key {
+			{{- range $i, $member := .Type.Members }}
+			case "{{ $member.Name }}":
+				{{- if (eq (dot.AdjCfg.UnionMemlayout dot.Type) "embedAll") }}
+				if n.tag != {{ $i }} {
+					return nil, ipld.ErrNotExists{ipld.PathSegmentOfString(key)}
+				}
+				return &n.x{{ $i }}, nil
+				{{- else if (eq (dot.AdjCfg.UnionMemlayout dot.Type) "interface") }}
+				if _, ok := n.x.({{ $member | TypeSymbol }}); !ok {
+					return nil, ipld.ErrNotExists{ipld.PathSegmentOfString(key)}
+				}
+				return n.x, nil
+				{{- end}}
+			{{- end}}
+			default:
+				return nil, schema.ErrNoSuchField{Type: nil /*TODO*/, FieldName: key}
+			}
+		}
+	`, w, g.AdjCfg, g)
+}
+
+func (g unionGenerator) EmitNodeMethodLookupByNode(w io.Writer) {
+	doTemplate(`
+		func (n {{ .Type | TypeSymbol }}) LookupByNode(key ipld.Node) (ipld.Node, error) {
+			ks, err := key.AsString()
+			if err != nil {
+				return nil, err
+			}
+			return n.LookupByString(ks)
+		}
+	`, w, g.AdjCfg, g)
+}
+
+func (g unionGenerator) EmitNodeMethodMapIterator(w io.Writer) {
+	// This is kind of a hilarious "iterator": it has to count all the way up to... 1.
+	doTemplate(`
+		func (n {{ .Type | TypeSymbol }}) MapIterator() ipld.MapIterator {
+			return &_{{ .Type | TypeSymbol }}__MapItr{n, false}
+		}
+
+		type _{{ .Type | TypeSymbol }}__MapItr struct {
+			n {{ .Type | TypeSymbol }}
+			done bool
+		}
+
+		func (itr *_{{ .Type | TypeSymbol }}__MapItr) Next() (k ipld.Node, v ipld.Node, _ error) {
+			if itr.done {
+				return nil, nil, ipld.ErrIteratorOverread{}
+			}
+			{{- if (eq (.AdjCfg.UnionMemlayout .Type) "embedAll") }}
+			switch itr.n.tag {
+			{{- range $i, $member := .Type.Members }}
+			case {{ $i }}:
+				return memberName__{{ dot.Type | TypeSymbol }}_{{ $member.Name }}, &n.x{{ $i }}, nil
+			{{- end}}
+			{{- else if (eq (.AdjCfg.UnionMemlayout .Type) "interface") }}
+			switch itr.n.x.(type) {
+			{{- range $member := .Type.Members }}
+			case {{ $member | TypeSymbol }}:
+				return memberName__{{ dot.Type | TypeSymbol }}_{{ $member.Name }}, n.x, nil
+			{{- end}}
+			{{- end}}
+			default:
+				panic("unreachable")
+			}
+			itr.done = true
+			return
+		}
+		func (itr *_{{ .Type | TypeSymbol }}__MapItr) Done() bool {
+			return itr.done
+		}
+
+	`, w, g.AdjCfg, g)
+}
+
+func (g unionGenerator) EmitNodeMethodLength(w io.Writer) {
+	doTemplate(`
+		func ({{ .Type | TypeSymbol }}) Length() int {
+			return 1
+		}
+	`, w, g.AdjCfg, g)
+}
+
+func (g unionGenerator) EmitNodeMethodPrototype(w io.Writer) {
+	emitNodeMethodPrototype_typical(w, g.AdjCfg, g)
+}
+
+func (g unionGenerator) EmitNodePrototypeType(w io.Writer) {
+	emitNodePrototypeType_typical(w, g.AdjCfg, g)
+}
+
+func (g unionGenerator) GetNodeBuilderGenerator() NodeBuilderGenerator {
+	return nil /* TODO */
 }

--- a/schema/gen/go/genUnion.go
+++ b/schema/gen/go/genUnion.go
@@ -1,0 +1,63 @@
+package gengo
+
+import (
+	"io"
+
+	"github.com/ipld/go-ipld-prime/schema"
+	"github.com/ipld/go-ipld-prime/schema/gen/go/mixins"
+)
+
+// The generator for unions is a bit more wild than most others:
+// it has at three major branches for how its internals are laid out:
+//
+//   - all possible children are embedded.
+//   - all possible children are pointers... in which case we collapse to one interface resident.
+//       (n.b. this does give up some inlining potential as well as gives up on alloc amortization, but it does make resident memory size minimal.)
+//   - some children are emebedded and some are pointers, and of the latter set, they may be either in one interface field or several discrete pointers.
+//       (discrete fields of pointer type makes inlining possible in some paths, whereas an interface field blocks it).
+//
+// ... We're not doing that last one at all right now.  The pareto-prevalence of these concerns is extremely low compared to the effort required.
+// But the first two are both very reasonable, and both are often wanted.
+//
+// These choices are made from adjunct config (which should make sense, because they're clearly all "golang" details -- not type semantics).
+// We still tackle all the generation for all these strategies this in one file,
+//  because all of the interfaces we export are the same, regardless of the internals (and it just seems easiest to do this way).
+
+type unionGenerator struct {
+	AdjCfg *AdjunctCfg
+	mixins.MapTraits
+	PkgName string
+	Type    schema.TypeUnion
+}
+
+func (unionGenerator) IsRepr() bool { return false } // hint used in some generalized templates.
+
+// --- native content and specializations --->
+
+func (g unionGenerator) EmitNativeType(w io.Writer) {
+	doTemplate(`
+		type _{{ .Type | TypeSymbol }} struct {
+			{{ with (eq .AdjCfg.UnionMemlayout "embedAll") -}}
+
+			{{- end}}
+			{{ with (eq .AdjCfg.UnionMemlayout "interface") -}}
+
+			{{- end}}
+		}
+		type {{ .Type | TypeSymbol }} = *_{{ .Type | TypeSymbol }}
+
+
+		{{ with (eq .AdjCfg.UnionMemlayout "interface") -}}
+			// ... is there any utility to making an interface type?
+			// internally: no.
+			// for export and use: unclear.
+			//   i don't think we need to kowtow to burntsushi's sumtype checker.  we could (and it would be pleasing to do so); but we can make our own just as well.
+			//   how would you use it?  would there be a method for unboxing the structptr into the interface type?  and vice versa (which would incur an alloc)?
+			//     if assignNode was going to work, ... actually it could just take the member type "concretely", they already implement Node, and we could just figure it out.  That'd be fine.
+			//   is there... any reason a programmer would prefer to use the interface, though?
+			//     if they wanted to make their own typeswitch, maybe?
+			//       is that going to be more efficient that doing a switch using an enum we generate, and then calling a function that does a cast explicitly?  probably.  heck.
+			//         do we need to have an *exported* interface for this to work, though?  I think not.  so that might be a solid choice.
+		{{- end}}
+	`, w, g.AdjCfg, g)
+}

--- a/schema/gen/go/genUnionReprKeyed.go
+++ b/schema/gen/go/genUnionReprKeyed.go
@@ -1,0 +1,31 @@
+package gengo
+
+import (
+	"github.com/ipld/go-ipld-prime/schema"
+	"github.com/ipld/go-ipld-prime/schema/gen/go/mixins"
+)
+
+var _ TypeGenerator = &unionReprKeyedGenerator{}
+
+func NewUnionReprKeyedGenerator(pkgName string, typ schema.TypeUnion, adjCfg *AdjunctCfg) TypeGenerator {
+	return unionReprKeyedGenerator{
+		unionGenerator{
+			adjCfg,
+			mixins.MapTraits{
+				pkgName,
+				string(typ.Name()),
+				adjCfg.TypeSymbol(typ),
+			},
+			pkgName,
+			typ,
+		},
+	}
+}
+
+type unionReprKeyedGenerator struct {
+	unionGenerator
+}
+
+func (g unionReprKeyedGenerator) GetRepresentationNodeGen() NodeGenerator {
+	return nil /* TODO */
+}

--- a/schema/gen/go/genUnionReprKeyed.go
+++ b/schema/gen/go/genUnionReprKeyed.go
@@ -460,7 +460,7 @@ func (g unionReprKeyedReprBuilderGenerator) emitMapAssemblerMethods(w io.Writer)
 				return _{{ $member | TypeSymbol }}__ReprPrototype{}
 			{{- end}}
 			default:
-				panic("FIXME oh dear the possibility of this method erroring was not accounted for yet")
+				return nil
 			}
 		}
 	`, w, g.AdjCfg, g)

--- a/schema/gen/go/genUnionReprKeyed.go
+++ b/schema/gen/go/genUnionReprKeyed.go
@@ -1,11 +1,17 @@
 package gengo
 
 import (
+	"io"
+
 	"github.com/ipld/go-ipld-prime/schema"
 	"github.com/ipld/go-ipld-prime/schema/gen/go/mixins"
 )
 
 var _ TypeGenerator = &unionReprKeyedGenerator{}
+
+// General observation: many things about the keyed representation of unions is *very* similar to the type-level code,
+//  because the type level code effective does espouse keyed-style behavior (just with type names as the keys).
+//  Be advised that this similarity does not hold at *all* true of any of the other representation modes of unions!
 
 func NewUnionReprKeyedGenerator(pkgName string, typ schema.TypeUnion, adjCfg *AdjunctCfg) TypeGenerator {
 	return unionReprKeyedGenerator{
@@ -27,5 +33,490 @@ type unionReprKeyedGenerator struct {
 }
 
 func (g unionReprKeyedGenerator) GetRepresentationNodeGen() NodeGenerator {
-	return nil /* TODO */
+	return unionReprKeyedReprGenerator{
+		g.AdjCfg,
+		mixins.MapTraits{
+			g.PkgName,
+			string(g.Type.Name()) + ".Repr",
+			"_" + g.AdjCfg.TypeSymbol(g.Type) + "__Repr",
+		},
+		g.PkgName,
+		g.Type,
+	}
+}
+
+type unionReprKeyedReprGenerator struct {
+	AdjCfg *AdjunctCfg
+	mixins.MapTraits
+	PkgName string
+	Type    schema.TypeUnion
+}
+
+func (unionReprKeyedReprGenerator) IsRepr() bool { return true } // hint used in some generalized templates.
+
+func (g unionReprKeyedReprGenerator) EmitNodeType(w io.Writer) {
+	// The type is structurally the same, but will have a different set of methods.
+	doTemplate(`
+		type _{{ .Type | TypeSymbol }}__Repr _{{ .Type | TypeSymbol }}
+	`, w, g.AdjCfg, g)
+
+	// We do also want some constants for our discriminant values;
+	//  they'll make iterators able to work faster.
+	doTemplate(`
+		var (
+			{{- range $member := .Type.Members }}
+			memberName__{{ dot.Type | TypeSymbol }}_{{ $member.Name }}_serial = _String{"{{ $member | dot.Type.RepresentationStrategy.GetDiscriminant }}"}
+			{{- end }}
+		)
+	`, w, g.AdjCfg, g)
+}
+
+func (g unionReprKeyedReprGenerator) EmitNodeTypeAssertions(w io.Writer) {
+	doTemplate(`
+		var _ ipld.Node = &_{{ .Type | TypeSymbol }}__Repr{}
+	`, w, g.AdjCfg, g)
+}
+
+func (g unionReprKeyedReprGenerator) EmitNodeMethodLookupByString(w io.Writer) {
+	// Similar to the type-level method, except uses discriminant values as keys instead of the member type names.
+	doTemplate(`
+		func (n *_{{ .Type | TypeSymbol }}__Repr) LookupByString(key string) (ipld.Node, error) {
+			switch key {
+			{{- range $i, $member := .Type.Members }}
+			case "{{ $member | dot.Type.RepresentationStrategy.GetDiscriminant }}":
+				{{- if (eq (dot.AdjCfg.UnionMemlayout dot.Type) "embedAll") }}
+				if n.tag != {{ add $i 1 }} {
+					return nil, ipld.ErrNotExists{ipld.PathSegmentOfString(key)}
+				}
+				return &n.x{{ add $i 1 }}, nil
+				{{- else if (eq (dot.AdjCfg.UnionMemlayout dot.Type) "interface") }}
+				if n2, ok := n.x.({{ $member | TypeSymbol }}); ok {
+					return n2, nil
+				} else {
+					return nil, ipld.ErrNotExists{ipld.PathSegmentOfString(key)}
+				}
+				{{- end}}
+			{{- end}}
+			default:
+				return nil, schema.ErrNoSuchField{Type: nil /*TODO*/, FieldName: key}
+			}
+		}
+	`, w, g.AdjCfg, g)
+}
+
+func (g unionReprKeyedReprGenerator) EmitNodeMethodLookupByNode(w io.Writer) {
+	doTemplate(`
+		func (n *_{{ .Type | TypeSymbol }}__Repr) LookupByNode(key ipld.Node) (ipld.Node, error) {
+			ks, err := key.AsString()
+			if err != nil {
+				return nil, err
+			}
+			return n.LookupByString(ks)
+		}
+	`, w, g.AdjCfg, g)
+}
+
+func (g unionReprKeyedReprGenerator) EmitNodeMethodMapIterator(w io.Writer) {
+	// Similar to the type-level method, except yields discriminant values as keys instead of the member type names.
+	doTemplate(`
+		func (n *_{{ .Type | TypeSymbol }}__Repr) MapIterator() ipld.MapIterator {
+			return &_{{ .Type | TypeSymbol }}__ReprMapItr{n, false}
+		}
+
+		type _{{ .Type | TypeSymbol }}__ReprMapItr struct {
+			n *_{{ .Type | TypeSymbol }}__Repr
+			done bool
+		}
+
+		func (itr *_{{ .Type | TypeSymbol }}__ReprMapItr) Next() (k ipld.Node, v ipld.Node, _ error) {
+			if itr.done {
+				return nil, nil, ipld.ErrIteratorOverread{}
+			}
+			{{- if (eq (.AdjCfg.UnionMemlayout .Type) "embedAll") }}
+			switch itr.n.tag {
+			{{- range $i, $member := .Type.Members }}
+			case {{ add $i 1 }}:
+				return &memberName__{{ dot.Type | TypeSymbol }}_{{ $member.Name }}_serial, itr.n.x{{ add $i 1 }}.Representation(), nil
+			{{- end}}
+			{{- else if (eq (.AdjCfg.UnionMemlayout .Type) "interface") }}
+			switch n2 := itr.n.x.(type) {
+			{{- range $member := .Type.Members }}
+			case {{ $member | TypeSymbol }}:
+				return &memberName__{{ dot.Type | TypeSymbol }}_{{ $member.Name }}_serial, n2.Representation(), nil
+			{{- end}}
+			{{- end}}
+			default:
+				panic("unreachable")
+			}
+			itr.done = true
+			return
+		}
+		func (itr *_{{ .Type | TypeSymbol }}__ReprMapItr) Done() bool {
+			return itr.done
+		}
+
+	`, w, g.AdjCfg, g)
+}
+
+func (g unionReprKeyedReprGenerator) EmitNodeMethodLength(w io.Writer) {
+	doTemplate(`
+		func (_{{ .Type | TypeSymbol }}__Repr) Length() int {
+			return 1
+		}
+	`, w, g.AdjCfg, g)
+}
+
+func (g unionReprKeyedReprGenerator) EmitNodeMethodPrototype(w io.Writer) {
+	emitNodeMethodPrototype_typical(w, g.AdjCfg, g)
+}
+
+func (g unionReprKeyedReprGenerator) EmitNodePrototypeType(w io.Writer) {
+	emitNodePrototypeType_typical(w, g.AdjCfg, g)
+}
+
+// --- NodeBuilder and NodeAssembler --->
+
+func (g unionReprKeyedReprGenerator) GetNodeBuilderGenerator() NodeBuilderGenerator {
+	return unionReprKeyedReprBuilderGenerator{
+		g.AdjCfg,
+		mixins.MapAssemblerTraits{
+			g.PkgName,
+			g.TypeName,
+			"_" + g.AdjCfg.TypeSymbol(g.Type) + "__Repr",
+		},
+		g.PkgName,
+		g.Type,
+	}
+}
+
+type unionReprKeyedReprBuilderGenerator struct {
+	AdjCfg *AdjunctCfg
+	mixins.MapAssemblerTraits
+	PkgName string
+	Type    schema.TypeUnion
+}
+
+func (unionReprKeyedReprBuilderGenerator) IsRepr() bool { return true } // hint used in some generalized templates.
+
+func (g unionReprKeyedReprBuilderGenerator) EmitNodeBuilderType(w io.Writer) {
+	emitEmitNodeBuilderType_typical(w, g.AdjCfg, g)
+}
+func (g unionReprKeyedReprBuilderGenerator) EmitNodeBuilderMethods(w io.Writer) {
+	emitNodeBuilderMethods_typical(w, g.AdjCfg, g)
+}
+func (g unionReprKeyedReprBuilderGenerator) EmitNodeAssemblerType(w io.Writer) {
+	// Nearly identical to the type-level system, except it embeds the Repr variant of child assemblers
+	//  (which is a very minor difference textually, but means this structure can end up with a pretty wildly different resident memory size than the type-level one).
+	doTemplate(`
+		type _{{ .Type | TypeSymbol }}__ReprAssembler struct {
+			w *_{{ .Type | TypeSymbol }}
+			m *schema.Maybe
+			state maState
+
+			cm schema.Maybe
+			{{- range $i, $member := .Type.Members }}
+			ca{{ add $i 1 }} {{ if (eq (dot.AdjCfg.UnionMemlayout dot.Type) "interface") }}*{{end}}_{{ $member | TypeSymbol }}__ReprAssembler
+			{{end -}}
+			ca uint
+		}
+	`, w, g.AdjCfg, g)
+
+	// Reset methods: also nearly identical to the type-level ones.
+	doTemplate(`
+		func (na *_{{ .Type | TypeSymbol }}__ReprAssembler) reset() {
+			na.state = maState_initial
+			switch na.ca {
+			case 0:
+				return
+			{{- range $i, $member := .Type.Members }}
+			case {{ add $i 1 }}:
+				na.ca{{ add $i 1 }}.reset()
+			{{end -}}
+			default:
+				panic("unreachable")
+			}
+			na.cm = schema.Maybe_Absent
+		}
+	`, w, g.AdjCfg, g)
+}
+func (g unionReprKeyedReprBuilderGenerator) EmitNodeAssemblerMethodBeginMap(w io.Writer) {
+	emitNodeAssemblerMethodBeginMap_strictoid(w, g.AdjCfg, g)
+}
+func (g unionReprKeyedReprBuilderGenerator) EmitNodeAssemblerMethodAssignNull(w io.Writer) {
+	// It might sound a bit odd to call a union "recursive", since it's so very trivially so (no fan-out),
+	//  but it's functionally accurate: the generated method should include a branch for the 'midvalue' state.
+	emitNodeAssemblerMethodAssignNull_recursive(w, g.AdjCfg, g)
+}
+func (g unionReprKeyedReprBuilderGenerator) EmitNodeAssemblerMethodAssignNode(w io.Writer) {
+	// DRY: this is once again not-coincidentally very nearly equal to the type-level method.  Would be good to dedup them... after we do the get-to-the-point-in-phase-3 improvement.
+	doTemplate(`
+		func (na *_{{ .Type | TypeSymbol }}__ReprAssembler) AssignNode(v ipld.Node) error {
+			if v.IsNull() {
+				return na.AssignNull()
+			}
+			if v2, ok := v.(*_{{ .Type | TypeSymbol }}); ok {
+				switch *na.m {
+				case schema.Maybe_Value, schema.Maybe_Null:
+					panic("invalid state: cannot assign into assembler that's already finished")
+				case midvalue:
+					panic("invalid state: cannot assign null into an assembler that's already begun working on recursive structures!")
+				}
+				{{- if .Type | MaybeUsesPtr }}
+				if na.w == nil {
+					na.w = v2
+					*na.m = schema.Maybe_Value
+					return nil
+				}
+				{{- end}}
+				*na.w = *v2
+				*na.m = schema.Maybe_Value
+				return nil
+			}
+			if v.ReprKind() != ipld.ReprKind_Map {
+				return ipld.ErrWrongKind{TypeName: "{{ .PkgName }}.{{ .Type.Name }}.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+			}
+			itr := v.MapIterator()
+			for !itr.Done() {
+				k, v, err := itr.Next()
+				if err != nil {
+					return err
+				}
+				if err := na.AssembleKey().AssignNode(k); err != nil {
+					return err
+				}
+				if err := na.AssembleValue().AssignNode(v); err != nil {
+					return err
+				}
+			}
+			return na.Finish()
+		}
+	`, w, g.AdjCfg, g)
+}
+func (g unionReprKeyedReprBuilderGenerator) EmitNodeAssemblerOtherBits(w io.Writer) {
+	g.emitMapAssemblerChildTidyHelper(w)
+	g.emitMapAssemblerMethods(w)
+	g.emitKeyAssembler(w)
+}
+func (g unionReprKeyedReprBuilderGenerator) emitMapAssemblerChildTidyHelper(w io.Writer) {
+	// Nearly identical to the type-level equivalent.
+	doTemplate(`
+		func (ma *_{{ .Type | TypeSymbol }}__ReprAssembler) valueFinishTidy() bool {
+			switch ma.cm {
+			case schema.Maybe_Value:
+				{{- /* nothing to do for memlayout=embedAll; the tag is already set and memory already in place. */ -}}
+				{{- /* nothing to do for memlayout=interface either; same story, the values are already in place. */ -}}
+				ma.state = maState_initial
+				return true
+			default:
+				return false
+			}
+		}
+	`, w, g.AdjCfg, g)
+}
+func (g unionReprKeyedReprBuilderGenerator) emitMapAssemblerMethods(w io.Writer) {
+	// All of these: shamelessly similar to the type-level equivalent, modulo a few appearances of "Repr".
+	//  Alright, and also the "discriminant values as keys instead of the member type names" thing.
+	// DRY: the number of times these `ma.state` switches are appearing is truly intense!  This is starting to look like one of them most important things to shrink the GSLOC/ASM size of!
+
+	doTemplate(`
+		func (ma *_{{ .Type | TypeSymbol }}__ReprAssembler) AssembleEntry(k string) (ipld.NodeAssembler, error) {
+			switch ma.state {
+			case maState_initial:
+				// carry on
+			case maState_midKey:
+				panic("invalid state: AssembleEntry cannot be called when in the middle of assembling another key")
+			case maState_expectValue:
+				panic("invalid state: AssembleEntry cannot be called when expecting start of value assembly")
+			case maState_midValue:
+				if !ma.valueFinishTidy() {
+					panic("invalid state: AssembleEntry cannot be called when in the middle of assembling a value")
+				} // if tidy success: carry on for the moment, but we'll still be erroring shortly.
+			case maState_finished:
+				panic("invalid state: AssembleEntry cannot be called on an assembler that's already finished")
+			}
+			if ma.ca != 0 {
+				return nil, schema.ErrNotUnionStructure{TypeName:"{{ .PkgName }}.{{ .Type.Name }}.Repr", Detail: "cannot add another entry -- a union can only contain one thing!"}
+			}
+			switch k {
+			{{- range $i, $member := .Type.Members }}
+			case "{{ $member | dot.Type.RepresentationStrategy.GetDiscriminant }}":
+				ma.state = maState_midValue
+				ma.ca = {{ add $i 1 }}
+				{{- if (eq (dot.AdjCfg.UnionMemlayout dot.Type) "embedAll") }}
+				ma.w.tag = {{ add $i 1 }}
+				ma.ca{{ add $i 1 }}.w = &ma.w.x{{ add $i 1 }}
+				ma.ca{{ add $i 1 }}.m = &ma.cm
+				return &ma.ca{{ add $i 1 }}, nil
+				{{- else if (eq (dot.AdjCfg.UnionMemlayout dot.Type) "interface") }}
+				x := &_{{ $member | TypeSymbol }}{}
+				ma.w.x = x
+				if ma.ca{{ add $i 1 }} == nil {
+					ma.ca{{ add $i 1 }} = &_{{ $member | TypeSymbol }}__Assembler{}
+				}
+				ma.ca{{ add $i 1 }}.w = x
+				ma.ca{{ add $i 1 }}.m = &ma.cm
+				return ma.ca{{ add $i 1 }}, nil
+				{{- end}}
+			{{- end}}
+			default:
+				return nil, ipld.ErrInvalidKey{TypeName:"{{ .PkgName }}.{{ .Type.Name }}.Repr", Key:&_String{k}}
+			}
+		}
+	`, w, g.AdjCfg, g)
+
+	doTemplate(`
+		func (ma *_{{ .Type | TypeSymbol }}__ReprAssembler) AssembleKey() ipld.NodeAssembler {
+			switch ma.state {
+			case maState_initial:
+				// carry on
+			case maState_midKey:
+				panic("invalid state: AssembleKey cannot be called when in the middle of assembling another key")
+			case maState_expectValue:
+				panic("invalid state: AssembleKey cannot be called when expecting start of value assembly")
+			case maState_midValue:
+				if !ma.valueFinishTidy() {
+					panic("invalid state: AssembleKey cannot be called when in the middle of assembling a value")
+				} // if tidy success: carry on for the moment, but we'll still be erroring shortly... or rather, the keyassembler will be.
+			case maState_finished:
+				panic("invalid state: AssembleKey cannot be called on an assembler that's already finished")
+			}
+			ma.state = maState_midKey
+			return (*_{{ .Type | TypeSymbol }}__ReprKeyAssembler)(ma)
+		}
+	`, w, g.AdjCfg, g)
+
+	doTemplate(`
+		func (ma *_{{ .Type | TypeSymbol }}__ReprAssembler) AssembleValue() ipld.NodeAssembler {
+			switch ma.state {
+			case maState_initial:
+				panic("invalid state: AssembleValue cannot be called when no key is primed")
+			case maState_midKey:
+				panic("invalid state: AssembleValue cannot be called when in the middle of assembling a key")
+			case maState_expectValue:
+				// carry on
+			case maState_midValue:
+				panic("invalid state: AssembleValue cannot be called when in the middle of assembling another value")
+			case maState_finished:
+				panic("invalid state: AssembleValue cannot be called on an assembler that's already finished")
+			}
+			ma.state = maState_midValue
+			switch ma.ca {
+			{{- range $i, $member := .Type.Members }}
+			case {{ $i }}:
+				{{- if (eq (dot.AdjCfg.UnionMemlayout dot.Type) "embedAll") }}
+				ma.ca{{ add $i 1 }}.w = &ma.w.x{{ add $i 1 }}
+				ma.ca{{ add $i 1 }}.m = &ma.cm
+				return &ma.ca{{ add $i 1 }}
+				{{- else if (eq (dot.AdjCfg.UnionMemlayout dot.Type) "interface") }}
+				x := &_{{ $member | TypeSymbol }}{}
+				ma.w.x = x
+				if ma.ca{{ add $i 1 }} == nil {
+					ma.ca{{ add $i 1 }} = &_{{ $member | TypeSymbol }}__ReprAssembler{}
+				}
+				ma.ca{{ add $i 1 }}.w = x
+				ma.ca{{ add $i 1 }}.m = &ma.cm
+				return ma.ca{{ add $i 1 }}
+				{{- end}}
+			{{- end}}
+			default:
+				panic("unreachable")
+			}
+		}
+	`, w, g.AdjCfg, g)
+
+	doTemplate(`
+		func (ma *_{{ .Type | TypeSymbol }}__ReprAssembler) Finish() error {
+			switch ma.state {
+			case maState_initial:
+				// carry on
+			case maState_midKey:
+				panic("invalid state: Finish cannot be called when in the middle of assembling a key")
+			case maState_expectValue:
+				panic("invalid state: Finish cannot be called when expecting start of value assembly")
+			case maState_midValue:
+				if !ma.valueFinishTidy() {
+					panic("invalid state: Finish cannot be called when in the middle of assembling a value")
+				} // if tidy success: carry on
+			case maState_finished:
+				panic("invalid state: Finish cannot be called on an assembler that's already finished")
+			}
+			if ma.ca == 0 {
+				return schema.ErrNotUnionStructure{TypeName:"{{ .PkgName }}.{{ .Type.Name }}.Repr", Detail: "a union must have exactly one entry (not none)!"}
+			}
+			ma.state = maState_finished
+			*ma.m = schema.Maybe_Value
+			return nil
+		}
+	`, w, g.AdjCfg, g)
+
+	doTemplate(`
+		func (ma *_{{ .Type | TypeSymbol }}__ReprAssembler) KeyPrototype() ipld.NodePrototype {
+			return _String__Prototype{}
+		}
+		func (ma *_{{ .Type | TypeSymbol }}__ReprAssembler) ValuePrototype(k string) ipld.NodePrototype {
+			switch k {
+			{{- range $i, $member := .Type.Members }}
+			case "{{ $member.Name }}":
+				return _{{ $member | TypeSymbol }}__ReprPrototype{}
+			{{- end}}
+			default:
+				panic("FIXME oh dear the possibility of this method erroring was not accounted for yet")
+			}
+		}
+	`, w, g.AdjCfg, g)
+}
+func (g unionReprKeyedReprBuilderGenerator) emitKeyAssembler(w io.Writer) {
+	doTemplate(`
+		type _{{ .Type | TypeSymbol }}__ReprKeyAssembler _{{ .Type | TypeSymbol }}__ReprAssembler
+	`, w, g.AdjCfg, g)
+	stubs := mixins.StringAssemblerTraits{
+		g.PkgName,
+		g.TypeName + ".KeyAssembler", // ".Repr" is already in `g.TypeName`, so don't stutter the "Repr" part.
+		"_" + g.AdjCfg.TypeSymbol(g.Type) + "__ReprKey",
+	}
+	// This key assembler can disregard any idea of complex keys because we know that our discriminants are just strings!
+	stubs.EmitNodeAssemblerMethodBeginMap(w)
+	stubs.EmitNodeAssemblerMethodBeginList(w)
+	stubs.EmitNodeAssemblerMethodAssignNull(w)
+	stubs.EmitNodeAssemblerMethodAssignBool(w)
+	stubs.EmitNodeAssemblerMethodAssignInt(w)
+	stubs.EmitNodeAssemblerMethodAssignFloat(w)
+	doTemplate(`
+		func (ka *_{{ .Type | TypeSymbol }}__ReprKeyAssembler) AssignString(k string) error {
+			if ka.state != maState_midKey {
+				panic("misuse: KeyAssembler held beyond its valid lifetime")
+			}
+			if ka.ca != 0 {
+				return schema.ErrNotUnionStructure{TypeName:"{{ .PkgName }}.{{ .Type.Name }}.Repr", Detail: "cannot add another entry -- a union can only contain one thing!"}
+			}
+			switch k {
+			{{- range $i, $member := .Type.Members }}
+			case "{{ $member | dot.Type.RepresentationStrategy.GetDiscriminant }}":
+				ka.ca = {{ add $i 1 }}
+				{{- if (eq (dot.AdjCfg.UnionMemlayout dot.Type) "embedAll") }}
+				ka.w.tag = {{ add $i 1 }}
+				{{- end}}
+				ka.state = maState_expectValue
+				return nil
+			{{- end}}
+			default:
+				return ipld.ErrInvalidKey{TypeName:"{{ .PkgName }}.{{ .Type.Name }}.Repr", Key:&_String{k}} // TODO: error quality: ErrInvalidUnionDiscriminant ?
+			}
+			return nil
+		}
+	`, w, g.AdjCfg, g)
+	stubs.EmitNodeAssemblerMethodAssignBytes(w)
+	stubs.EmitNodeAssemblerMethodAssignLink(w)
+	doTemplate(`
+		func (ka *_{{ .Type | TypeSymbol }}__ReprKeyAssembler) AssignNode(v ipld.Node) error {
+			if v2, err := v.AsString(); err != nil {
+				return err
+			} else {
+				return ka.AssignString(v2)
+			}
+		}
+		func (_{{ .Type | TypeSymbol }}__ReprKeyAssembler) Prototype() ipld.NodePrototype {
+			return _String__Prototype{}
+		}
+	`, w, g.AdjCfg, g)
 }

--- a/schema/gen/go/generate.go
+++ b/schema/gen/go/generate.go
@@ -44,6 +44,8 @@ func Generate(pth string, pkgName string, ts schema.TypeSystem, adjCfg *AdjunctC
 				EmitEntireType(NewMapReprMapGenerator(pkgName, t2, adjCfg), f)
 			case schema.TypeList:
 				EmitEntireType(NewListReprListGenerator(pkgName, t2, adjCfg), f)
+			case schema.TypeUnion:
+				panic("this ain't done yet :) you can't do the synthesis until the end, sadly")
 			default:
 				panic("add more type switches here :)")
 			}

--- a/schema/gen/go/generate.go
+++ b/schema/gen/go/generate.go
@@ -45,7 +45,12 @@ func Generate(pth string, pkgName string, ts schema.TypeSystem, adjCfg *AdjunctC
 			case schema.TypeList:
 				EmitEntireType(NewListReprListGenerator(pkgName, t2, adjCfg), f)
 			case schema.TypeUnion:
-				panic("this ain't done yet :) you can't do the synthesis until the end, sadly")
+				switch t2.RepresentationStrategy().(type) {
+				case schema.UnionRepresentation_Keyed:
+					EmitEntireType(NewUnionReprKeyedGenerator(pkgName, t2, adjCfg), f)
+				default:
+					panic("unrecognized union representation strategy")
+				}
 			default:
 				panic("add more type switches here :)")
 			}

--- a/schema/gen/go/genpartsStrictoid.go
+++ b/schema/gen/go/genpartsStrictoid.go
@@ -1,0 +1,35 @@
+package gengo
+
+import (
+	"io"
+)
+
+// What's "strictoid" mean?  Anything that's recursive but not infinite -- so structs, unions.
+
+// This form of BeginMap method is reusable for anything that has fixed size and thus ignores sizehint.
+// That means: structs, unions, and their relevant representations.
+func emitNodeAssemblerMethodBeginMap_strictoid(w io.Writer, adjCfg *AdjunctCfg, data interface{}) {
+	// We currently disregard sizeHint.  It's not relevant to us.
+	//  We could check it strictly and emit errors; presently, we don't.
+	// This method contains a branch to support MaybeUsesPtr because new memory may need to be allocated.
+	//  This allocation only happens if the 'w' ptr is nil, which means we're being used on a Maybe;
+	//  otherwise, the 'w' ptr should already be set, and we fill that memory location without allocating, as usual.
+	//  (Note that the Maybe we're talking about here is for us, not our children: so it applies on unions too.)
+	doTemplate(`
+		func (na *_{{ .Type | TypeSymbol }}__{{ if .IsRepr }}Repr{{end}}Assembler) BeginMap(int) (ipld.MapAssembler, error) {
+			switch *na.m {
+			case schema.Maybe_Value, schema.Maybe_Null:
+				panic("invalid state: cannot assign into assembler that's already finished")
+			case midvalue:
+				panic("invalid state: it makes no sense to 'begin' twice on the same assembler!")
+			}
+			*na.m = midvalue
+			{{- if .Type | MaybeUsesPtr }}
+			if na.w == nil {
+				na.w = &_{{ .Type | TypeSymbol }}{}
+			}
+			{{- end}}
+			return na, nil
+		}
+	`, w, adjCfg, data)
+}

--- a/schema/gen/go/templateUtil.go
+++ b/schema/gen/go/templateUtil.go
@@ -13,10 +13,18 @@ import (
 func doTemplate(tmplstr string, w io.Writer, adjCfg *AdjunctCfg, data interface{}) {
 	tmpl := template.Must(template.New("").
 		Funcs(template.FuncMap{
+
+			// These methods are used for symbol munging and appear constantly, so they need to be short.
+			//  (You could also get at them through `.AdjCfg`, but going direct saves some screen real estate.)
 			"TypeSymbol":       adjCfg.TypeSymbol,
 			"FieldSymbolLower": adjCfg.FieldSymbolLower,
 			"FieldSymbolUpper": adjCfg.FieldSymbolUpper,
 			"MaybeUsesPtr":     adjCfg.MaybeUsesPtr,
+
+			// The whole AdjunctConfig can be accessed.
+			//  Access methods like UnionMemlayout through this, as e.g. `.AdjCfg.UnionMemlayout`.
+			"AdjCfg": func() *AdjunctCfg { return adjCfg },
+
 			"KindPrim": func(k ipld.ReprKind) string {
 				switch k {
 				case ipld.ReprKind_Map:

--- a/schema/gen/go/templateUtil.go
+++ b/schema/gen/go/templateUtil.go
@@ -25,6 +25,11 @@ func doTemplate(tmplstr string, w io.Writer, adjCfg *AdjunctCfg, data interface{
 			//  Access methods like UnionMemlayout through this, as e.g. `.AdjCfg.UnionMemlayout`.
 			"AdjCfg": func() *AdjunctCfg { return adjCfg },
 
+			// "dot" is a dummy value that's equal to the original `.` expression, but stays there.
+			//  Use this if you're inside a range or other feature that shifted the dot and you want the original.
+			//  (This may seem silly, but empirically, I found myself writing a dummy line to store the value of dot before endering a range clause >20 times; that's plenty.)
+			"dot": func() interface{} { return data },
+
 			"KindPrim": func(k ipld.ReprKind) string {
 				switch k {
 				case ipld.ReprKind_Map:
@@ -52,10 +57,6 @@ func doTemplate(tmplstr string, w io.Writer, adjCfg *AdjunctCfg, data interface{
 			"add":   func(a, b int) int { return a + b },
 			"title": func(s string) string { return strings.Title(s) },
 		}).
-		// Seriously consider prepending `{{ $dot := . }}` (or 'top', or something).
-		// Or a func into the map that causes `dot` to mean `func() interface{} { return data }`.
-		// The number of times that the range feature has a dummy capture line above it is... not reasonable.
-		//  (Grep for "/* ranging modifies dot, unhelpfully */" -- empirically, it's over 20 times already.)
 		Parse(wish.Dedent(tmplstr)))
 	if err := tmpl.Execute(w, data); err != nil {
 		panic(err)

--- a/schema/gen/go/testUnions_test.go
+++ b/schema/gen/go/testUnions_test.go
@@ -1,0 +1,64 @@
+package gengo
+
+import (
+	"testing"
+
+	. "github.com/warpfork/go-wish"
+
+	"github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/fluent"
+	"github.com/ipld/go-ipld-prime/must"
+	"github.com/ipld/go-ipld-prime/schema"
+)
+
+func TestUnionPoke(t *testing.T) {
+	t.Skip("not implemented yet")
+
+	ts := schema.TypeSystem{}
+	ts.Init()
+	adjCfg := &AdjunctCfg{
+		maybeUsesPtr: map[schema.TypeName]bool{},
+	}
+	ts.Accumulate(schema.SpawnString("String"))
+	ts.Accumulate(schema.SpawnString("Strung"))
+	ts.Accumulate(schema.SpawnUnion("StrStr",
+		[]schema.Type{
+			ts.TypeByName("String"),
+			ts.TypeByName("Strung"),
+		},
+		schema.SpawnUnionRepresentationKeyed(map[string]schema.Type{
+			"a": ts.TypeByName("String"),
+			"b": ts.TypeByName("Strung"),
+		},
+		)))
+
+	prefix := "union-keyed"
+	pkgName := "main"
+	genAndCompileAndTest(t, prefix, pkgName, ts, adjCfg, func(t *testing.T, getPrototypeByName func(string) ipld.NodePrototype) {
+		np := getPrototypeByName("StrStr")
+		nrp := getPrototypeByName("StrStr.Repr")
+		var n schema.TypedNode
+		t.Run("typed-create", func(t *testing.T) {
+			n = fluent.MustBuildMap(np, 1, func(na fluent.MapAssembler) {
+				na.AssembleEntry("Strung").AssignString("whee")
+			}).(schema.TypedNode)
+			t.Run("typed-read", func(t *testing.T) {
+				Require(t, n.ReprKind(), ShouldEqual, ipld.ReprKind_Map)
+				Wish(t, n.Length(), ShouldEqual, 1)
+				Wish(t, must.String(must.Node(n.LookupByString("Strung"))), ShouldEqual, "whee")
+			})
+			t.Run("repr-read", func(t *testing.T) {
+				nr := n.Representation()
+				Require(t, nr.ReprKind(), ShouldEqual, ipld.ReprKind_Map)
+				Wish(t, nr.Length(), ShouldEqual, 1)
+				Wish(t, must.String(must.Node(n.LookupByString("b"))), ShouldEqual, "whee")
+			})
+		})
+		t.Run("repr-create", func(t *testing.T) {
+			nr := fluent.MustBuildMap(nrp, 2, func(na fluent.MapAssembler) {
+				na.AssembleEntry("b").AssignString("whee")
+			})
+			Wish(t, n, ShouldEqual, nr)
+		})
+	})
+}

--- a/schema/gen/go/testUnions_test.go
+++ b/schema/gen/go/testUnions_test.go
@@ -11,14 +11,10 @@ import (
 	"github.com/ipld/go-ipld-prime/schema"
 )
 
-func TestUnionPoke(t *testing.T) {
-	t.Skip("not implemented yet")
-
+func TestUnionKeyed(t *testing.T) {
 	ts := schema.TypeSystem{}
 	ts.Init()
-	adjCfg := &AdjunctCfg{
-		maybeUsesPtr: map[schema.TypeName]bool{},
-	}
+	adjCfg := &AdjunctCfg{}
 	ts.Accumulate(schema.SpawnString("String"))
 	ts.Accumulate(schema.SpawnString("Strung"))
 	ts.Accumulate(schema.SpawnUnion("StrStr",
@@ -32,9 +28,7 @@ func TestUnionPoke(t *testing.T) {
 		},
 		)))
 
-	prefix := "union-keyed"
-	pkgName := "main"
-	genAndCompileAndTest(t, prefix, pkgName, ts, adjCfg, func(t *testing.T, getPrototypeByName func(string) ipld.NodePrototype) {
+	test := func(t *testing.T, getPrototypeByName func(string) ipld.NodePrototype) {
 		np := getPrototypeByName("StrStr")
 		nrp := getPrototypeByName("StrStr.Repr")
 		var n schema.TypedNode
@@ -59,6 +53,27 @@ func TestUnionPoke(t *testing.T) {
 				na.AssembleEntry("b").AssignString("whee")
 			})
 			Wish(t, n, ShouldEqual, nr)
+		})
+	}
+
+	t.Skip("not yet finished") // mostly there -- all the templates work.  can't compile until we finish all the builders.
+
+	t.Run("union-using-embed", func(t *testing.T) {
+		adjCfg.unionMemlayout = map[schema.TypeName]string{"StrStr": "embedAll"}
+
+		prefix := "union-keyed-using-embed"
+		pkgName := "main"
+		genAndCompileAndTest(t, prefix, pkgName, ts, adjCfg, func(t *testing.T, getPrototypeByName func(string) ipld.NodePrototype) {
+			test(t, getPrototypeByName)
+		})
+	})
+	t.Run("union-using-interface", func(t *testing.T) {
+		adjCfg.unionMemlayout = map[schema.TypeName]string{"StrStr": "interface"}
+
+		prefix := "union-keyed-using-interface"
+		pkgName := "main"
+		genAndCompileAndTest(t, prefix, pkgName, ts, adjCfg, func(t *testing.T, getPrototypeByName func(string) ipld.NodePrototype) {
+			test(t, getPrototypeByName)
 		})
 	})
 }

--- a/schema/gen/go/testUnions_test.go
+++ b/schema/gen/go/testUnions_test.go
@@ -25,8 +25,8 @@ func TestUnionKeyed(t *testing.T) {
 		schema.SpawnUnionRepresentationKeyed(map[string]schema.Type{
 			"a": ts.TypeByName("String"),
 			"b": ts.TypeByName("Strung"),
-		},
-		)))
+		}),
+	))
 
 	test := func(t *testing.T, getPrototypeByName func(string) ipld.NodePrototype) {
 		np := getPrototypeByName("StrStr")
@@ -45,7 +45,7 @@ func TestUnionKeyed(t *testing.T) {
 				nr := n.Representation()
 				Require(t, nr.ReprKind(), ShouldEqual, ipld.ReprKind_Map)
 				Wish(t, nr.Length(), ShouldEqual, 1)
-				Wish(t, must.String(must.Node(n.LookupByString("b"))), ShouldEqual, "whee")
+				Wish(t, must.String(must.Node(nr.LookupByString("b"))), ShouldEqual, "whee")
 			})
 		})
 		t.Run("repr-create", func(t *testing.T) {
@@ -55,8 +55,6 @@ func TestUnionKeyed(t *testing.T) {
 			Wish(t, n, ShouldEqual, nr)
 		})
 	}
-
-	t.Skip("not yet finished") // mostly there -- all the templates work.  can't compile until we finish all the builders.
 
 	t.Run("union-using-embed", func(t *testing.T) {
 		adjCfg.unionMemlayout = map[schema.TypeName]string{"StrStr": "embedAll"}

--- a/schema/tmpBuilders.go
+++ b/schema/tmpBuilders.go
@@ -68,6 +68,13 @@ func SpawnStructRepresentationStringjoin(delim string) StructRepresentation_Stri
 	return StructRepresentation_Stringjoin{delim}
 }
 
+func SpawnUnion(name TypeName, members []Type, repr UnionRepresentation) TypeUnion {
+	return TypeUnion{typeBase{name, nil}, members, repr}
+}
+func SpawnUnionRepresentationKeyed(table map[string]Type) UnionRepresentation_Keyed {
+	return UnionRepresentation_Keyed{table}
+}
+
 // The methods relating to TypeSystem are also mutation-heavy and placeholdery.
 
 func (ts *TypeSystem) Init() {

--- a/schema/tmpBuilders.go
+++ b/schema/tmpBuilders.go
@@ -9,6 +9,19 @@ package schema
 //
 // (Meanwhile, we're using these methods in the codegen prototypes.)
 
+// These methods use Type objects as parameters when pointing to other things,
+//  but this is... turning out consistently problematic.
+//   Even when we're doing this hacky direct-call doesn't-need-to-be-serializable temp stuff,
+//    as written, this doesn't actually let us express cyclic things viably!
+//   The same initialization questions are also going to come up again when we try to make
+//    concrete values in the output of codegen.
+// Maybe it's actually just a bad idea to have our reified Type types use Type pointers at all.
+//  (I will never get tired of the tongue twisters, evidently.)
+//  I'm not actually using that much, and it's always avoidable (it's trivial to replace with a map lookup bouncing through a 'ts' variable somewhere).
+//  And having the AST gen'd types be... just... the thing... sounds nice.  It could save a lot of work.
+//   (It would mean the golang types don't tell you whether the values have been checked for global properties or not, but, eh.)
+//   (It's not really compatible with "Prototype and Type are the same thing for codegen'd stuff", either (or, we need more interfaces, and to *really* lean into them), but maybe that's okay.)
+
 func SpawnString(name TypeName) TypeString {
 	return TypeString{typeBase{name, nil}}
 }

--- a/schema/tmpBuilders.go
+++ b/schema/tmpBuilders.go
@@ -10,36 +10,36 @@ package schema
 // (Meanwhile, we're using these methods in the codegen prototypes.)
 
 func SpawnString(name TypeName) TypeString {
-	return TypeString{anyType{name, nil}}
+	return TypeString{typeBase{name, nil}}
 }
 
 func SpawnInt(name TypeName) TypeInt {
-	return TypeInt{anyType{name, nil}}
+	return TypeInt{typeBase{name, nil}}
 }
 
 func SpawnBytes(name TypeName) TypeBytes {
-	return TypeBytes{anyType{name, nil}}
+	return TypeBytes{typeBase{name, nil}}
 }
 
 func SpawnLink(name TypeName) TypeLink {
-	return TypeLink{anyType{name, nil}, nil, false}
+	return TypeLink{typeBase{name, nil}, nil, false}
 }
 
 func SpawnLinkReference(name TypeName, referenceType Type) TypeLink {
-	return TypeLink{anyType{name, nil}, referenceType, true}
+	return TypeLink{typeBase{name, nil}, referenceType, true}
 }
 
 func SpawnList(name TypeName, typ Type, nullable bool) TypeList {
-	return TypeList{anyType{name, nil}, false, typ, nullable}
+	return TypeList{typeBase{name, nil}, false, typ, nullable}
 }
 
 func SpawnMap(name TypeName, keyType Type, valueType Type, nullable bool) TypeMap {
-	return TypeMap{anyType{name, nil}, false, keyType, valueType, nullable}
+	return TypeMap{typeBase{name, nil}, false, keyType, valueType, nullable}
 }
 
 func SpawnStruct(name TypeName, fields []StructField, repr StructRepresentation) TypeStruct {
 	v := TypeStruct{
-		anyType{name, nil},
+		typeBase{name, nil},
 		fields,
 		make(map[string]StructField, len(fields)),
 		repr,

--- a/schema/type.go
+++ b/schema/type.go
@@ -88,33 +88,33 @@ var (
 	_ Type = TypeEnum{}
 )
 
-type anyType struct {
+type typeBase struct {
 	name     TypeName
 	universe *TypeSystem
 }
 
 type TypeBool struct {
-	anyType
+	typeBase
 }
 
 type TypeString struct {
-	anyType
+	typeBase
 }
 
 type TypeBytes struct {
-	anyType
+	typeBase
 }
 
 type TypeInt struct {
-	anyType
+	typeBase
 }
 
 type TypeFloat struct {
-	anyType
+	typeBase
 }
 
 type TypeMap struct {
-	anyType
+	typeBase
 	anonymous     bool
 	keyType       Type // must be ReprKind==string (e.g. Type==String|Enum).
 	valueType     Type
@@ -122,21 +122,21 @@ type TypeMap struct {
 }
 
 type TypeList struct {
-	anyType
+	typeBase
 	anonymous     bool
 	valueType     Type
 	valueNullable bool
 }
 
 type TypeLink struct {
-	anyType
+	typeBase
 	referencedType    Type
 	hasReferencedType bool
 	// ...?
 }
 
 type TypeUnion struct {
-	anyType
+	typeBase
 	style        UnionStyle
 	valuesKinded map[ipld.ReprKind]Type // for Style==Kinded
 	values       map[string]Type        // for Style!=Kinded (note, key is freetext, not necessarily TypeName of the value)
@@ -154,7 +154,7 @@ var (
 )
 
 type TypeStruct struct {
-	anyType
+	typeBase
 	// n.b. `Fields` is an (order-preserving!) map in the schema-schema;
 	//  but it's a list here, with the keys denormalized into the value,
 	//   because that's typically how we use it.
@@ -186,7 +186,7 @@ type StructRepresentation_StringPairs struct{ sep1, sep2 string }
 type StructRepresentation_Stringjoin struct{ sep string }
 
 type TypeEnum struct {
-	anyType
+	typeBase
 	members []string
 }
 

--- a/schema/type.go
+++ b/schema/type.go
@@ -153,6 +153,11 @@ func (UnionRepresentation_Kinded) _UnionRepresentation()   {}
 func (UnionRepresentation_Envelope) _UnionRepresentation() {}
 func (UnionRepresentation_Inline) _UnionRepresentation()   {}
 
+// A bunch of these tables in union representation might be easier to use if flipped;
+//  we almost always index into them by type (since that's what we have an ordered list of);
+//  and they're unique in both directions, so it's equally valid either way.
+//  The order they're currently written in matches the serial form in the schema AST.
+
 type UnionRepresentation_Keyed struct {
 	table map[string]Type // key is user-defined freetext
 }

--- a/schema/typeMethods.go
+++ b/schema/typeMethods.go
@@ -77,6 +77,15 @@ func (t TypeUnion) RepresentationStrategy() UnionRepresentation {
 	return t.representation
 }
 
+func (r UnionRepresentation_Keyed) GetDiscriminant(t Type) string {
+	for d, t2 := range r.table {
+		if t2 == t {
+			return d
+		}
+	}
+	panic("that type isn't a member of this union")
+}
+
 // Fields returns a slice of descriptions of the object's fields.
 func (t TypeStruct) Fields() []StructField {
 	a := make([]StructField, len(t.fields))

--- a/schema/typeMethods.go
+++ b/schema/typeMethods.go
@@ -64,20 +64,17 @@ func (t TypeList) ValueIsNullable() bool {
 	return t.valueNullable
 }
 
-// UnionMembers returns a set of all the types that can inhabit this Union.
-func (t TypeUnion) UnionMembers() map[Type]struct{} {
-	m := make(map[Type]struct{}, len(t.values)+len(t.valuesKinded))
-	switch t.style {
-	case UnionStyle_Kinded:
-		for _, v := range t.valuesKinded {
-			m[v] = struct{}{}
-		}
-	default:
-		for _, v := range t.values {
-			m[v] = struct{}{}
-		}
+// Members returns the list of all types that are possible inhabitants of this union.
+func (t TypeUnion) Members() []Type {
+	a := make([]Type, len(t.members))
+	for i := range t.members {
+		a[i] = t.members[i]
 	}
-	return m
+	return a
+}
+
+func (t TypeUnion) RepresentationStrategy() UnionRepresentation {
+	return t.representation
 }
 
 // Fields returns a slice of descriptions of the object's fields.

--- a/schema/typeMethods.go
+++ b/schema/typeMethods.go
@@ -2,9 +2,9 @@ package schema
 
 /* cookie-cutter standard interface stuff */
 
-func (anyType) _Type()                    {}
-func (t anyType) TypeSystem() *TypeSystem { return t.universe }
-func (t anyType) Name() TypeName          { return t.name }
+func (typeBase) _Type()                    {}
+func (t typeBase) TypeSystem() *TypeSystem { return t.universe }
+func (t typeBase) Name() TypeName          { return t.name }
 
 func (TypeBool) Kind() Kind   { return Kind_Bool }
 func (TypeString) Kind() Kind { return Kind_String }


### PR DESCRIPTION
Unions!  :tada: 

Unions were one of the last major groups of functionality in the feature table that we had *no* codegen implementations of yet, so this is pretty huge news overall.  Nothing broke; no abstractions shattered.  Whew.  (Enums are the only thing left, but those are pretty easy-peasy.  Unions, being a container/recursive type kind rather than a leaf, were pretty heavy-duty.)

We have two things here, as always: the "type-level" and the "representation-level" implementations of the Node and NodeAssembler interfaces.

- the "type-level" Node for a Union always acts like a map, and the keys are always the names of the member Type.
- the "representation-level" Node behavior may (of course) vary, but for "keyed" representations... it's roughly the same as the type-level semantics; it's just that the keys are the strings defined by the schema author, rather than being the member type's name.

The "keyed" representations are the only representation implemented so far, as those are by far the easiest to ship, but adding the rest should just be a Small Matter of Programming.  (Which is not to say easy or instantaneous to scratch out, but at least it's not _theoretically_ challenging, nor likely to encounter Unknown Unknowns.)

Individual commits have more details in their messages.

---

Two styles of internal memory layout in the generated code are supported!  One is "embedAll"; the other is "interface".

- In "embedAll" memory layout, it... does what it say on the tin: all possible member types are embedded into the union type.  Only one of them is actually initialized with data; which one that is is marked by a 'tag' field which adds another word of memory.  Overall this means the resident memory size can be potentially rather large, but, the allocation count when using these is zero.  (If we had language-level support for "unions" that share memory in Golang, the resident memory size could be much less, as well.  Alas; this is not available (unless one resorts to 'unsafe', which as a general rule I avoid).)
- In "interface" memory layout, the generated golang structure for the union type will contain just one field, which is an interface.  The type info is thus in the golang native interface type info; simple.  These interfaces are smaller in resident memory (and probably the right choice by default), but in contrast to "embedAll", constructing them does necessarily cause heap allocations.

(All this talk about performance differences of these two memory layout strategies may sound theoretical!  And perhaps for applications that don't care about performance, that is true.  However, we do also have examples of both modes elsewhere in the go-ipld-prime codebase already, and they were absolutely the result of profiling which indicated it made a serious, make-or-break difference when those types were involved in "hot" loops.  Check out the `ipld.PathSegment` type, for example, which resembles the "embed" strategy.)

In either case, an interface type is also generated, so that if the user of the generated code wants to do a native type-switch of their own, they can call `AsInterface()` and proceed to do so.

---

There are still substantial "todos" regarding the quality of error handling.  The types used sometimes carry too much information, or too little; or the information that they carry is inconvenient (e.g. may require processing) to actually have on hand in some cases; and the general consistency of the error type ontology... well, isn't.  I've started accumulating more comments and notes about this, but a massive pass over the entire suite of relevant packages will be required at some point, once we've gathered enough experiences to make final strategic decisions about the subject.

(One example thought on the subject of errors is: perhaps we should start attaching NodePrototype values to them, and also introduce a Stringer requirement to that interface.  This would serve up type name info for typed/codegen'd nodes, while also being clearly defineable for untyped nodes; this would help resolve a lot of awkward sticking points currently showing up around error info handling.  But: this is a biggish change; it would live in its own PR.)

---

Looking forward...

In the the near future: one of the reasons having unions be generable now is that a lot of schemas have at least one of them... including, for example, the schema-schema itself (the "self-hosting" document that describes the schema information as a schema).  This means we're getting really close to being able to generate code that we could then use to parse our own schema ASTs!  That, in turn, would let us throw out a great deal of placeholder code which was waiting for this day; and also means we'd get e.g. JSON-unmarshalling of Schema info "for free"... which in turn will mean we're dang near ready to make an end-user CLI tool for all this codegen stuff that you can feed declarative schema documents into and go!

(... but, one step at a time.  First, it turns out we'll need to fix the "placeholder" schema info types one more time: it's not currently possible to construct values with "cycles" in them, and we actually need that to describe the schema-schema.  Heh.)

(... and, the schema-schema currently uses inline unions, as well as keyed unions.  I might actually change the schema-schema.  It would make boostrapping to self-hosting easier, yes.  But there are other reasons as well: I've become much more averse to inline unions through the course of this work, and seeing more and more closely how their performance will (necessarily!) suck.  I also suspect the ease-of-implementation of keyed unions will be a recurring theme for people building IPLD + Schema tooling in other languages, and therefore, making the schema-schema use only keyed unions will be a bootstrap simplifying move for them, too.  All in all, such a change seems likely worth pursuing.)

Tl;dr much more excitement soon to come :3