### PR TITLE
all: make 'go test ./...' pass on Go 1.15

### DIFF
--- a/codec/jst/jst_test.go
+++ b/codec/jst/jst_test.go
@@ -24,7 +24,7 @@ func TestSimple(t *testing.T) {
 	st := state{}
 	Wish(t, stride(&st, n), ShouldEqual, nil)
 	Wish(t, st.tables, ShouldEqual, map[tableGroupID]*table{
-		"path": &table{
+		"path": {
 			entryStyles: map[columnName]entryStyle{"path": entryStyle_column, "moduleName": entryStyle_column, "status": entryStyle_column},
 			keySize:     map[columnName]int{"path": 6, "moduleName": 12, "status": 8},
 			cols:        []columnName{"path", "moduleName", "status"},

--- a/codec/jst/util.go
+++ b/codec/jst/util.go
@@ -42,7 +42,7 @@ type codecAborted struct {
 }
 
 func (e codecAborted) Error() string {
-	return fmt.Sprintf("codec aborted: %s", e)
+	return fmt.Sprintf("codec aborted: %s", e.e)
 }
 
 // attempt to record where the codec efforts encountered an error.

--- a/errors.go
+++ b/errors.go
@@ -119,7 +119,7 @@ func (e ErrInvalidSegmentForList) Error() string {
 	if e.TypeName != "" {
 		v += " of type " + e.TypeName
 	}
-	return v + fmt.Sprintf(": %q: %s", e.TroubleSegment.s, e)
+	return v + fmt.Sprintf(": %q: %s", e.TroubleSegment.s, e.Reason)
 }
 
 // ErrUnmatchable is the catch-all type for parse errors in schema representation work.


### PR DESCRIPTION
There were two vet errors in two packages containing tests, resulting in
'go test' erroring out before any tests were run. Both were due to the
same reason - an Error method that ends up calling itself forever, thus
a panic.

While at it, 'gofmt -w -s' everything, which removes a redundant type.