### PR TITLE
linking/cid: check a previously unused error

### DIFF
--- a/codec/dagcbor/marshal.go
+++ b/codec/dagcbor/marshal.go
@@ -137,7 +137,7 @@ func marshal(n ipld.Node, tk *tok.Token, sink shared.TokenSink) error {
 			tk.Tagged = false
 			return err
 		default:
-			return fmt.Errorf("schemafree link emission only supported by this codec for CID type links!")
+			return fmt.Errorf("schemafree link emission only supported by this codec for CID type links")
 		}
 	default:
 		panic("unreachable")

--- a/codec/dagjson/marshal.go
+++ b/codec/dagjson/marshal.go
@@ -147,7 +147,7 @@ func Marshal(n ipld.Node, sink shared.TokenSink) error {
 			}
 			return nil
 		default:
-			return fmt.Errorf("schemafree link emission only supported by this codec for CID type links!")
+			return fmt.Errorf("schemafree link emission only supported by this codec for CID type links")
 		}
 	default:
 		panic("unreachable")

--- a/linking/cid/cidLink.go
+++ b/linking/cid/cidLink.go
@@ -84,6 +84,9 @@ func (lb LinkBuilder) Build(ctx context.Context, lnkCtx ipld.LinkContext, node i
 		return nil, err
 	}
 	cid, err := lb.Prefix.Sum(hasher.Bytes())
+	if err != nil {
+		return nil, err
+	}
 	lnk := Link{cid}
 	if err := commit(lnk); err != nil {
 		return lnk, err


### PR DESCRIPTION
As spotted by staticcheck. While at it, remove punctuation from another
couple of errors, as per
https://github.com/golang/go/wiki/CodeReviewComments#error-strings:

	Error strings should not be capitalized (unless beginning with
	proper nouns or acronyms) or end with punctuation, since they
	are usually printed following other context.