### PR TITLE
WIP: schema/gen/go: make all top-level tests parallel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,9 @@ jobs:
       matrix:
         go-version: [1.14.x, 1.15.x]
         # TODO(mvdan): fix and enable windows
+        # TODO(mvdan): mac seems to timeout too often
         # os: [ubuntu-latest, macos-latest, windows-latest]
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Install Go

--- a/schema/gen/go/testLists_test.go
+++ b/schema/gen/go/testLists_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestListsContainingMaybe(t *testing.T) {
+	t.Parallel()
+
 	ts := schema.TypeSystem{}
 	ts.Init()
 	adjCfg := &AdjunctCfg{
@@ -121,6 +123,8 @@ func TestListsContainingMaybe(t *testing.T) {
 //   - that representation semantics are held correctly when we recurse, both in builders and in reading
 // To cover that latter situation, this depends on structs (so we can use rename directives on the representation to make it distinctive).
 func TestListsContainingLists(t *testing.T) {
+	t.Parallel()
+
 	ts := schema.TypeSystem{}
 	ts.Init()
 	adjCfg := &AdjunctCfg{

--- a/schema/gen/go/testMaps_test.go
+++ b/schema/gen/go/testMaps_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestMapsContainingMaybe(t *testing.T) {
+	t.Parallel()
+
 	ts := schema.TypeSystem{}
 	ts.Init()
 	adjCfg := &AdjunctCfg{
@@ -121,6 +123,8 @@ func TestMapsContainingMaybe(t *testing.T) {
 //   - that representation semantics are held correctly when we recurse, both in builders and in reading
 // To cover that latter situation, this depends on structs (so we can use rename directives on the representation to make it distinctive).
 func TestMapsContainingMaps(t *testing.T) {
+	t.Parallel()
+
 	ts := schema.TypeSystem{}
 	ts.Init()
 	adjCfg := &AdjunctCfg{
@@ -208,6 +212,8 @@ func TestMapsContainingMaps(t *testing.T) {
 }
 
 func TestMapsWithComplexKeys(t *testing.T) {
+	t.Parallel()
+
 	ts := schema.TypeSystem{}
 	ts.Init()
 	adjCfg := &AdjunctCfg{

--- a/schema/gen/go/testString_test.go
+++ b/schema/gen/go/testString_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestString(t *testing.T) {
+	t.Parallel()
+
 	ts := schema.TypeSystem{}
 	ts.Init()
 	adjCfg := &AdjunctCfg{

--- a/schema/gen/go/testStructNesting_test.go
+++ b/schema/gen/go/testStructNesting_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestStructNesting(t *testing.T) {
+	t.Parallel()
+
 	ts := schema.TypeSystem{}
 	ts.Init()
 	adjCfg := &AdjunctCfg{

--- a/schema/gen/go/testStructReprStringjoin_test.go
+++ b/schema/gen/go/testStructReprStringjoin_test.go
@@ -16,6 +16,8 @@ import (
 // These should pass even if the natural map representation doesn't.
 // No maybes are exercised.
 func TestStructReprStringjoin(t *testing.T) {
+	t.Parallel()
+
 	prefix := "structstrjoin"
 	pkgName := "main"
 

--- a/schema/gen/go/testStructReprTuple_test.go
+++ b/schema/gen/go/testStructReprTuple_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestStructReprTuple(t *testing.T) {
+	t.Parallel()
+
 	prefix := "structtuple"
 	pkgName := "main"
 

--- a/schema/gen/go/testStructsContainingMaybe_test.go
+++ b/schema/gen/go/testStructsContainingMaybe_test.go
@@ -15,6 +15,8 @@ import (
 // Both type-level generic build and access as well as representation build and access are exercised;
 // the representation used is map (the native representation for structs).
 func TestStructsContainingMaybe(t *testing.T) {
+	t.Parallel()
+
 	// Type declarations.
 	//  The tests here will all be targetted against this "Stroct" type.
 	ts := schema.TypeSystem{}

--- a/schema/gen/go/testUnionsKinded_test.go
+++ b/schema/gen/go/testUnionsKinded_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestUnionKinded(t *testing.T) {
+	t.Parallel()
+
 	ts := schema.TypeSystem{}
 	ts.Init()
 	adjCfg := &AdjunctCfg{}

--- a/schema/gen/go/testUnions_test.go
+++ b/schema/gen/go/testUnions_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestUnionKeyed(t *testing.T) {
+	t.Parallel()
+
 	ts := schema.TypeSystem{}
 	ts.Init()
 	adjCfg := &AdjunctCfg{}
@@ -84,6 +86,8 @@ func TestUnionKeyed(t *testing.T) {
 // the ReprAssemblers are actually aliases of the type-level Assemblers!
 // Aaaand that makes a few things "work" by coincidence that wouldn't otherwise fly.
 func TestUnionKeyedComplexChildren(t *testing.T) {
+	t.Parallel()
+
 	ts := schema.TypeSystem{}
 	ts.Init()
 	adjCfg := &AdjunctCfg{}


### PR DESCRIPTION
They do quite a lot of work, including setting up a type system,
generating Go code, and building it.

This package is by far the slowest to test. On a warm cache, 'go test
-count=1 ./...' shows all packages under 0.2s, while this one sits at
~1.5s.

1.5s is not unreasonable with a warm cache, but we can bring that down
to 0.6s on my quad-core laptop by just making all tests parallel. Note
that sub-tests aren't parallel for now, since there are multiple layers
of them and I'm not sure I even follow what's going on.