### PR TITLE
Update tests for unions; several fixes

### DIFF
--- a/schema/gen/go/genUnion.go
+++ b/schema/gen/go/genUnion.go
@@ -324,6 +324,7 @@ func (g unionBuilderGenerator) EmitNodeAssemblerType(w io.Writer) {
 			default:
 				panic("unreachable")
 			}
+			na.ca = 0
 			na.cm = schema.Maybe_Absent
 		}
 	`, w, g.AdjCfg, g)

--- a/schema/gen/go/genUnion.go
+++ b/schema/gen/go/genUnion.go
@@ -198,13 +198,13 @@ func (g unionGenerator) EmitNodeMethodMapIterator(w io.Writer) {
 			switch itr.n.tag {
 			{{- range $i, $member := .Type.Members }}
 			case {{ add $i 1 }}:
-				return &memberName__{{ dot.Type | TypeSymbol }}_{{ $member.Name }}, &itr.n.x{{ add $i 1 }}, nil
+				k, v = &memberName__{{ dot.Type | TypeSymbol }}_{{ $member.Name }}, &itr.n.x{{ add $i 1 }}
 			{{- end}}
 			{{- else if (eq (.AdjCfg.UnionMemlayout .Type) "interface") }}
 			switch n2 := itr.n.x.(type) {
 			{{- range $member := .Type.Members }}
 			case {{ $member | TypeSymbol }}:
-				return &memberName__{{ dot.Type | TypeSymbol }}_{{ $member.Name }}, n2, nil
+				k, v = &memberName__{{ dot.Type | TypeSymbol }}_{{ $member.Name }}, n2
 			{{- end}}
 			{{- end}}
 			default:

--- a/schema/gen/go/genUnionReprKeyed.go
+++ b/schema/gen/go/genUnionReprKeyed.go
@@ -235,6 +235,7 @@ func (g unionReprKeyedReprBuilderGenerator) EmitNodeAssemblerType(w io.Writer) {
 			default:
 				panic("unreachable")
 			}
+			na.ca = 0
 			na.cm = schema.Maybe_Absent
 		}
 	`, w, g.AdjCfg, g)

--- a/schema/gen/go/genUnionReprKeyed.go
+++ b/schema/gen/go/genUnionReprKeyed.go
@@ -136,13 +136,13 @@ func (g unionReprKeyedReprGenerator) EmitNodeMethodMapIterator(w io.Writer) {
 			switch itr.n.tag {
 			{{- range $i, $member := .Type.Members }}
 			case {{ add $i 1 }}:
-				return &memberName__{{ dot.Type | TypeSymbol }}_{{ $member.Name }}_serial, itr.n.x{{ add $i 1 }}.Representation(), nil
+				k, v = &memberName__{{ dot.Type | TypeSymbol }}_{{ $member.Name }}_serial, itr.n.x{{ add $i 1 }}.Representation()
 			{{- end}}
 			{{- else if (eq (.AdjCfg.UnionMemlayout .Type) "interface") }}
 			switch n2 := itr.n.x.(type) {
 			{{- range $member := .Type.Members }}
 			case {{ $member | TypeSymbol }}:
-				return &memberName__{{ dot.Type | TypeSymbol }}_{{ $member.Name }}_serial, n2.Representation(), nil
+				k, v = &memberName__{{ dot.Type | TypeSymbol }}_{{ $member.Name }}_serial, n2.Representation()
 			{{- end}}
 			{{- end}}
 			default:

--- a/schema/gen/go/genUnionReprKinded.go
+++ b/schema/gen/go/genUnionReprKinded.go
@@ -396,6 +396,7 @@ func (g unionReprKindedReprBuilderGenerator) EmitNodeAssemblerType(w io.Writer) 
 			default:
 				panic("unreachable")
 			}
+			na.ca = 0
 		}
 	`, w, g.AdjCfg, g)
 }


### PR DESCRIPTION
Update the tests targeting codegen'd unions to use the new test helper system introduced in https://github.com/ipld/go-ipld-prime/pull/66 .

The increased coverage found an infinite loop in iterators, so the fix for this is included.  Similarly, a bug in the assembler's reset mechanism was found, and is fixed.

With these two fixes, I'm also coincidentally able now able to use codegen'd unions in some pretty interesting larger demos without incident.  More news on that shortly ;)