### PR TITLE
codegen: make error info available when tuples process data that is too long.

### DIFF
--- a/schema/gen/go/genStructReprTuple.go
+++ b/schema/gen/go/genStructReprTuple.go
@@ -392,7 +392,7 @@ func (g structReprTupleReprBuilderGenerator) emitListAssemblerChildListAssembler
 				panic("invalid state: AssembleValue cannot be called on an assembler that's already finished")
 			}
 			if la.f >= {{ len .Type.Fields }} {
-				return nil // schema.ErrNoSuchField{Type: nil /*TODO*/, Field: ipld.PathSegmentOfInt({{ len .Type.Fields }})} // FIXME: need an error thunking assembler!  it has returned.  sigh.
+				return _ErrorThunkAssembler{schema.ErrNoSuchField{Type: nil /*TODO*/, Field: ipld.PathSegmentOfInt({{ len .Type.Fields }})}}
 			}
 			la.state = laState_midValue
 			switch la.f {


### PR DESCRIPTION
Make error info available when tuples process data that is too long.
 
(Should fix https://github.com/ipld/go-ipld-prime/issues/97 .)

This requires introducing an error-carrying NodeAssembler,
because the AssembleValue methods don't have the ability to return errors themselves.

AssembleValue methods have not needed to return errors before!
Most lists don't have any reason to error: out of our whole system,
it's only struct-with-tuple-representation that can have errors here,
due to tuples having length limits.
AssembleValue for maps doesn't have a similar challenge either,
because key invalidity can always be indicated by errors returned from
the key assembly process.

I'm not a big fan of this diff -- error carrying thunks like this are
ugly to write and they're also pretty ugly to use -- but I'm not sure
what would be better.  ListAssembler.AssembleValue returning an error?
Turning ListAssembler into a two phase thing, e.g. with an Advance
method that fills some of the same role as AssembleKey does for maps,
and gives us a place to return errors?