### PR TITLE
Security fix: patch crashing inputs

### DIFF
--- a/codec/dagcbor/unmarshal.go
+++ b/codec/dagcbor/unmarshal.go
@@ -41,7 +41,7 @@ func unmarshal(na ipld.NodeAssembler, tokSrc shared.TokenSource, tk *tok.Token) 
 	case tok.TMapOpen:
 		expectLen := tk.Length
 		allocLen := tk.Length
-		if tk.Length == -1 {
+		if tk.Length == -1 || tk.Length > math.MaxInt32 {
 			expectLen = math.MaxInt32
 			allocLen = 0
 		}
@@ -84,7 +84,7 @@ func unmarshal(na ipld.NodeAssembler, tokSrc shared.TokenSource, tk *tok.Token) 
 	case tok.TArrOpen:
 		expectLen := tk.Length
 		allocLen := tk.Length
-		if tk.Length == -1 {
+		if tk.Length == -1 || tk.Length > math.MaxInt32 {
 			expectLen = math.MaxInt32
 			allocLen = 0
 		}


### PR DESCRIPTION
# Goals

See this report https://github.com/LeastAuthority/go-ipld-prime/issues/2

The Filecoin security audit found some values that can be passed to dagcbor's decode that will produce a panic. (discovered while fuzzing graphsync, which uses IPLD's builders for some of it's work)

This fix was created by the auditors -- I just rebased it on master.