### PR TITLE
Add a demo ADL (rot13adl)

### DIFF
--- a/adl/rot13adl/example_test.go
+++ b/adl/rot13adl/example_test.go
@@ -1,0 +1,18 @@
+package rot13adl_test
+
+func ExampleWoo() {
+
+	// Output:
+}
+
+// An Unmarshal2 function could take a (fairly complex) argument that says what NodePrototype to use in certain positions
+//  (is this accomplished with a Selector?  that's a scary large dependency, but maybe.).
+//  This can be used for many purposes (efficiency, misc tuning, expecting a *schema* thing part way through...),
+//  and it could also be used to say where a NodePrototype for an ADL's substrate should be used.
+//
+// Schemas, even the repr builders, still ultimately result in "returning" (not really, but, roll with me here) the high-level typed info.
+// ...
+// This ADL, as currently drafted, does not.
+// That's... maybe bad?
+// It can be passed through the Reify method and there's a feeling of consistency, there.
+// But I'm not sure.

--- a/adl/rot13adl/example_test.go
+++ b/adl/rot13adl/example_test.go
@@ -1,18 +1,66 @@
 package rot13adl_test
 
-func ExampleWoo() {
+import (
+	"fmt"
+	"strings"
+
+	"github.com/polydawn/refmt/json"
+
+	"github.com/ipld/go-ipld-prime/adl/rot13adl"
+	"github.com/ipld/go-ipld-prime/codec/dagjson"
+	"github.com/ipld/go-ipld-prime/must"
+)
+
+func ExampleUnmarshallingToADL() {
+	// Create a NodeBuilder for the ADL's substrate.
+	//  Unmarshalling into this memory structure is optimal,
+	//   because it immediately puts data into the right memory layout for the ADL code to work on,
+	//  but you could use any other kind of NodeBuilder just as well and still get correct results.
+	nb := rot13adl.Prototype.SubstrateRoot.NewBuilder()
+
+	// Unmarshal -- using the substrate's nodebuilder just like you'd unmarshal with any other nodebuilder.
+	err := dagjson.Unmarshal(nb, json.NewDecoder(strings.NewReader(`"n pbby fgevat"`)))
+	fmt.Printf("unmarshal error: %v\n", err)
+
+	// Use `Reify` to get the synthetic high-level view of the ADL data.
+	substrateNode := nb.Build()
+	syntheticView, err := rot13adl.Reify(substrateNode)
+	fmt.Printf("reify error: %v\n", err)
+
+	// We can inspect the synthetic ADL node like any other node!
+	fmt.Printf("adl node kind: %v\n", syntheticView.ReprKind())
+	fmt.Printf("adl view value: %q\n", must.String(syntheticView))
 
 	// Output:
+	// unmarshal error: <nil>
+	// reify error: <nil>
+	// adl node kind: string
+	// adl view value: "a cool string"
 }
 
-// An Unmarshal2 function could take a (fairly complex) argument that says what NodePrototype to use in certain positions
-//  (is this accomplished with a Selector?  that's a scary large dependency, but maybe.).
-//  This can be used for many purposes (efficiency, misc tuning, expecting a *schema* thing part way through...),
-//  and it could also be used to say where a NodePrototype for an ADL's substrate should be used.
+// It's worth noting that the builders for an ADL substrate node still return the substrate.
+// (This is interesting in contrast to Schemas, where codegenerated representation-level builders
+// yield the type-level node values (and not the representation level node).)
 //
-// Schemas, even the repr builders, still ultimately result in "returning" (not really, but, roll with me here) the high-level typed info.
-// ...
-// This ADL, as currently drafted, does not.
-// That's... maybe bad?
-// It can be passed through the Reify method and there's a feeling of consistency, there.
-// But I'm not sure.
+// To convert the substrate node to the high level synthesized view of the ADL,
+// use Reify as normal -- it's the same whether you've used the substrate type
+// or if you've used any other node implementation to hold the data.
+//
+
+// Future work: unmarshalling which can invoke an ADL mid-structure,
+// and automatically places the reified ADL in place in the larger structure.
+//
+// There will be several ways to do this (it hinges around "the signalling problem",
+// discussed in https://github.com/ipld/specs/issues/130 ):
+//
+// The first way is to use IPLD Schemas, which provide a signalling mechanism
+// by leaning on the schema, and the matching of shape of surrounding data to the schema,
+// as a way to determine where an ADL is expected to appear.
+//
+// A second mechanism could involve new unmarshal function contracts
+// which would ake a (fairly complex) argument that says what NodePrototype to use in certain positions.
+// This could be accomplished by use of Selectors.
+// (This would also have many other potential purposes -- implementing this in terms of NodePrototype selection is very multi-purpose,
+// and could be used for efficiency and misc tuning purposes,
+// for expecting a *schema* thing part way through, and so forth.)
+//

--- a/adl/rot13adl/example_test.go
+++ b/adl/rot13adl/example_test.go
@@ -1,6 +1,7 @@
 package rot13adl_test
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 
@@ -36,6 +37,39 @@ func ExampleUnmarshallingToADL() {
 	// reify error: <nil>
 	// adl node kind: string
 	// adl view value: "a cool string"
+}
+
+func ExampleCreatingViaADL() {
+	// Create a NodeBuilder for the ADL -- the high-level synthesized thing (not the substrate).
+	nb := rot13adl.Prototype.Node.NewBuilder()
+
+	// Create a ADL node via its builder.  This is just like creating any other node in IPLD.
+	nb.AssignString("woohoo")
+	n := nb.Build()
+
+	// We can inspect the synthetic ADL node like any other node!
+	fmt.Printf("adl node kind: %v\n", n.ReprKind())
+	fmt.Printf("adl view value: %q\n", must.String(n))
+
+	// We can get the substrate view and examine that as a node too.
+	// (This requires a cast to see that we have an ADL, though.  Not all IPLD nodes have a 'Substrate' property.)
+	substrateNode := n.(rot13adl.R13String).Substrate()
+	fmt.Printf("substrate node kind: %v\n", substrateNode.ReprKind())
+	fmt.Printf("substrate value: %q\n", must.String(substrateNode))
+
+	// To marshal the ADL, just use marshal methods on its substrate as normal:
+	var marshalBuffer bytes.Buffer
+	err := dagjson.Marshal(substrateNode, json.NewEncoder(&marshalBuffer, json.EncodeOptions{}))
+	fmt.Printf("marshalled: %v\n", marshalBuffer.String())
+	fmt.Printf("marshal error: %v\n", err)
+
+	// Output:
+	// adl node kind: string
+	// adl view value: "woohoo"
+	// substrate node kind: string
+	// substrate value: "jbbubb"
+	// marshalled: "jbbubb"
+	// marshal error: <nil>
 }
 
 // It's worth noting that the builders for an ADL substrate node still return the substrate.

--- a/adl/rot13adl/rot13logic.go
+++ b/adl/rot13adl/rot13logic.go
@@ -1,0 +1,78 @@
+package rot13adl
+
+import (
+	"strings"
+)
+
+var replaceTable = []string{
+	"A", "N",
+	"B", "O",
+	"C", "P",
+	"D", "Q",
+	"E", "R",
+	"F", "S",
+	"G", "T",
+	"H", "U",
+	"I", "V",
+	"J", "W",
+	"K", "X",
+	"L", "Y",
+	"M", "Z",
+	"N", "A",
+	"O", "B",
+	"P", "C",
+	"Q", "D",
+	"R", "E",
+	"S", "F",
+	"T", "G",
+	"U", "H",
+	"V", "I",
+	"W", "J",
+	"X", "K",
+	"Y", "L",
+	"Z", "M",
+	"a", "n",
+	"b", "o",
+	"c", "p",
+	"d", "q",
+	"e", "r",
+	"f", "s",
+	"g", "t",
+	"h", "u",
+	"i", "v",
+	"j", "w",
+	"k", "x",
+	"l", "y",
+	"m", "z",
+	"n", "a",
+	"o", "b",
+	"p", "c",
+	"q", "d",
+	"r", "e",
+	"s", "f",
+	"t", "g",
+	"u", "h",
+	"v", "i",
+	"w", "j",
+	"x", "k",
+	"y", "l",
+	"z", "m",
+}
+var unreplaceTable = func() []string {
+	v := make([]string, len(replaceTable))
+	for i := 0; i < len(replaceTable); i += 2 {
+		v[i] = replaceTable[i+1]
+		v[i+1] = replaceTable[i]
+	}
+	return v
+}()
+
+// rotate transforms from the logical content to the raw content.
+func rotate(s string) string {
+	return strings.NewReplacer(replaceTable...).Replace(s)
+}
+
+// unrotate transforms from the raw content to the logical content.
+func unrotate(s string) string {
+	return strings.NewReplacer(unreplaceTable...).Replace(s)
+}

--- a/adl/rot13adl/rot13node.go
+++ b/adl/rot13adl/rot13node.go
@@ -7,10 +7,16 @@
 
 	There are several ways to move data in and out of the ADL:
 
-		- using the exported NodePrototype can be used to get a NodeBuilder which can accept the synthesized data;
-		- Nodes resulting from that construction process can be read to see synthesized data;
-		- the raw substrate data, if already parsed into Nodes, can be processed into a synthesized Node using the Reify function;
-		- TODO nodes
+		- treat it like a regular IPLD map:
+			- using the exported NodePrototype can be used to get a NodeBuilder which can accept keys and values;
+			- using the resulting Node and doing lookup operations on it like a regular map;
+		- load up raw substrate data and `Reify()` it into the synthesized form, and *then* treat it like a regular map:
+			- this is handy if the raw data already parsed into Nodes.
+			- optionally, use `SubstrateRootPrototype` as the prototype for loading the raw substrate data;
+			  any kind of Node is a valid input to Reify, but this one will generally have optimal performance.
+		- take the synthesized form and inspect its substrate data:
+			- the `Substrate()` method will return another ipld.Node which is the root of the raw substrate data,
+			  and can be walked normally like any other ipld.Node.
 */
 package rot13adl
 
@@ -83,9 +89,7 @@ func (*_R13String) Prototype() ipld.NodePrototype {
 
 // -- NodePrototype -->
 
-var _ ipld.NodePrototype = Prototype{}
-
-type Prototype = _R13String__Prototype
+var _ ipld.NodePrototype = _R13String__Prototype{}
 
 type _R13String__Prototype struct {
 	// There's no configuration to this ADL.

--- a/adl/rot13adl/rot13node.go
+++ b/adl/rot13adl/rot13node.go
@@ -1,0 +1,193 @@
+/*
+	rot13adl is a demo ADL -- its purpose is to show what an ADL and its public interface can look like.
+	It implements a "rot13" string: when creating data through the ADL, the user gives it a regular string;
+	the ADL will create aninternal representation of it which has the characters altered in a reversable way.
+
+	It provides reference and example materal, but it's very unlikely you want to use it in real situations ;)
+
+	There are several ways to move data in and out of the ADL:
+
+		- using the exported NodePrototype can be used to get a NodeBuilder which can accept the synthesized data;
+		- Nodes resulting from that construction process can be read to see synthesized data;
+		- the raw substrate data, if already parsed into Nodes, can be processed into a synthesized Node using the Reify function;
+		- TODO nodes
+*/
+package rot13adl
+
+import (
+	"github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/node/mixins"
+	"github.com/ipld/go-ipld-prime/schema"
+)
+
+// -- Node -->
+
+var _ ipld.Node = (*_R13String)(nil)
+
+type _R13String struct {
+	raw         string // the raw content, before our ADL lens is applied to it.
+	synthesized string // the content that the ADL presents.  calculated proactively from the original, in this implementation (though you could imagine implementing it lazily, in either direction, too).
+}
+
+func (*_R13String) ReprKind() ipld.ReprKind {
+	return ipld.ReprKind_String
+}
+func (*_R13String) LookupByString(string) (ipld.Node, error) {
+	return mixins.String{"rot13adl.R13String"}.LookupByString("")
+}
+func (*_R13String) LookupByNode(ipld.Node) (ipld.Node, error) {
+	return mixins.String{"rot13adl.R13String"}.LookupByNode(nil)
+}
+func (*_R13String) LookupByIndex(idx int) (ipld.Node, error) {
+	return mixins.String{"rot13adl.R13String"}.LookupByIndex(0)
+}
+func (*_R13String) LookupBySegment(seg ipld.PathSegment) (ipld.Node, error) {
+	return mixins.String{"rot13adl.R13String"}.LookupBySegment(seg)
+}
+func (*_R13String) MapIterator() ipld.MapIterator {
+	return nil
+}
+func (*_R13String) ListIterator() ipld.ListIterator {
+	return nil
+}
+func (*_R13String) Length() int {
+	return -1
+}
+func (*_R13String) IsAbsent() bool {
+	return false
+}
+func (*_R13String) IsNull() bool {
+	return false
+}
+func (*_R13String) AsBool() (bool, error) {
+	return mixins.String{"rot13adl.R13String"}.AsBool()
+}
+func (*_R13String) AsInt() (int, error) {
+	return mixins.String{"rot13adl.R13String"}.AsInt()
+}
+func (*_R13String) AsFloat() (float64, error) {
+	return mixins.String{"rot13adl.R13String"}.AsFloat()
+}
+func (n *_R13String) AsString() (string, error) {
+	return n.synthesized, nil
+}
+func (*_R13String) AsBytes() ([]byte, error) {
+	return mixins.String{"rot13adl.R13String"}.AsBytes()
+}
+func (*_R13String) AsLink() (ipld.Link, error) {
+	return mixins.String{"rot13adl.R13String"}.AsLink()
+}
+func (*_R13String) Prototype() ipld.NodePrototype {
+	return _R13String__Prototype{}
+}
+
+// -- NodePrototype -->
+
+var _ ipld.NodePrototype = Prototype{}
+
+type Prototype = _R13String__Prototype
+
+type _R13String__Prototype struct {
+	// There's no configuration to this ADL.
+
+	// A more complex ADL might have some kind of parameters here.
+	//
+	// The general contract of a NodePrototype is supposed to be that:
+	// when you get one from an existing Node,
+	//  it should have enough information to create a new Node that
+	//   could "replace" the previous one in whatever context it's in.
+	// For ADLs, that means it should carry most of the configuration.
+	//
+	// An ADL that does multi-block stuff might also need functions like a LinkLoader passed in through here.
+}
+
+func (np _R13String__Prototype) NewBuilder() ipld.NodeBuilder {
+	return &_R13String__Builder{}
+}
+
+// -- NodeBuilder -->
+
+var _ ipld.NodeBuilder = (*_R13String__Builder)(nil)
+
+type _R13String__Builder struct {
+	_R13String__Assembler
+}
+
+func (nb *_R13String__Builder) Build() ipld.Node {
+	if nb.m != schema.Maybe_Value {
+		panic("invalid state: cannot call Build on an assembler that's not finished")
+	}
+	return nb.w
+}
+func (nb *_R13String__Builder) Reset() {
+	*nb = _R13String__Builder{}
+}
+
+// -- NodeAssembler -->
+
+var _ ipld.NodeAssembler = (*_R13String__Assembler)(nil)
+
+type _R13String__Assembler struct {
+	w *_R13String
+	m schema.Maybe // REVIEW: if the package where this Maybe enum lives is maybe not the right home for it after all.  Or should this line use something different?  We're only using some of its values after all.
+}
+
+func (_R13String__Assembler) BeginMap(sizeHint int) (ipld.MapAssembler, error) {
+	return mixins.StringAssembler{"rot13adl.R13String"}.BeginMap(0)
+}
+func (_R13String__Assembler) BeginList(sizeHint int) (ipld.ListAssembler, error) {
+	return mixins.StringAssembler{"rot13adl.R13String"}.BeginList(0)
+}
+func (na *_R13String__Assembler) AssignNull() error {
+	// REVIEW: unclear how this might compose with some other context (like a schema) which does allow nulls.  Probably a wrapper type?
+	return mixins.StringAssembler{"rot13adl.R13String"}.AssignNull()
+}
+func (_R13String__Assembler) AssignBool(bool) error {
+	return mixins.StringAssembler{"rot13adl.R13String"}.AssignBool(false)
+}
+func (_R13String__Assembler) AssignInt(int) error {
+	return mixins.StringAssembler{"rot13adl.R13String"}.AssignInt(0)
+}
+func (_R13String__Assembler) AssignFloat(float64) error {
+	return mixins.StringAssembler{"rot13adl.R13String"}.AssignFloat(0)
+}
+func (na *_R13String__Assembler) AssignString(v string) error {
+	switch na.m {
+	case schema.Maybe_Value:
+		panic("invalid state: cannot assign into assembler that's already finished")
+	}
+	na.w = &_R13String{
+		raw:         rotate(v),
+		synthesized: v,
+	}
+	na.m = schema.Maybe_Value
+	return nil
+}
+func (_R13String__Assembler) AssignBytes([]byte) error {
+	return mixins.StringAssembler{"rot13adl.R13String"}.AssignBytes(nil)
+}
+func (_R13String__Assembler) AssignLink(ipld.Link) error {
+	return mixins.StringAssembler{"rot13adl.R13String"}.AssignLink(nil)
+}
+func (na *_R13String__Assembler) AssignNode(v ipld.Node) error {
+	if v.IsNull() {
+		return na.AssignNull()
+	}
+	if v2, ok := v.(*_R13String); ok {
+		switch na.m {
+		case schema.Maybe_Value:
+			panic("invalid state: cannot assign into assembler that's already finished")
+		}
+		na.w = v2
+		na.m = schema.Maybe_Value
+		return nil
+	}
+	if v2, err := v.AsString(); err != nil {
+		return err
+	} else {
+		return na.AssignString(v2)
+	}
+}
+func (_R13String__Assembler) Prototype() ipld.NodePrototype {
+	return _R13String__Prototype{}
+}

--- a/adl/rot13adl/rot13node.go
+++ b/adl/rot13adl/rot13node.go
@@ -28,7 +28,9 @@ import (
 
 // -- Node -->
 
-var _ ipld.Node = (*_R13String)(nil)
+var _ ipld.Node = (R13String)(nil)
+
+type R13String = *_R13String
 
 type _R13String struct {
 	raw         string // the raw content, before our ADL lens is applied to it.

--- a/adl/rot13adl/rot13node_test.go
+++ b/adl/rot13adl/rot13node_test.go
@@ -1,0 +1,38 @@
+package rot13adl
+
+import (
+	"testing"
+
+	. "github.com/warpfork/go-wish"
+
+	"github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/node/basic"
+)
+
+func TestLogicalNodeRoundtrip(t *testing.T) {
+	nb := Prototype{}.NewBuilder()
+	err := nb.AssignString("abcd")
+	Require(t, err, ShouldEqual, nil)
+	n := nb.Build()
+	s, err := n.AsString()
+	Wish(t, err, ShouldEqual, nil)
+	Wish(t, s, ShouldEqual, "abcd")
+}
+
+func TestNodeInternal(t *testing.T) {
+	nb := Prototype{}.NewBuilder()
+	err := nb.AssignString("abcd")
+	Require(t, err, ShouldEqual, nil)
+	n := nb.Build()
+	Wish(t, n.(*_R13String).raw, ShouldEqual, "nopq")
+}
+
+func TestReify(t *testing.T) {
+	sn := basicnode.NewString("nopq")
+	synth, err := Reify(sn)
+	Require(t, err, ShouldEqual, nil)
+	Wish(t, synth.ReprKind(), ShouldEqual, ipld.ReprKind_String)
+	s, err := synth.AsString()
+	Wish(t, err, ShouldEqual, nil)
+	Wish(t, s, ShouldEqual, "abcd")
+}

--- a/adl/rot13adl/rot13node_test.go
+++ b/adl/rot13adl/rot13node_test.go
@@ -69,6 +69,9 @@ func TestInspectingSubstrate(t *testing.T) {
 	n := nb.Build()
 	// Ask it about its substrate, and inspect that.
 	sn := n.(*_R13String).Substrate()
+	// TODO: the cast above isn't available outside this package: we should probably make an interface with `Substrate()` and make it available.
+	//  Is it reasonable to make this part of a standard feature detection pattern,
+	//   and make that interface reside in the main IPLD package?  Or in an `adl` package that contains such standard interfaces?
 	ss, err := sn.AsString()
 	Wish(t, err, ShouldEqual, nil)
 	Wish(t, ss, ShouldEqual, "nopq")

--- a/adl/rot13adl/rot13node_test.go
+++ b/adl/rot13adl/rot13node_test.go
@@ -10,29 +10,66 @@ import (
 )
 
 func TestLogicalNodeRoundtrip(t *testing.T) {
-	nb := Prototype{}.NewBuilder()
+	// Build high level node.
+	nb := Prototype.Node.NewBuilder()
 	err := nb.AssignString("abcd")
 	Require(t, err, ShouldEqual, nil)
 	n := nb.Build()
+	// Inspect the high level node.
 	s, err := n.AsString()
 	Wish(t, err, ShouldEqual, nil)
 	Wish(t, s, ShouldEqual, "abcd")
 }
 
 func TestNodeInternal(t *testing.T) {
-	nb := Prototype{}.NewBuilder()
+	// Build high level node.
+	nb := Prototype.Node.NewBuilder()
 	err := nb.AssignString("abcd")
 	Require(t, err, ShouldEqual, nil)
 	n := nb.Build()
+	// Poke its insides directly to see that the transformation occured.
+	Wish(t, n.(*_R13String).synthesized, ShouldEqual, "abcd")
 	Wish(t, n.(*_R13String).raw, ShouldEqual, "nopq")
 }
 
 func TestReify(t *testing.T) {
-	sn := basicnode.NewString("nopq")
-	synth, err := Reify(sn)
+	t.Run("using unspecialized raw node", func(t *testing.T) {
+		// Build substrate-shaped data using basicnode.
+		sn := basicnode.NewString("nopq")
+		// Reify it.
+		synth, err := Reify(sn)
+		// Inspect the resulting high level node.
+		Require(t, err, ShouldEqual, nil)
+		Wish(t, synth.ReprKind(), ShouldEqual, ipld.ReprKind_String)
+		s, err := synth.AsString()
+		Wish(t, err, ShouldEqual, nil)
+		Wish(t, s, ShouldEqual, "abcd")
+	})
+	t.Run("using substrate node", func(t *testing.T) {
+		// Build substrate-shaped data, in the substrate type right from the start.
+		snb := Prototype.SubstrateRoot.NewBuilder()
+		snb.AssignString("nopq")
+		sn := snb.Build()
+		// Reify it.
+		synth, err := Reify(sn)
+		// Inspect the resulting high level node.
+		Require(t, err, ShouldEqual, nil)
+		Wish(t, synth.ReprKind(), ShouldEqual, ipld.ReprKind_String)
+		s, err := synth.AsString()
+		Wish(t, err, ShouldEqual, nil)
+		Wish(t, s, ShouldEqual, "abcd")
+	})
+}
+
+func TestInspectingSubstrate(t *testing.T) {
+	// Build high level node.
+	nb := Prototype.Node.NewBuilder()
+	err := nb.AssignString("abcd")
 	Require(t, err, ShouldEqual, nil)
-	Wish(t, synth.ReprKind(), ShouldEqual, ipld.ReprKind_String)
-	s, err := synth.AsString()
+	n := nb.Build()
+	// Ask it about its substrate, and inspect that.
+	sn := n.(*_R13String).Substrate()
+	ss, err := sn.AsString()
 	Wish(t, err, ShouldEqual, nil)
-	Wish(t, s, ShouldEqual, "abcd")
+	Wish(t, ss, ShouldEqual, "nopq")
 }

--- a/adl/rot13adl/rot13node_test.go
+++ b/adl/rot13adl/rot13node_test.go
@@ -68,8 +68,8 @@ func TestInspectingSubstrate(t *testing.T) {
 	Require(t, err, ShouldEqual, nil)
 	n := nb.Build()
 	// Ask it about its substrate, and inspect that.
-	sn := n.(*_R13String).Substrate()
-	// TODO: the cast above isn't available outside this package: we should probably make an interface with `Substrate()` and make it available.
+	sn := n.(R13String).Substrate()
+	// TODO: It's unfortunate this is only available as a concrete type cast: we should probably make a standard feature detection interface with `Substrate()`.
 	//  Is it reasonable to make this part of a standard feature detection pattern,
 	//   and make that interface reside in the main IPLD package?  Or in an `adl` package that contains such standard interfaces?
 	ss, err := sn.AsString()

--- a/adl/rot13adl/rot13prototypes.go
+++ b/adl/rot13adl/rot13prototypes.go
@@ -1,0 +1,25 @@
+package rot13adl
+
+// Prototype embeds a NodePrototype for every kind of Node implementation in this package.
+// This includes both the synthesized node as well as the substrate root node
+// (other substrate interior node prototypes are not exported here;
+// it's unlikely they'll be useful outside of the scope of the ADL's implementation package.)
+//
+// You can use it like this:
+//
+// 		rot13adl.Prototype.Node.NewBuilder() //...
+//
+// and:
+//
+// 		rot13adl.Prototype.SubstrateRoot.NewBuilder() // ...
+//
+var Prototype prototype
+
+// This may seem a tad mundane, but we do it for consistency with the way
+// other Node implementation packages (like basicnode) do this:
+// it's a convention for "pkgname.Prototype.SpecificThing.NewBuilder()" to be defined.
+
+type prototype struct {
+	Node          _R13String__Prototype
+	SubstrateRoot _Substrate__Prototype
+}

--- a/adl/rot13adl/rot13prototypes.go
+++ b/adl/rot13adl/rot13prototypes.go
@@ -23,3 +23,9 @@ type prototype struct {
 	Node          _R13String__Prototype
 	SubstrateRoot _Substrate__Prototype
 }
+
+// REVIEW: In ADLs that use codegenerated substrate types defined by an IPLD Schema, the `Prototype.SubstrateRoot` field...
+// should it be a `_SubstrateRoot__Prototype`, or a `_SubstrateRoot__ReprPrototype`?
+//  Probably the latter, because the only thing an external user of this package should be interested in is how to read data into memory in an optimal path.
+// But does this answer all questions?  Codegen ReprPrototypes currently still return the type-level node from their Build method!
+//  This probably would functionally work -- we could make the Reify methods check for either the type-level or repr-level types -- but would it be weird/surprising/hard-to-use?

--- a/adl/rot13adl/rot13reification.go
+++ b/adl/rot13adl/rot13reification.go
@@ -1,0 +1,44 @@
+package rot13adl
+
+import (
+	"fmt"
+
+	"github.com/ipld/go-ipld-prime"
+)
+
+// Reify attempts to process raw Data Model data as substrate data to synthesize an ADL.
+// If it succeeds in recognizing the raw data as this ADL,
+// Reify returns a new Node which exhibits the logical behaviors of the ADL;
+// otherwise, it returns an error.
+//
+// The input data can be any implementation of ipld.Node;
+// it will be considered purely through that interface.
+//
+// If your application is expecting ADL data, this pipeline can be optimized
+// by using the SubstratePrototype right from the start when unmarshalling;
+// then, Reify can detect if the rawRoot parameter is of that implementation,
+// and it can save some processing work internally that can be known to already be done.
+//
+func Reify(rawRoot ipld.Node) (ipld.Node, error) {
+	// Is it evidentally a valid substrate for this ADL?
+	//  This is a pretty trivial check for rot13adl.
+	//  (Other ADLs probably want to include some additional data and structure in them which allow more validation here,
+	//   though in general, this validation should also usually stick to not crossing any block loading boundaries.)
+	if rawRoot.ReprKind() != ipld.ReprKind_String {
+		return nil, fmt.Errorf("cannot reify rot13adl: substrate root node is wrong kind (must be string)")
+	}
+
+	// Construct and return the reified node.
+	//  If we can recognize the rawRoot as being our own substrate types,
+	//   we can shortcut some things;
+	//  Otherwise, just process it via the data model.
+	if x, ok := rawRoot.(*_Substrate); ok {
+		return (*_R13String)(x), nil
+	}
+	// Shortcut didn't work.  Process via the data model.
+	s, _ := rawRoot.AsString()
+	return &_R13String{
+		raw:         s,
+		synthesized: unrotate(s),
+	}, nil
+}

--- a/adl/rot13adl/rot13reification.go
+++ b/adl/rot13adl/rot13reification.go
@@ -6,7 +6,8 @@ import (
 	"github.com/ipld/go-ipld-prime"
 )
 
-// Reify attempts to process raw Data Model data as substrate data to synthesize an ADL.
+// Reify examines data in a Node to see if it matches the shape for valid substrate data for this ADL,
+// and if so, synthesizes and returns the high-level view of the ADL.
 // If it succeeds in recognizing the raw data as this ADL,
 // Reify returns a new Node which exhibits the logical behaviors of the ADL;
 // otherwise, it returns an error.
@@ -19,26 +20,53 @@ import (
 // then, Reify can detect if the rawRoot parameter is of that implementation,
 // and it can save some processing work internally that can be known to already be done.
 //
-func Reify(rawRoot ipld.Node) (ipld.Node, error) {
-	// Is it evidentally a valid substrate for this ADL?
-	//  This is a pretty trivial check for rot13adl.
-	//  (Other ADLs probably want to include some additional data and structure in them which allow more validation here,
-	//   though in general, this validation should also usually stick to not crossing any block loading boundaries.)
-	if rawRoot.ReprKind() != ipld.ReprKind_String {
-		return nil, fmt.Errorf("cannot reify rot13adl: substrate root node is wrong kind (must be string)")
-	}
+// Reification will generally operate on the data in a single block
+// (e.g. this function will not do any additional block loads and unmarshalling).
+// This is important because some ADLs handle data so large that loading it all
+// eagerly would be impractical (and in some cases outright impossible).
+// However, it also necessarily implies that invalid data may lie beyond
+// one of those lazy loads, and it won't be discovered at the time of Reify.
+//
+// In this demo ADL, we don't have multi-block content at all,
+// so of course we don't have any additional block loads!
+// However, ADL implementations may vary in their approaches to lazy vs eager loading.
+// All ADLs should document their exact semantics regarding this --
+// especially if it has any implications for boundaries of data validity checking.
+//
+// REVIEW: this function is currently not conforming to any particular interface;
+// if we evolve the contract for ADLs to include an interface for reficiation functions,
+// might we need to add context and link loader systems as parameters to it?
+// Not all implementations might need it, as per previous paragraph; but some might.
+// Reification for multiblock ADLs might also need link loader systems as a parameter here
+// so they can capture them as config and hold them for use in future operations that do lazy loading.
+//
+func Reify(maybeSubstrateRoot ipld.Node) (ipld.Node, error) {
+	// Reify is often very easy to implement,
+	//  especially if you have an IPLD Schema that specifies the shape of the substrate data:
+	// We can just check if the data in maybeSubstrateRoot happens to already be exactly the right type,
+	//  and if so, take very direct shortcuts because we already know its been validated in shape;
+	// otherwise, we create a new piece of memory for our native substrate memory layout,
+	//  and assign into it from the raw node, validating in the process,
+	//   which again just leans directly on the shape validation logic already given to us by the schema logic on that type.
+	// (Checking the concrete type of maybeSubstrateRoot in search of a shortcut is seemingly a tad redundant,
+	//  because the AssignNode path later also has such a check!
+	//  However, doing it earlier allows us to avoid an allocation;
+	//   the AssignNode path doesn't become available until after NewBuilder is invoked, and NewBuilder is where allocations happen.)
 
-	// Construct and return the reified node.
-	//  If we can recognize the rawRoot as being our own substrate types,
-	//   we can shortcut some things;
-	//  Otherwise, just process it via the data model.
-	if x, ok := rawRoot.(*_Substrate); ok {
+	// Check if we can recognize the maybeSubstrateRoot as being our own substrate types;
+	//  if it is, we can shortcut pretty drastically.
+	if x, ok := maybeSubstrateRoot.(*_Substrate); ok {
+		// In this ADL implementation, the high level node has the exact same memory layout as the substrate root,
+		//  and so our only remaining processing here is just to cast them, so that
+		//   the node we return has the correct methodset exposed.
 		return (*_R13String)(x), nil
 	}
+
 	// Shortcut didn't work.  Process via the data model.
-	s, _ := rawRoot.AsString()
-	return &_R13String{
-		raw:         s,
-		synthesized: unrotate(s),
-	}, nil
+	//  The AssignNode method on the substrate type already contains all the logic necessary for this, so we use that.
+	nb := Prototype.SubstrateRoot.NewBuilder()
+	if err := nb.AssignNode(maybeSubstrateRoot); err != nil {
+		fmt.Errorf("rot13adl.Reify failed: data does not match expected shape for substrate: %w", err)
+	}
+	return (*_R13String)(nb.Build().(*_Substrate)), nil
 }

--- a/adl/rot13adl/rot13substrate.go
+++ b/adl/rot13adl/rot13substrate.go
@@ -1,0 +1,181 @@
+package rot13adl
+
+import (
+	"github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/node/mixins"
+	"github.com/ipld/go-ipld-prime/schema"
+)
+
+// Substrate returns the root node of the raw internal data form of the ADL's content.
+func (n *_R13String) Substrate() ipld.Node {
+	// This is a very minor twist in the case of the rot13 ADL.
+	//  However, for larger ADLs (especially those relating to multi-block collections),
+	//   this could be quite a bit more involved, and would almost certainly be the root node of a larger tree.
+	return (*_Substrate)(n)
+}
+
+// -- Node -->
+
+var _ ipld.Node = (*_Substrate)(nil)
+
+// Somewhat unusually for an ADL, there's only one substrate node type,
+// and we actually made it have the same in-memory structure as the synthesized view node.
+type _Substrate _R13String
+
+// REVIEW: what on earth we think the "TypeName" strings in error messages and other references to this node should be.
+//  At the moment, it shares a prefix with the synthesized node, which is potentially confusing (?),
+//  and I'm not sure what, if any, suffix actually makes meaningful sense to a user either.
+//  I added the segment ".internal." to the middle of the name mangle; does this seem helpful?
+
+func (*_Substrate) ReprKind() ipld.ReprKind {
+	return ipld.ReprKind_String
+}
+func (*_Substrate) LookupByString(string) (ipld.Node, error) {
+	return mixins.String{"rot13adl.internal.Substrate"}.LookupByString("")
+}
+func (*_Substrate) LookupByNode(ipld.Node) (ipld.Node, error) {
+	return mixins.String{"rot13adl.internal.Substrate"}.LookupByNode(nil)
+}
+func (*_Substrate) LookupByIndex(idx int) (ipld.Node, error) {
+	return mixins.String{"rot13adl.internal.Substrate"}.LookupByIndex(0)
+}
+func (*_Substrate) LookupBySegment(seg ipld.PathSegment) (ipld.Node, error) {
+	return mixins.String{"rot13adl.internal.Substrate"}.LookupBySegment(seg)
+}
+func (*_Substrate) MapIterator() ipld.MapIterator {
+	return nil
+}
+func (*_Substrate) ListIterator() ipld.ListIterator {
+	return nil
+}
+func (*_Substrate) Length() int {
+	return -1
+}
+func (*_Substrate) IsAbsent() bool {
+	return false
+}
+func (*_Substrate) IsNull() bool {
+	return false
+}
+func (*_Substrate) AsBool() (bool, error) {
+	return mixins.String{"rot13adl.internal.Substrate"}.AsBool()
+}
+func (*_Substrate) AsInt() (int, error) {
+	return mixins.String{"rot13adl.internal.Substrate"}.AsInt()
+}
+func (*_Substrate) AsFloat() (float64, error) {
+	return mixins.String{"rot13adl.internal.Substrate"}.AsFloat()
+}
+func (n *_Substrate) AsString() (string, error) {
+	return n.synthesized, nil
+}
+func (*_Substrate) AsBytes() ([]byte, error) {
+	return mixins.String{"rot13adl.internal.Substrate"}.AsBytes()
+}
+func (*_Substrate) AsLink() (ipld.Link, error) {
+	return mixins.String{"rot13adl.internal.Substrate"}.AsLink()
+}
+func (*_Substrate) Prototype() ipld.NodePrototype {
+	return _Substrate__Prototype{}
+}
+
+// -- NodePrototype -->
+
+var _ ipld.NodePrototype = Prototype{}
+
+type SubstrateRootPrototype = _Substrate__Prototype
+
+type _Substrate__Prototype struct {
+	// There's no configuration to this ADL.
+}
+
+func (np _Substrate__Prototype) NewBuilder() ipld.NodeBuilder {
+	return &_Substrate__Builder{}
+}
+
+// -- NodeBuilder -->
+
+var _ ipld.NodeBuilder = (*_Substrate__Builder)(nil)
+
+type _Substrate__Builder struct {
+	_Substrate__Assembler
+}
+
+func (nb *_Substrate__Builder) Build() ipld.Node {
+	if nb.m != schema.Maybe_Value {
+		panic("invalid state: cannot call Build on an assembler that's not finished")
+	}
+	return nb.w
+}
+func (nb *_Substrate__Builder) Reset() {
+	*nb = _Substrate__Builder{}
+}
+
+// -- NodeAssembler -->
+
+var _ ipld.NodeAssembler = (*_Substrate__Assembler)(nil)
+
+type _Substrate__Assembler struct {
+	w *_Substrate
+	m schema.Maybe // REVIEW: if the package where this Maybe enum lives is maybe not the right home for it after all.  Or should this line use something different?  We're only using some of its values after all.
+}
+
+func (_Substrate__Assembler) BeginMap(sizeHint int) (ipld.MapAssembler, error) {
+	return mixins.StringAssembler{"rot13adl.internal.Substrate"}.BeginMap(0)
+}
+func (_Substrate__Assembler) BeginList(sizeHint int) (ipld.ListAssembler, error) {
+	return mixins.StringAssembler{"rot13adl.internal.Substrate"}.BeginList(0)
+}
+func (na *_Substrate__Assembler) AssignNull() error {
+	// REVIEW: unclear how this might compose with some other context (like a schema) which does allow nulls.  Probably a wrapper type?
+	return mixins.StringAssembler{"rot13adl.internal.Substrate"}.AssignNull()
+}
+func (_Substrate__Assembler) AssignBool(bool) error {
+	return mixins.StringAssembler{"rot13adl.internal.Substrate"}.AssignBool(false)
+}
+func (_Substrate__Assembler) AssignInt(int) error {
+	return mixins.StringAssembler{"rot13adl.internal.Substrate"}.AssignInt(0)
+}
+func (_Substrate__Assembler) AssignFloat(float64) error {
+	return mixins.StringAssembler{"rot13adl.internal.Substrate"}.AssignFloat(0)
+}
+func (na *_Substrate__Assembler) AssignString(v string) error {
+	switch na.m {
+	case schema.Maybe_Value:
+		panic("invalid state: cannot assign into assembler that's already finished")
+	}
+	na.w = &_Substrate{
+		raw:         v,
+		synthesized: unrotate(v),
+	}
+	na.m = schema.Maybe_Value
+	return nil
+}
+func (_Substrate__Assembler) AssignBytes([]byte) error {
+	return mixins.StringAssembler{"rot13adl.internal.Substrate"}.AssignBytes(nil)
+}
+func (_Substrate__Assembler) AssignLink(ipld.Link) error {
+	return mixins.StringAssembler{"rot13adl.internal.Substrate"}.AssignLink(nil)
+}
+func (na *_Substrate__Assembler) AssignNode(v ipld.Node) error {
+	if v.IsNull() {
+		return na.AssignNull()
+	}
+	if v2, ok := v.(*_Substrate); ok {
+		switch na.m {
+		case schema.Maybe_Value:
+			panic("invalid state: cannot assign into assembler that's already finished")
+		}
+		na.w = v2
+		na.m = schema.Maybe_Value
+		return nil
+	}
+	if v2, err := v.AsString(); err != nil {
+		return err
+	} else {
+		return na.AssignString(v2)
+	}
+}
+func (_Substrate__Assembler) Prototype() ipld.NodePrototype {
+	return _Substrate__Prototype{}
+}

--- a/adl/rot13adl/rot13substrate.go
+++ b/adl/rot13adl/rot13substrate.go
@@ -67,7 +67,7 @@ func (*_Substrate) AsFloat() (float64, error) {
 	return mixins.String{"rot13adl.internal.Substrate"}.AsFloat()
 }
 func (n *_Substrate) AsString() (string, error) {
-	return n.synthesized, nil
+	return n.raw, nil
 }
 func (*_Substrate) AsBytes() ([]byte, error) {
 	return mixins.String{"rot13adl.internal.Substrate"}.AsBytes()
@@ -81,9 +81,7 @@ func (*_Substrate) Prototype() ipld.NodePrototype {
 
 // -- NodePrototype -->
 
-var _ ipld.NodePrototype = Prototype{}
-
-type SubstrateRootPrototype = _Substrate__Prototype
+var _ ipld.NodePrototype = _Substrate__Prototype{}
 
 type _Substrate__Prototype struct {
 	// There's no configuration to this ADL.

--- a/adl/rot13adl/rot13substrate.go
+++ b/adl/rot13adl/rot13substrate.go
@@ -20,6 +20,9 @@ var _ ipld.Node = (*_Substrate)(nil)
 
 // Somewhat unusually for an ADL, there's only one substrate node type,
 // and we actually made it have the same in-memory structure as the synthesized view node.
+//
+// When implementing other more complex ADLs, it will probably be more common to have
+// the synthesized high-level node type either embed or have a pointer to the substrate root node.
 type _Substrate _R13String
 
 // REVIEW: what on earth we think the "TypeName" strings in error messages and other references to this node should be.


### PR DESCRIPTION
I've been working on an ADL implementation for demo purposes -- a "rot13" ADL: it treats the raw data as a rot13 string, and rotates it for the high level view.  This is a pretty useless gadget... except it's so simple that I'm hoping it will make a good piece of example code, to help show what ADLs do and how their interfaces should work.  The goal of this is to be able to hand a link to this package to someone wanting to implement a new ADL, and have them get a lot of useful pointers about how to start implementing their own ideas in a new package of their own.

The package docs in the diff body say more about the publicly exported interfaces and what kind of logical contracts we expect from them, but in summary:

- there are high-level `Node`/`NodeBuilder`/`NodePrototype` types, which expose the synthesized view of the ADL after the data has been processed;
- there are "substrate" types as well, with their own `Node`/`NodeBuilder`/`NodePrototype` family.  In this case, there's only one of of them, but in more complex ADLs, there'd probably be a root type, and then the whole family again for the various other types of internal data (... *if* the ADL internals are specified by an IPLD Schema that is; it's not required for them to be!).
- there's a `Reify(maybeSubstrate Node) (synthesized Node, orNope error)` method to take substrate data already in memory and get an ADL out of it
- there's a `.Substrate() Node` method on the high-level ADL Node type which lets you get at the guts inside.

(You can imagine all the arrows between those modes: they should form a pretty cyclic graph -- you should be able to get from any view of the data to any other view pretty freely.)

There's a couple of design review questions I still don't have a confident final answer on; these are marked with "REVIEW" or "TODO" comments in the diff.  I'll start comment threads on them so we can discuss more here.  (I'm not sure all of them will need strict answers right now -- maybe some of it will be worth standardizing early; maybe some of this stuff might be totally fine developing in independent directions in various ADL projects for a while.  We'll see!)