### PR TITLE
all: don't use buffers where readers suffice

### DIFF
--- a/codec/dagcbor/roundtripCidlink_test.go
+++ b/codec/dagcbor/roundtripCidlink_test.go
@@ -33,7 +33,7 @@ func TestRoundtripCidlink(t *testing.T) {
 	nb := basicnode.Prototype__Any{}.NewBuilder()
 	err = lnk.Load(context.Background(), ipld.LinkContext{}, nb,
 		func(lnk ipld.Link, _ ipld.LinkContext) (io.Reader, error) {
-			return bytes.NewBuffer(buf.Bytes()), nil
+			return bytes.NewReader(buf.Bytes()), nil
 		},
 	)
 	Require(t, err, ShouldEqual, nil)

--- a/codec/dagcbor/roundtrip_test.go
+++ b/codec/dagcbor/roundtrip_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/rand"
 	"io"
+	"strings"
 	"testing"
 
 	cid "github.com/ipfs/go-cid"
@@ -42,7 +43,7 @@ func TestRoundtrip(t *testing.T) {
 		Wish(t, buf.String(), ShouldEqual, serial)
 	})
 	t.Run("decoding", func(t *testing.T) {
-		buf := bytes.NewBufferString(serial)
+		buf := strings.NewReader(serial)
 		nb := basicnode.Prototype__Map{}.NewBuilder()
 		err := Decoder(nb, buf)
 		Require(t, err, ShouldEqual, nil)
@@ -61,7 +62,7 @@ func TestRoundtripScalar(t *testing.T) {
 		Wish(t, buf.String(), ShouldEqual, `japplesauce`)
 	})
 	t.Run("decoding", func(t *testing.T) {
-		buf := bytes.NewBufferString(`japplesauce`)
+		buf := strings.NewReader(`japplesauce`)
 		nb := basicnode.Prototype__String{}.NewBuilder()
 		err := Decoder(nb, buf)
 		Require(t, err, ShouldEqual, nil)

--- a/codec/dagjson/roundtripCidlink_test.go
+++ b/codec/dagjson/roundtripCidlink_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"io"
 	"io/ioutil"
+	"strings"
 	"testing"
 
 	. "github.com/warpfork/go-wish"
@@ -34,7 +35,7 @@ func TestRoundtripCidlink(t *testing.T) {
 	nb := basicnode.Prototype__Any{}.NewBuilder()
 	err = lnk.Load(context.Background(), ipld.LinkContext{}, nb,
 		func(lnk ipld.Link, _ ipld.LinkContext) (io.Reader, error) {
-			return bytes.NewBuffer(buf.Bytes()), nil
+			return bytes.NewReader(buf.Bytes()), nil
 		},
 	)
 	Require(t, err, ShouldEqual, nil)
@@ -64,7 +65,7 @@ func TestUnmarshalTrickyMapContainingLink(t *testing.T) {
 
 	// Unmarshal.  Hopefully we get a map with a link in it.
 	nb := basicnode.Prototype__Any{}.NewBuilder()
-	err = Decoder(nb, bytes.NewBufferString(tricky))
+	err = Decoder(nb, strings.NewReader(tricky))
 	Require(t, err, ShouldEqual, nil)
 	n := nb.Build()
 	Wish(t, n.ReprKind(), ShouldEqual, ipld.ReprKind_Map)

--- a/codec/dagjson/roundtrip_test.go
+++ b/codec/dagjson/roundtrip_test.go
@@ -2,6 +2,7 @@ package dagjson
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 
 	. "github.com/warpfork/go-wish"
@@ -52,7 +53,7 @@ func TestRoundtrip(t *testing.T) {
 		Wish(t, buf.String(), ShouldEqual, serial)
 	})
 	t.Run("decoding", func(t *testing.T) {
-		buf := bytes.NewBufferString(serial)
+		buf := strings.NewReader(serial)
 		nb := basicnode.Prototype__Map{}.NewBuilder()
 		err := Decoder(nb, buf)
 		Require(t, err, ShouldEqual, nil)
@@ -71,7 +72,7 @@ func TestRoundtripScalar(t *testing.T) {
 		Wish(t, buf.String(), ShouldEqual, `"applesauce"`)
 	})
 	t.Run("decoding", func(t *testing.T) {
-		buf := bytes.NewBufferString(`"applesauce"`)
+		buf := strings.NewReader(`"applesauce"`)
 		nb := basicnode.Prototype__String{}.NewBuilder()
 		err := Decoder(nb, buf)
 		Require(t, err, ShouldEqual, nil)

--- a/codec/jst/demo/main.go
+++ b/codec/jst/demo/main.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"bytes"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/ipld/go-ipld-prime/codec/dagjson"
 	"github.com/ipld/go-ipld-prime/codec/jst"
@@ -23,7 +23,7 @@ func main() {
 		  ]}
 	]`
 	nb := basicnode.Prototype.Any.NewBuilder()
-	if err := dagjson.Decoder(nb, bytes.NewBufferString(fixture)); err != nil {
+	if err := dagjson.Decoder(nb, strings.NewReader(fixture)); err != nil {
 		panic(err)
 	}
 	n := nb.Build()

--- a/codec/jst/jst_test.go
+++ b/codec/jst/jst_test.go
@@ -2,6 +2,7 @@ package jst
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 
 	. "github.com/warpfork/go-wish"
@@ -18,7 +19,7 @@ func TestSimple(t *testing.T) {
 		  {"path": "./quxx", "moduleName": "example.net/quxx",     "status": "lit"}
 		]`)
 	nb := basicnode.Prototype.Any.NewBuilder()
-	Require(t, dagjson.Decoder(nb, bytes.NewBufferString(fixture)), ShouldEqual, nil)
+	Require(t, dagjson.Decoder(nb, strings.NewReader(fixture)), ShouldEqual, nil)
 	n := nb.Build()
 
 	st := state{}
@@ -47,7 +48,7 @@ func TestAbsentColumn(t *testing.T) {
 		  {"path": "./quxx", "optionalColumn": "wicked", "status": "lit"}
 		]`)
 		nb := basicnode.Prototype.Any.NewBuilder()
-		Require(t, dagjson.Decoder(nb, bytes.NewBufferString(fixture)), ShouldEqual, nil)
+		Require(t, dagjson.Decoder(nb, strings.NewReader(fixture)), ShouldEqual, nil)
 		n := nb.Build()
 
 		var buf bytes.Buffer
@@ -62,7 +63,7 @@ func TestAbsentColumn(t *testing.T) {
 		  {"path": "./quxx", "status": "lit",     "optionalColumn": "wicked"}
 		]`)
 		nb := basicnode.Prototype.Any.NewBuilder()
-		Require(t, dagjson.Decoder(nb, bytes.NewBufferString(fixture)), ShouldEqual, nil)
+		Require(t, dagjson.Decoder(nb, strings.NewReader(fixture)), ShouldEqual, nil)
 		n := nb.Build()
 
 		var buf bytes.Buffer
@@ -87,7 +88,7 @@ func TestSubTables(t *testing.T) {
 		  {"path": "./quxx", "moduleName": "example.net/quxx",     "status": "lit"}
 		]`)
 	nb := basicnode.Prototype.Any.NewBuilder()
-	Require(t, dagjson.Decoder(nb, bytes.NewBufferString(fixture)), ShouldEqual, nil)
+	Require(t, dagjson.Decoder(nb, strings.NewReader(fixture)), ShouldEqual, nil)
 	n := nb.Build()
 
 	var buf bytes.Buffer
@@ -111,7 +112,7 @@ func TestSubTablesCorrelated(t *testing.T) {
 		    ]}
 		]`)
 	nb := basicnode.Prototype.Any.NewBuilder()
-	Require(t, dagjson.Decoder(nb, bytes.NewBufferString(fixture)), ShouldEqual, nil)
+	Require(t, dagjson.Decoder(nb, strings.NewReader(fixture)), ShouldEqual, nil)
 	n := nb.Build()
 
 	var buf bytes.Buffer
@@ -143,7 +144,7 @@ func TestSubSubTables(t *testing.T) {
 		    ]}
 		]`)
 	nb := basicnode.Prototype.Any.NewBuilder()
-	Require(t, dagjson.Decoder(nb, bytes.NewBufferString(fixture)), ShouldEqual, nil)
+	Require(t, dagjson.Decoder(nb, strings.NewReader(fixture)), ShouldEqual, nil)
 	n := nb.Build()
 
 	var buf bytes.Buffer

--- a/exampleLinking_test.go
+++ b/exampleLinking_test.go
@@ -82,7 +82,7 @@ func ExampleLoadingLink() {
 	//  then decides where to get the referenced raw data from,
 	//   and returns that as a standard `io.Reader`.
 	var loader ipld.Loader = func(lnk ipld.Link, _ ipld.LinkContext) (io.Reader, error) {
-		return bytes.NewBuffer(storage[lnk]), nil
+		return bytes.NewReader(storage[lnk]), nil
 	}
 
 	// Second, we'll need to decide what in-memory implementation of ipld.Node we want to use.

--- a/examples_test.go
+++ b/examples_test.go
@@ -1,9 +1,9 @@
 package ipld_test
 
 import (
-	"bytes"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/ipld/go-ipld-prime/codec/dagjson"
 	basicnode "github.com/ipld/go-ipld-prime/node/basic"
@@ -31,7 +31,7 @@ func ExampleCreateDataAndMarshal() {
 }
 
 func ExampleUnmarshalData() {
-	serial := bytes.NewBufferString(`{"hey":"it works!","yes": true}`)
+	serial := strings.NewReader(`{"hey":"it works!","yes": true}`)
 
 	np := basicnode.Prototype.Any // Pick a stle for the in-memory data.
 	nb := np.NewBuilder()         // Create a builder.

--- a/node/gendemo/hax_test.go
+++ b/node/gendemo/hax_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/ipld/go-ipld-prime/node/tests"
 	"github.com/ipld/go-ipld-prime/schema"
-	"github.com/ipld/go-ipld-prime/schema/gen/go"
+	gengo "github.com/ipld/go-ipld-prime/schema/gen/go"
 )
 
 // i am the worst person and this is the worst code

--- a/node/tests/marshalBenchmarks.go
+++ b/node/tests/marshalBenchmarks.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"testing"
 
 	refmtjson "github.com/polydawn/refmt/json"
@@ -25,7 +26,7 @@ import (
 
 func BenchmarkSpec_Marshal_Map3StrInt(b *testing.B, np ipld.NodePrototype) {
 	nb := np.NewBuilder()
-	must.NotError(codec.Unmarshal(nb, refmtjson.NewDecoder(bytes.NewBufferString(`{"whee":1,"woot":2,"waga":3}`))))
+	must.NotError(codec.Unmarshal(nb, refmtjson.NewDecoder(strings.NewReader(`{"whee":1,"woot":2,"waga":3}`))))
 	n := nb.Build()
 	b.ResetTimer()
 	var err error
@@ -41,7 +42,7 @@ func BenchmarkSpec_Marshal_Map3StrInt(b *testing.B, np ipld.NodePrototype) {
 
 func BenchmarkSpec_Marshal_Map3StrInt_CodecNull(b *testing.B, np ipld.NodePrototype) {
 	nb := np.NewBuilder()
-	must.NotError(codec.Unmarshal(nb, refmtjson.NewDecoder(bytes.NewBufferString(`{"whee":1,"woot":2,"waga":3}`))))
+	must.NotError(codec.Unmarshal(nb, refmtjson.NewDecoder(strings.NewReader(`{"whee":1,"woot":2,"waga":3}`))))
 	n := nb.Build()
 	b.ResetTimer()
 	var err error

--- a/node/tests/unmarshalBenchmarks.go
+++ b/node/tests/unmarshalBenchmarks.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"testing"
 
 	refmtjson "github.com/polydawn/refmt/json"
@@ -25,7 +26,7 @@ func BenchmarkSpec_Unmarshal_Map3StrInt(b *testing.B, np ipld.NodePrototype) {
 	var err error
 	for i := 0; i < b.N; i++ {
 		nb := np.NewBuilder()
-		err = codec.Unmarshal(nb, refmtjson.NewDecoder(bytes.NewBufferString(`{"whee":1,"woot":2,"waga":3}`)))
+		err = codec.Unmarshal(nb, refmtjson.NewDecoder(strings.NewReader(`{"whee":1,"woot":2,"waga":3}`)))
 		sink = nb.Build()
 	}
 	if err != nil {
@@ -43,7 +44,7 @@ func BenchmarkSpec_Unmarshal_MapNStrMap3StrInt(b *testing.B, np ipld.NodePrototy
 			var err error
 			nb := np.NewBuilder()
 			for i := 0; i < b.N; i++ {
-				err = codec.Unmarshal(nb, refmtjson.NewDecoder(bytes.NewBufferString(msg)))
+				err = codec.Unmarshal(nb, refmtjson.NewDecoder(strings.NewReader(msg)))
 				node = nb.Build()
 				nb.Reset()
 			}

--- a/node/tests/util.go
+++ b/node/tests/util.go
@@ -1,7 +1,7 @@
 package tests
 
 import (
-	"bytes"
+	"strings"
 
 	refmtjson "github.com/polydawn/refmt/json"
 
@@ -17,7 +17,7 @@ var sink interface{}
 
 func mustNodeFromJsonString(np ipld.NodePrototype, str string) ipld.Node {
 	nb := np.NewBuilder()
-	must.NotError(codec.Unmarshal(nb, refmtjson.NewDecoder(bytes.NewBufferString(str))))
+	must.NotError(codec.Unmarshal(nb, refmtjson.NewDecoder(strings.NewReader(str))))
 	return nb.Build()
 }
 

--- a/schema/gen/go/testcase_test.go
+++ b/schema/gen/go/testcase_test.go
@@ -3,6 +3,7 @@ package gengo
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/polydawn/refmt/json"
@@ -189,7 +190,7 @@ func (tcase testcase) Test(t *testing.T, np, npr ipld.NodePrototype) {
 func testUnmarshal(t *testing.T, np ipld.NodePrototype, data string, expectFail error) ipld.Node {
 	t.Helper()
 	nb := np.NewBuilder()
-	err := dagjson.Unmarshal(nb, json.NewDecoder(bytes.NewBufferString(data)))
+	err := dagjson.Unmarshal(nb, json.NewDecoder(strings.NewReader(data)))
 	switch {
 	case expectFail == nil && err != nil:
 		t.Fatalf("fixture parse failed: %s", err)
@@ -272,7 +273,7 @@ func closeEnough(actual, expected interface{}) (string, bool) {
 func reformat(x string, opts json.EncodeOptions) string {
 	var buf bytes.Buffer
 	if err := (shared.TokenPump{
-		json.NewDecoder(bytes.NewBufferString(x)),
+		json.NewDecoder(strings.NewReader(x)),
 		json.NewEncoder(&buf, opts),
 	}).Run(); err != nil {
 		panic(err)

--- a/traversal/focus_test.go
+++ b/traversal/focus_test.go
@@ -164,7 +164,7 @@ func TestFocusWithLinkLoading(t *testing.T) {
 		err := traversal.Progress{
 			Cfg: &traversal.Config{
 				LinkLoader: func(lnk ipld.Link, _ ipld.LinkContext) (io.Reader, error) {
-					return bytes.NewBuffer(storage[lnk]), nil
+					return bytes.NewReader(storage[lnk]), nil
 				},
 				LinkTargetNodePrototypeChooser: func(_ ipld.Link, _ ipld.LinkContext) (ipld.NodePrototype, error) {
 					return basicnode.Prototype__Any{}, nil
@@ -196,7 +196,7 @@ func TestGetWithLinkLoading(t *testing.T) {
 		n, err := traversal.Progress{
 			Cfg: &traversal.Config{
 				LinkLoader: func(lnk ipld.Link, _ ipld.LinkContext) (io.Reader, error) {
-					return bytes.NewBuffer(storage[lnk]), nil
+					return bytes.NewReader(storage[lnk]), nil
 				},
 				LinkTargetNodePrototypeChooser: func(_ ipld.Link, _ ipld.LinkContext) (ipld.NodePrototype, error) {
 					return basicnode.Prototype__Any{}, nil

--- a/traversal/selector/exploreRecursive_test.go
+++ b/traversal/selector/exploreRecursive_test.go
@@ -1,8 +1,8 @@
 package selector
 
 import (
-	"bytes"
 	"fmt"
+	"strings"
 	"testing"
 
 	. "github.com/warpfork/go-wish"
@@ -199,7 +199,7 @@ func TestExploreRecursiveExplore(t *testing.T) {
 		}
 		`
 		nb := basicnode.Prototype__Any{}.NewBuilder()
-		err := dagjson.Decoder(nb, bytes.NewBufferString(nodeString))
+		err := dagjson.Decoder(nb, strings.NewReader(nodeString))
 		Wish(t, err, ShouldEqual, nil)
 		rn := nb.Build()
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("Parents"))
@@ -250,7 +250,7 @@ func TestExploreRecursiveExplore(t *testing.T) {
 		}
 		`
 		nb := basicnode.Prototype__Any{}.NewBuilder()
-		err := dagjson.Decoder(nb, bytes.NewBufferString(nodeString))
+		err := dagjson.Decoder(nb, strings.NewReader(nodeString))
 		Wish(t, err, ShouldEqual, nil)
 		rn := nb.Build()
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("Parents"))
@@ -293,7 +293,7 @@ func TestExploreRecursiveExplore(t *testing.T) {
 		}
 		`
 		nb := basicnode.Prototype__Any{}.NewBuilder()
-		err := dagjson.Decoder(nb, bytes.NewBufferString(nodeString))
+		err := dagjson.Decoder(nb, strings.NewReader(nodeString))
 		Wish(t, err, ShouldEqual, nil)
 		rn := nb.Build()
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("Parents"))
@@ -338,7 +338,7 @@ func TestExploreRecursiveExplore(t *testing.T) {
 		}
 		`
 		nb := basicnode.Prototype__Any{}.NewBuilder()
-		err := dagjson.Decoder(nb, bytes.NewBufferString(nodeString))
+		err := dagjson.Decoder(nb, strings.NewReader(nodeString))
 		Wish(t, err, ShouldEqual, nil)
 		n := nb.Build()
 
@@ -423,7 +423,7 @@ func TestExploreRecursiveExplore(t *testing.T) {
 		}
 		`
 		nb := basicnode.Prototype__Any{}.NewBuilder()
-		err := dagjson.Decoder(nb, bytes.NewBufferString(nodeString))
+		err := dagjson.Decoder(nb, strings.NewReader(nodeString))
 		Wish(t, err, ShouldEqual, nil)
 		rn := nb.Build()
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("Parents"))

--- a/traversal/walk_test.go
+++ b/traversal/walk_test.go
@@ -122,7 +122,7 @@ func TestWalkMatching(t *testing.T) {
 		err = traversal.Progress{
 			Cfg: &traversal.Config{
 				LinkLoader: func(lnk ipld.Link, _ ipld.LinkContext) (io.Reader, error) {
-					return bytes.NewBuffer(storage[lnk]), nil
+					return bytes.NewReader(storage[lnk]), nil
 				},
 				LinkTargetNodePrototypeChooser: func(_ ipld.Link, _ ipld.LinkContext) (ipld.NodePrototype, error) {
 					return basicnode.Prototype__Any{}, nil
@@ -168,7 +168,7 @@ func TestWalkMatching(t *testing.T) {
 		err = traversal.Progress{
 			Cfg: &traversal.Config{
 				LinkLoader: func(lnk ipld.Link, _ ipld.LinkContext) (io.Reader, error) {
-					return bytes.NewBuffer(storage[lnk]), nil
+					return bytes.NewReader(storage[lnk]), nil
 				},
 				LinkTargetNodePrototypeChooser: func(_ ipld.Link, _ ipld.LinkContext) (ipld.NodePrototype, error) {
 					return basicnode.Prototype__Any{}, nil
@@ -213,7 +213,7 @@ func TestWalkMatching(t *testing.T) {
 		err = traversal.Progress{
 			Cfg: &traversal.Config{
 				LinkLoader: func(lnk ipld.Link, _ ipld.LinkContext) (io.Reader, error) {
-					return bytes.NewBuffer(storage[lnk]), nil
+					return bytes.NewReader(storage[lnk]), nil
 				},
 				LinkTargetNodePrototypeChooser: func(_ ipld.Link, _ ipld.LinkContext) (ipld.NodePrototype, error) {
 					return basicnode.Prototype__Any{}, nil


### PR DESCRIPTION
Buffers are not a good option for tests if the other side expects a
reader. Otherwise, the code being tested could build assumptions around
the reader stream being a single contiguous chunk of bytes, such as:

	_ = r.(*bytes.Buffer).Bytes()

This kind of hack might seem unlikely, but it's an easy mistake to make,
especially with APIs like fmt which automatically call String methods.

With bytes.Reader and strings.Reader, the types are much more
restricted, so the tests need to be more faithful.