### PR TITLE
Codec revamp

### DIFF
--- a/codec/codectools/scratch/reader.go
+++ b/codec/codectools/scratch/reader.go
@@ -1,0 +1,280 @@
+package scratch
+
+import (
+	"io"
+)
+
+// Reader provides zero-copy read methods and other helpful utilities commonly desired in parsers
+// around either an io.Reader or a plain byte slice.
+//
+// Read methods with 'n' in the name take a size parameter for how much to read.
+// Read methods with a number in the name read that fixed number of bytes.
+// Read methods with 'b' in the name accept a byte slice parameter which will be used for output, allowing you to control memory reuse.
+// Read methods with 'z' in the name will attempt to return zero-copy access to buffers controlled by the Reader --
+// be careful when using these 'z' methods; it is not recommended to expose the zero-copy slices these methods yield,
+// because the reader itself may also reuse them, and so the likelihood of spooky-action-at-a-distance bugs is high.
+//
+// While this Reader does some buffering, it's not much (and primarily oriented around reuse of scratch buffers rather than intentionly large batch readaheads);
+// it may still be advisable to use a buffered reader to avoid small reads if reading streamingly from external IO like disk or network.
+type Reader struct {
+	stream     io.Reader                 // source to keep pumping, or may be nil if we're wrapping a single already-in-memory slice and we know it.
+	buf        []byte                    // alternative to `stream`, if we have a single already-in-memory slice and we know it.
+	cursor     int                       // position of start of next read, if we're using `buf`.
+	scratch    [scratchByteArrayLen]byte // temp byte array re-used internally for efficiency during read.  'readz' methods return views into this.
+	numRead    int64                     // aggregate number of bytes read (since last reset of numRead, anyway).
+	tracked    []byte                    // bytes that have been read while we've been in tracking state.  a subslice of `buf` where possible, but may be its own alloc if we're in streaming mode.
+	unread     byte                      // a byte tracked for the potential need for unreading.  only used if using `stream`; if using `buf`, we just adjusted `cursor`.
+	isTracking bool                      // whether we're in the tracking state.
+	canUnread  bool                      // whether unread is currently valid.
+	haveUnread bool                      // whether we need to replay an unread byte.  only checked when in `stream` mode, because `buf` mode just adjusts `cursor`.
+}
+
+// You'll find many implementation methods have a large switch around `z.stream == nil`.
+// This is effectively a toggle for whether we're operating in streaming mode or on already-in-memory byte slices.
+// This would've been cleaner code with an interface and two implementations -- no doubt!
+// However, it ends up less inliner-friendly if an interface is involved.
+//
+// Stylistically: I've allowed rightward drift in 'if' cases for stream vs buf mode,
+// rather than using the usual golang rule of thumb about early returns.  I find this easier to read, given the semiotics.
+//
+// FUTURE: it may be worth reviewing the utility of this when go1.16 is out -- some of its features for optimization
+//  through interfaces when concrete types can be inferred might change the consequences of this design quite a bit.
+
+const (
+	scratchByteArrayLen = 32
+)
+
+var (
+	zeroByteSlice = []byte{}[:0:0]
+)
+
+// Init makes this Reader ready to consume the given io.Reader.
+// If this Reader has been used before, all state is zeroed out cleanly.
+//
+// As a convenience, if the io.Reader looks like it can return all the bytes at once
+// (e.g., it has a `Bytes() []byte` method -- as bytes.Buffer does, for example),
+// then Init will access that and use InitSlice, which should lead to better performance.
+func (z *Reader) Init(r io.Reader) {
+	type BytesAccessor interface {
+		Bytes() []byte
+	}
+	if ba, ok := r.(BytesAccessor); ok {
+		z.InitSlice(ba.Bytes())
+	} else {
+		z.InitReader(r)
+	}
+}
+
+// InitSlice makes this Reader ready to consume the given byte slice.
+// If this Reader has been used before, all state is zeroed out cleanly.
+//
+// InitSlice is functionally equivalent to wrapping the byte slice in a reader and using Init,
+// but will result in a Reader that generally operates somewhat faster and is able to deliver more zero-copy behaviors.
+// (When we know we're working with a byte slice that's already entirely in memory,
+// we never have to worry about read alignment, etc.)
+func (z *Reader) InitSlice(bs []byte) {
+	*z = Reader{}
+	z.buf = bs
+}
+
+// InitReader makes this Reader ready to consume the given io.Reader.
+// If this Reader has been used before, all state is zeroed out cleanly.
+//
+// Unlike Init, this initializer will not attempt to autodetect any interface
+// which may provide direct access to underlying byte slices; it will always work in stream mode.
+func (z *Reader) InitReader(r io.Reader) {
+	*z = Reader{} // FUTURE: this could try to recycle any capacity in z.tracked.
+	z.stream = r
+}
+
+// Readnzc read up to n bytes into a byte slice which may be shared and must not be reused after any additional calls to this reader.
+// Readnzc will use the implementation scratch buffer if possible, (i.e. n < scratchByteArrayLen),
+// or may return a view of the []byte being decoded from if the read is larger.
+// If there is less than n bytes to be read, a shorter slice will be returned, and err will be ErrUnexpectedEOF.
+// Requesting a zero length read will return `zeroByteSlice`, a len-zero cap-zero slice.
+// If you know your read may be longer than scratchByteArrayLen and
+// you already have an existing slice of sufficient size to reuse, prefer `Readb`.
+func (z *Reader) Readnzc(n int) (bs []byte, err error) {
+	if n == 0 {
+		return zeroByteSlice, nil
+	}
+	z.canUnread = false
+	if z.stream == nil { // in `buf` mode, we can just return subslices.
+		remaining := len(z.buf) - z.cursor
+		if n > remaining { // partial read from end of buf
+			n = remaining             // mostly the same, just shorter
+			err = io.ErrUnexpectedEOF // and give notice of the short read
+		}
+		bs = z.buf[z.cursor : z.cursor+n]
+		z.cursor += n
+		z.numRead += int64(n)
+		if z.isTracking {
+			z.tracked = z.tracked[:len(z.tracked)+n] // See TestTechniqueSliceExtension if this bewilders you.
+		}
+		return
+	} else { // in `stream` mode, we'll set up buffers, then use Readb do to most of the work.
+		if n < len(z.scratch) { // read from stream and fits in scratch
+			bs = z.scratch[:n]
+		} else { // read from stream and needs a new allocation
+			bs = make([]byte, n) // this is a sadpath; you should've used Readb.
+		}
+		n, err = z.readStream(bs)
+		return bs[:n], err
+	}
+}
+
+// Readb reads up to `len(b)` bytes into the given slice, starting at its beginning,
+// overwriting all values, and disregarding any extra capacity.
+// If the there is less than `len(b)` bytes to be read, a partial read will be returned:
+// some of the slice will be modified, n will be less than the slice length, and err will be ErrUnexpectedEOF.
+// (If you're intentionally providing a larger slice than may be necessary in order to get a batch read,
+// you will want to check for and discard ErrUnexpectedEOF!)
+// If no error is returned, n will always be the length of the slice.
+//
+// Readb will never return a zero-copy subslice of an existing buffer;
+// use one of the 'Read*z*' methods for that.
+func (z *Reader) Readb(bs []byte) (n int, err error) {
+	if len(bs) == 0 {
+		return 0, nil
+	}
+	z.canUnread = false
+	if z.stream == nil { // in `buf` mode, we can just return subslices.
+		n = len(bs)
+		remaining := len(z.buf) - z.cursor
+		if n > remaining { // partial read from end of buf
+			n = remaining             // mostly the same, just shorter
+			err = io.ErrUnexpectedEOF // and give notice of the short read
+		}
+		copy(bs, z.buf[z.cursor:z.cursor+n])
+		z.cursor += n
+		z.numRead += int64(n)
+		if z.isTracking {
+			z.tracked = z.tracked[:len(z.tracked)+n] // See TestTechniqueSliceExtension if this bewilders you.
+		}
+		return
+	} else {
+		return z.readStream(bs)
+	}
+}
+
+func (z *Reader) readStream(bs []byte) (n int, err error) {
+	// fun note: a corresponding readBuf method turned out not useful to create,
+	//  because the different return conventions of the exported methods actually matter to what shortcuts we can take when wrangling raw slices
+	//   (whereas the impact of those return conventions turn out not to carry as far when we already have to handle extra slices as we do in `stream` mode).
+
+	// In `stream` mode, we first handle replaying unreads if necessary; then, use io.ReadAtLeast to load as much data as requested.
+	if z.haveUnread {
+		bs[0] = z.unread
+		z.haveUnread = false
+		n, err = io.ReadAtLeast(z.stream, bs[1:], len(bs)-1)
+		n++
+	} else {
+		n, err = io.ReadAtLeast(z.stream, bs, len(bs))
+	}
+	z.numRead += int64(n)
+	if z.isTracking {
+		z.tracked = append(z.tracked, bs[:n]...)
+	}
+	return
+}
+
+// Readn reads up to n bytes into a new byte slice.
+// If there is less than n bytes to be read, a shorter slice will be returned, and err will be ErrUnexpectedEOF.
+// If zero-copy views into existing buffers are acceptable (e.g. you know you
+// won't later mutate, reference or expose this memory again), prefer `Readnzc`.
+// If you already have an existing slice of sufficient size to reuse, prefer `Readb`.
+// Requesting a zero length read will return `zeroByteSlice`, a len-zero cap-zero slice.
+//
+// Readn will never return a zero-copy subslice of an existing buffer;
+// use one of the 'Read*z*' methods for that.
+// (Readn is purely a convenience method; you can always use Readb to equivalent effect.)
+func (z *Reader) Readn(n int) (bs []byte, err error) {
+	if n == 0 {
+		return zeroByteSlice, nil
+	}
+	// This really is just a convenience method.  It's the same regardless of mode we're in.
+	bs = make([]byte, n)
+	n, err = z.Readb(bs)
+	return bs[:n], err
+}
+
+// Readn1 reads a single byte.
+func (z *Reader) Readn1() (byte, error) {
+	// Just use Readnzc, which handles any tracking shifts, and also any unread replays, transparently.
+	//  Hopefully the compiler is clever enough to make the assembly shorter than the source.
+	//   REVIEW: may want to look especially at the benchmark and the assembly on this; it might be improvable by hand-rolling more of this specialization,
+	//    and it's probably important to do so, considering how much of parsing for textual formats like json involves single-byte scanning.
+	bs, err := z.Readnzc(1)
+	if err != nil {
+		return 0, err
+	}
+	z.canUnread = true
+	z.unread = bs[0]
+	return bs[0], nil
+}
+
+// Unreadn1 "unreads" a single byte which was previously read by Readn1.
+// The result is that subsequent reads will include that byte,
+// and applying the Track method will also cause the track result to include that byte.
+//
+// Unreadn1 can only be used when the previous call was Readn1, and may panic otherwise.
+func (z *Reader) Unreadn1() {
+	if !z.canUnread {
+		panic("Unreadn1 can only be used following Readn1")
+	}
+	z.canUnread = false
+	z.numRead--
+	if z.isTracking {
+		z.tracked = z.tracked[0 : len(z.tracked)-1]
+	}
+	if z.stream == nil {
+		z.cursor--
+	} else {
+		z.haveUnread = true
+	}
+}
+
+func (z *Reader) NumRead() int64 {
+	return z.numRead
+}
+
+func (z *Reader) ResetNumRead() {
+	z.numRead = 0
+}
+
+// Track causes the Reader to place a marker and accumulate all bytes into a single contiguous slice
+// up until StopTrack is called; StopTrack will return a reference to this slice.
+// Thus, StopTrack will yield bytes which have already also been seen via other read method calls.
+//
+// This can be useful when parsing logic requires scanning ahead to look for the end of an unknown-length segment of data, for example.
+//
+// Calling Track twice without an intervening StopTrack will result in panic.
+func (z *Reader) Track() {
+	if z.isTracking {
+		panic("Track cannot be called again when already tracking")
+	}
+	z.isTracking = true
+	if z.stream == nil {
+		// save the start position.  we'll just extend the length of it over the cap of buf as we go forward.
+		z.tracked = z.buf[z.cursor:z.cursor]
+	} else {
+		// nothing to do for stream mode; it'll just accumulate naturally through appends.
+	}
+}
+
+// StopTrack returns the byte slice accumulated since Track was called, and drops the marker.
+//
+// Calling StopTrack when Track is not in effect will result in panic.
+//
+// The slice returned by StopTrack may be reused if Track is called again in the future;
+// the caller should copy the contents to a new byte slice before the next call to Track
+// they intend to either make this data available for a long time or to mutate it.
+func (z *Reader) StopTrack() []byte {
+	if !z.isTracking {
+		panic("StopTrack cannot be called when not tracking")
+	}
+	z.isTracking = false
+	answer := z.tracked
+	z.tracked = z.tracked[0:0]
+	return answer
+}

--- a/codec/codectools/scratch/reader_test.go
+++ b/codec/codectools/scratch/reader_test.go
@@ -1,0 +1,202 @@
+package scratch
+
+import (
+	"bytes"
+	"io"
+	"runtime"
+	"testing"
+
+	. "github.com/warpfork/go-wish"
+)
+
+func someBytes(lo, hi byte) []byte {
+	bs := make([]byte, hi-lo)
+	for i := lo; i < hi; i++ {
+		bs[i-lo] = byte(i)
+	}
+	return bs
+}
+
+var m1, m2 runtime.MemStats
+
+func init() {
+	runtime.GOMAXPROCS(1) // necessary for asking precise questions about allocation.
+	runtime.GC()          // magic.  shouldn't be necessary.  is.
+}
+func memCheckpoint() {
+	runtime.GC()
+	runtime.ReadMemStats(&m1)
+}
+func newMallocs() int {
+	runtime.GC()
+	runtime.ReadMemStats(&m2)
+	return int(m2.Mallocs - m1.Mallocs)
+}
+
+func TestReader(t *testing.T) {
+	tests := func(t *testing.T, r *Reader, streaming bool) {
+		// This is looks like one big nasty long walk, and so it is, but...
+		//  the point is to test stateful interactions, so to write it this way is telling the truth.
+
+		// Fixed length short read should work.
+		memCheckpoint()
+		bs, err := r.Readnzc(4)
+		Wish(t, newMallocs(), ShouldEqual, 0) // in either mode, should be hitting the scratch slice.
+		Wish(t, err, ShouldEqual, nil)
+		Wish(t, bs, ShouldEqual, []byte{0, 1, 2, 3})
+		Wish(t, r.NumRead(), ShouldEqual, int64(4))
+
+		// Another read should work.
+		memCheckpoint()
+		bs, err = r.Readnzc(4)
+		Wish(t, newMallocs(), ShouldEqual, 0) // in either mode, should be hitting the scratch slice.
+		Wish(t, err, ShouldEqual, nil)
+		Wish(t, bs, ShouldEqual, []byte{4, 5, 6, 7})
+		Wish(t, r.NumRead(), ShouldEqual, int64(8))
+
+		// Single-byte reads should work.
+		memCheckpoint()
+		b, err := r.Readn1()
+		Wish(t, newMallocs(), ShouldEqual, 0) // in either mode, should be hitting the scratch slice.
+		Wish(t, err, ShouldEqual, nil)
+		Wish(t, b, ShouldEqual, byte(8))
+		Wish(t, r.NumRead(), ShouldEqual, int64(9))
+
+		// Unread should be valid at this point.
+		memCheckpoint()
+		r.Unreadn1()
+		Wish(t, newMallocs(), ShouldEqual, 0) // no reason at all for this to ever alloc.
+		Wish(t, r.NumRead(), ShouldEqual, int64(8))
+
+		// Single byte reads should re-read the unread byte.
+		memCheckpoint()
+		b, err = r.Readn1()
+		Wish(t, newMallocs(), ShouldEqual, 0) // shouldn't allocate no matter how it's implemented.
+		Wish(t, err, ShouldEqual, nil)
+		Wish(t, b, ShouldEqual, byte(8))
+		Wish(t, r.NumRead(), ShouldEqual, int64(9))
+
+		// Unread again to set up for next check.
+		r.Unreadn1()
+		Wish(t, r.NumRead(), ShouldEqual, int64(8))
+
+		// Any length of read should get the unread byte.
+		bs = make([]byte, 6)
+		memCheckpoint()
+		n, err := r.Readb(bs)
+		Wish(t, newMallocs(), ShouldEqual, 0) // alloc was done by caller; shouldn't be any more.
+		Wish(t, err, ShouldEqual, nil)
+		Wish(t, n, ShouldEqual, 6)
+		Wish(t, bs, ShouldEqual, []byte{8, 9, 10, 11, 12, 13})
+		Wish(t, r.NumRead(), ShouldEqual, int64(14))
+
+		// Tracking should work.
+		memCheckpoint()
+		r.Track()
+		Wish(t, newMallocs(), ShouldEqual, 0)
+
+		// Continue reading ahead while tracking.
+		memCheckpoint()
+		n, err = r.Readb(bs)
+		if streaming {
+			Wish(t, newMallocs(), ShouldEqual, 1) // streaming has to start a new buffer here.
+		} else {
+			Wish(t, newMallocs(), ShouldEqual, 0) // if in buf mode, it's all subslicing.
+		}
+		Wish(t, err, ShouldEqual, nil)
+		Wish(t, n, ShouldEqual, 6)
+		Wish(t, bs, ShouldEqual, []byte{14, 15, 16, 17, 18, 19})
+		Wish(t, r.NumRead(), ShouldEqual, int64(20))
+
+		// More reading while tracking.
+		memCheckpoint()
+		b, err = r.Readn1()
+		Wish(t, newMallocs(), ShouldEqual, 0) // if in buf mode, subslicing; if in stream mode, happens to be amortized.
+		Wish(t, err, ShouldEqual, nil)
+		Wish(t, b, ShouldEqual, byte(20))
+		Wish(t, r.NumRead(), ShouldEqual, int64(21))
+		b, err = r.Readn1()
+		Wish(t, err, ShouldEqual, nil)
+		Wish(t, b, ShouldEqual, byte(21))
+		Wish(t, r.NumRead(), ShouldEqual, int64(22))
+
+		// And an unread while tracking.
+		r.Unreadn1()
+		Wish(t, r.NumRead(), ShouldEqual, int64(21))
+
+		// Poke every variation of read while tracking.
+		memCheckpoint()
+		bs, err = r.Readnzc(5)
+		if streaming {
+			Wish(t, newMallocs(), ShouldEqual, 1) // streaming happens to stride over an amortization threshhold here, causing an alloc during growing the tracking slice.
+		} else {
+			Wish(t, newMallocs(), ShouldEqual, 0) // if in buf mode, it's all subslicing.
+		}
+		Wish(t, err, ShouldEqual, nil)
+		Wish(t, bs, ShouldEqual, []byte{21, 22, 23, 24, 25})
+		Wish(t, r.NumRead(), ShouldEqual, int64(26))
+
+		// StopTrack should yield all that in duplicate.
+		memCheckpoint()
+		bs = r.StopTrack()
+		Wish(t, newMallocs(), ShouldEqual, 0) // in either mode, all the allocations (if any!) were already done.
+		Wish(t, bs, ShouldEqual, someBytes(14, 26))
+		Wish(t, r.NumRead(), ShouldEqual, int64(26))
+
+		// Read outside of tracking.
+		memCheckpoint()
+		bs, err = r.Readnzc(4)
+		Wish(t, newMallocs(), ShouldEqual, 0) // in either mode, should be hitting the scratch slice.
+		Wish(t, err, ShouldEqual, nil)
+		Wish(t, bs, ShouldEqual, someBytes(26, 30))
+		Wish(t, r.NumRead(), ShouldEqual, int64(30))
+
+		// Subsequent tracks should still work right.
+		memCheckpoint()
+		r.Track()
+		r.Readnzc(4)
+		r.Readnzc(2)
+		bs = r.StopTrack()
+		Wish(t, newMallocs(), ShouldEqual, 0) // amount read is smaller than previous tracking buffer, so shouldn't alloc even in stream mode.
+		Wish(t, bs, ShouldEqual, someBytes(30, 36))
+		Wish(t, r.NumRead(), ShouldEqual, int64(36))
+
+		// Read us past the end.  Should get an error warning so.
+		memCheckpoint()
+		bs, err = r.Readnzc(300)
+		if streaming {
+			Wish(t, newMallocs(), ShouldEqual, 1) // this read is bigger than scratchByteArrayLen, so it allocs.
+		} else {
+			Wish(t, newMallocs(), ShouldEqual, 0) // if in buf mode, it's STILL all subslicing.
+		}
+		Wish(t, err, ShouldEqual, io.ErrUnexpectedEOF)
+		Wish(t, bs, ShouldEqual, someBytes(36, 64))
+		Wish(t, r.NumRead(), ShouldEqual, int64(64))
+	}
+	t.Run("StreamMode", func(t *testing.T) {
+		var r Reader
+		r.InitReader(bytes.NewBuffer(someBytes(0, 64)))
+		tests(t, &r, true)
+	})
+	t.Run("SliceMode", func(t *testing.T) {
+		var r Reader
+		r.InitSlice(someBytes(0, 64))
+		tests(t, &r, false)
+	})
+}
+
+// TestTechniqueSliceExtension is just a quick demo on how slice extension works, meant for human reading.
+// Long story short: yeah, you can actually use subslicing syntax to just tell a slice to get longer from its current position if it still has cap;
+// and you can use this to peek back into memory that you had previously removed from view by subslicing.
+func TestTechniqueSliceExtension(t *testing.T) {
+	slice := make([]int, 10, 10)
+	slice[5] = 5
+	slice[9] = 9
+	t.Logf("slice len = %d cap = %d", len(slice), cap(slice))
+	subslice := slice[3:5] // if we *really* wanted to drop ability to ever see "5" and "9" again, we'd want to do `[3:5:5]` here.
+	t.Logf("subslice len = %d cap = %d", len(subslice), cap(subslice))
+	t.Logf("subslice: %v", subslice) // should show up just zeros -- the "5" and "9" are both in the cap area but in reach of len.
+	subslice2 := subslice[0:5]
+	t.Logf("subslice2 len = %d cap = %d", len(subslice2), cap(subslice2))
+	t.Logf("subslice2: %v", subslice2) // should show up the "5" again
+}

--- a/codec/codectools/scratch/reader_test.go
+++ b/codec/codectools/scratch/reader_test.go
@@ -38,6 +38,11 @@ func TestReader(t *testing.T) {
 		// This is looks like one big nasty long walk, and so it is, but...
 		//  the point is to test stateful interactions, so to write it this way is telling the truth.
 
+		// Force one more GC before we begin our accounting.
+		// (This doesn't really seem like it should be necessary, because indeed, memCheckpoint is also doing a forced GC;
+		//  but empirically (at least as of go1.15), it is; flakey numbers for the very first test will result without this double-GC to prime things.)
+		runtime.GC()
+
 		// Fixed length short read should work.
 		memCheckpoint()
 		bs, err := r.Readnzc(4)

--- a/codec/dagjson2/doc.go
+++ b/codec/dagjson2/doc.go
@@ -1,0 +1,14 @@
+// Several groups of exported symbols are available at different levels of abstraction:
+//
+//   - You might just want the multicodec registration!  Then never deal with this package directly again.
+//   - You might want to use the `Encode(Node,Writer)` and `Decode(NodeAssembler,Reader)` functions directly.
+//   - You might want to use `ReusableEncoder` and `ReusableDecoder` types and their configuration options,
+//     then use their Encode and Decode methods with that additional control.
+//   - You might want to use the lower-level TokenReader and TokenWriter tools to process the serial data
+//     as a stream, without necessary creating ipld Nodes at all.
+//   - (this is a stretch) You might want to use some of the individual token processing functions,
+//     perhaps as part of a totally new codec that just happens to share some behaviors with this one.
+//
+// The first three are exported from this package.
+// The last two can be found in the "./token" subpackage.
+package dagjson

--- a/codec/dagjson2/json_unmarshaller.go
+++ b/codec/dagjson2/json_unmarshaller.go
@@ -1,0 +1,55 @@
+package dagjson
+
+import (
+	"io"
+
+	"github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/codec/codectools"
+	"github.com/ipld/go-ipld-prime/codec/dagjson2/token"
+)
+
+// Unmarshal reads data from input, parses it as DAG-JSON,
+// and unfolds the data into the given NodeAssembler.
+//
+// The strict interpretation of DAG-JSON is used.
+// Use a ReusableMarshaller and set its DecoderConfig if you need
+// looser or otherwise customized decoding rules.
+//
+// This function is the same as the function found for DAG-JSON
+// in the default multicodec registry.
+func Unmarshal(into ipld.NodeAssembler, input io.Reader) error {
+	// FUTURE: consider doing a whole sync.Pool jazz around this.
+	r := ReusableUnmarshaller{}
+	r.SetDecoderConfig(jsontoken.DecoderConfig{
+		AllowDanglingComma:  false,
+		AllowWhitespace:     false,
+		AllowEscapedUnicode: false,
+		ParseUtf8C8:         true,
+	})
+	r.SetInitialBudget(1 << 20)
+	return r.Unmarshal(into, input)
+}
+
+// ReusableUnmarshaller has an Unmarshal method, and also supports
+// customizable DecoderConfig and resource budgets.
+//
+// The Unmarshal method may be used repeatedly (although not concurrently).
+// Keeping a ReusableUnmarshaller around and using it repeatedly may allow
+// the user to amortize some allocations (some internal buffers can be reused).
+type ReusableUnmarshaller struct {
+	d jsontoken.Decoder
+
+	InitialBudget int
+}
+
+func (r *ReusableUnmarshaller) SetDecoderConfig(cfg jsontoken.DecoderConfig) {
+	r.d.DecoderConfig = cfg
+}
+func (r *ReusableUnmarshaller) SetInitialBudget(budget int) {
+	r.InitialBudget = budget
+}
+
+func (r *ReusableUnmarshaller) Unmarshal(into ipld.NodeAssembler, input io.Reader) error {
+	r.d.Init(input)
+	return codectools.TokenAssemble(into, r.d.Step, r.InitialBudget)
+}

--- a/codec/dagjson2/token/json_decode.go
+++ b/codec/dagjson2/token/json_decode.go
@@ -1,0 +1,240 @@
+package jsontoken
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/ipld/go-ipld-prime/codec/codectools"
+	"github.com/ipld/go-ipld-prime/codec/codectools/scratch"
+)
+
+type Decoder struct {
+	r scratch.Reader
+
+	phase decoderPhase   // current phase.
+	stack []decoderPhase // stack of any phases that need to be popped back up to before we're done with a complete tree.
+	some  bool           // true after first value in any context; use to decide if a comma must precede the next value.  (doesn't need a stack, because if you're popping, it's true again.)
+
+	tok codectools.Token // we'll be yielding this repeatedly.
+
+	DecoderConfig
+}
+
+type DecoderConfig struct {
+	AllowDanglingComma  bool // normal json: false; strict: false.
+	AllowWhitespace     bool // normal json: true;  strict: false.
+	AllowEscapedUnicode bool // normal json: true;  strict: false.
+	ParseUtf8C8         bool // normal json: false; dag-json: true.
+}
+
+func (d *Decoder) Init(r io.Reader) {
+	d.r.Init(r)
+	d.phase = decoderPhase_acceptValue
+	d.stack = d.stack[0:0]
+	d.some = false
+}
+
+func (d *Decoder) Step(budget *int) (next *codectools.Token, err error) {
+	switch d.phase {
+	case decoderPhase_acceptValue:
+		err = d.step_acceptValue()
+	case decoderPhase_acceptMapKeyOrEnd:
+		err = d.step_acceptMapKeyOrEnd()
+	case decoderPhase_acceptMapValue:
+		err = d.step_acceptMapValue()
+	case decoderPhase_acceptListValueOrEnd:
+		err = d.step_acceptListValueOrEnd()
+	}
+	return &d.tok, err
+}
+
+func (d *Decoder) pushPhase(newPhase decoderPhase) {
+	d.stack = append(d.stack, d.phase)
+	d.phase = newPhase
+	d.some = false
+}
+
+func (d *Decoder) popPhase() {
+	d.phase = d.stack[len(d.stack)-1]
+	d.stack = d.stack[:len(d.stack)-1]
+	d.some = true
+}
+
+type decoderPhase uint8
+
+const (
+	decoderPhase_acceptValue decoderPhase = iota
+	decoderPhase_acceptMapKeyOrEnd
+	decoderPhase_acceptMapValue
+	decoderPhase_acceptListValueOrEnd
+)
+
+func (d *Decoder) readn1skippingWhitespace() (majorByte byte, err error) {
+	if d.DecoderConfig.AllowWhitespace {
+		for {
+			majorByte, err = d.r.Readn1()
+			switch majorByte {
+			case ' ', '\t', '\r', '\n': // continue
+			default:
+				return
+			}
+		}
+	} else {
+		for {
+			majorByte, err = d.r.Readn1()
+			switch majorByte {
+			case ' ', '\t', '\r', '\n':
+				return 0, fmt.Errorf("whitespace not allowed by decoder configured for strictness")
+			default:
+				return
+			}
+		}
+	}
+}
+
+// The original step, where any value is accepted, and no terminators for recursives are valid.
+// ONLY used in the original step; all other steps handle leaf nodes internally.
+func (d *Decoder) step_acceptValue() error {
+	majorByte, err := d.r.Readn1()
+	if err != nil {
+		return err
+	}
+	return d.stepHelper_acceptValue(majorByte)
+}
+
+// Step in midst of decoding a map, key expected up next, or end.
+func (d *Decoder) step_acceptMapKeyOrEnd() error {
+	majorByte, err := d.readn1skippingWhitespace()
+	if err != nil {
+		return err
+	}
+	if d.some {
+		switch majorByte {
+		case '}':
+			d.tok.Kind = codectools.TokenKind_MapClose
+			d.popPhase()
+			return nil
+		case ',':
+			majorByte, err = d.readn1skippingWhitespace()
+			if err != nil {
+				return err
+			}
+			// and now fall through to the next switch
+			// FIXME: AllowDanglingComma needs a check hereabouts
+		}
+	}
+	switch majorByte {
+	case '}':
+		d.tok.Kind = codectools.TokenKind_MapClose
+		d.popPhase()
+		return nil
+	default:
+		// Consume a value for key.
+		//  Given that this is JSON, this has to be a string.
+		err := d.stepHelper_acceptValue(majorByte)
+		if err != nil {
+			return err
+		}
+		if d.tok.Kind != codectools.TokenKind_String {
+			return fmt.Errorf("unexpected non-string token where expecting a map key")
+		}
+		// Now scan up to consume the colon as well, which is required next.
+		majorByte, err = d.readn1skippingWhitespace()
+		if err != nil {
+			return err
+		}
+		if majorByte != ':' {
+			return fmt.Errorf("expected colon after map key; got 0x%x", majorByte)
+		}
+		// Next up: expect a value.
+		d.phase = decoderPhase_acceptMapValue
+		d.some = true
+		return nil
+	}
+}
+
+// Step in midst of decoding a map, value expected up next.
+func (d *Decoder) step_acceptMapValue() error {
+	majorByte, err := d.readn1skippingWhitespace()
+	if err != nil {
+		return err
+	}
+	d.phase = decoderPhase_acceptMapKeyOrEnd
+	return d.stepHelper_acceptValue(majorByte)
+}
+
+// Step in midst of decoding an array.
+func (d *Decoder) step_acceptListValueOrEnd() error {
+	majorByte, err := d.readn1skippingWhitespace()
+	if err != nil {
+		return err
+	}
+	if d.some {
+		switch majorByte {
+		case ']':
+			d.tok.Kind = codectools.TokenKind_ListClose
+			d.popPhase()
+			return nil
+		case ',':
+			majorByte, err = d.readn1skippingWhitespace()
+			if err != nil {
+				return err
+			}
+			// and now fall through to the next switch
+			// FIXME: AllowDanglingComma needs a check hereabouts
+		}
+	}
+	switch majorByte {
+	case ']':
+		d.tok.Kind = codectools.TokenKind_ListClose
+		d.popPhase()
+		return nil
+	default:
+		d.some = true
+		return d.stepHelper_acceptValue(majorByte)
+	}
+}
+
+func (d *Decoder) stepHelper_acceptValue(majorByte byte) (err error) {
+	switch majorByte {
+	case '{':
+		d.tok.Kind = codectools.TokenKind_MapOpen
+		d.tok.Length = -1
+		d.pushPhase(decoderPhase_acceptMapKeyOrEnd)
+		return nil
+	case '[':
+		d.tok.Kind = codectools.TokenKind_ListOpen
+		d.tok.Length = -1
+		d.pushPhase(decoderPhase_acceptListValueOrEnd)
+		return nil
+	case 'n':
+		d.r.Readnzc(3) // FIXME must check these equal "ull"!
+		d.tok.Kind = codectools.TokenKind_Null
+		return nil
+	case '"':
+		d.tok.Kind = codectools.TokenKind_String
+		d.tok.Str, err = DecodeStringBody(&d.r)
+		if err == nil {
+			d.r.Readn1() // Swallow the trailing `"` (which DecodeStringBody has insured we have).
+		}
+		return err
+	case 'f':
+		d.r.Readnzc(4) // FIXME must check these equal "alse"!
+		d.tok.Kind = codectools.TokenKind_Bool
+		d.tok.Bool = false
+		return nil
+	case 't':
+		d.r.Readnzc(3) // FIXME must check these equal "rue"!
+		d.tok.Kind = codectools.TokenKind_Bool
+		d.tok.Bool = true
+		return nil
+	case '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
+		// Some kind of numeric... but in json, we can't tell if it's float or int.  At least, certainly not yet.
+		// We'll have to look ahead quite a bit more to try to differentiate.  The decodeNumber function does this for us.
+		d.r.Unreadn1()
+		d.tok.Kind, d.tok.Int, d.tok.Float, err = DecodeNumber(&d.r)
+		return err
+	default:
+		return fmt.Errorf("Invalid byte while expecting start of value: 0x%x", majorByte)
+	}
+}

--- a/codec/dagjson2/token/json_decode_number.go
+++ b/codec/dagjson2/token/json_decode_number.go
@@ -1,0 +1,154 @@
+package jsontoken
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+
+	"github.com/ipld/go-ipld-prime/codec/codectools"
+	"github.com/ipld/go-ipld-prime/codec/codectools/scratch"
+)
+
+// License note: the string and numeric parsers here borrow
+// heavily from the golang stdlib json parser scanner.
+// That code is originally Copyright 2010 The Go Authors,
+// and is governed by a BSD-style license.
+
+// DecodeNumber will attempt to decode data in the format of a JSON numer from the reader.
+// JSON is somewhat ambiguous about numbers: we'll return an int if we can, and a float if there's any decimal point involved.
+// The boolean return indicates which kind of number we have:
+// if true, we have an int (and the float return is invalid);
+// if false, we have a float (and the int return is invalid).
+func DecodeNumber(r *scratch.Reader) (codectools.TokenKind, int64, float64, error) {
+	r.Track()
+	// Scan until scanner tells us end of numeric.
+	// Pick the first scanner stepfunc based on the leading byte.
+	majorByte, err := r.Readn1()
+	if err != nil {
+		return codectools.TokenKind_Null, 0, 0, err
+	}
+	var step numscanStep
+	switch majorByte {
+	case '-':
+		step = numscan_neg
+	case '0':
+		step = numscan_0
+	case '1', '2', '3', '4', '5', '6', '7', '8', '9':
+		step = numscan_1
+	default:
+		panic("unreachable") // FIXME not anymore it ain't, this is exported
+	}
+	for {
+		b, err := r.Readn1()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return 0, 0, 0, err
+		}
+		step, err = step(b)
+		if step == nil {
+			// Unread one.  The scan loop consumed one char beyond the end (this is unavoidable in json!),
+			//  and that might be part of what whatever is going to be decoded from this stream next.
+			r.Unreadn1()
+			break
+		}
+		if err != nil {
+			return 0, 0, 0, err
+		}
+	}
+	// Parse!
+	// *This is not a fast parse*.
+	// Try int first; if it fails try float; if that fails return the float error.
+	s := string(r.StopTrack())
+	if i, err := strconv.ParseInt(s, 10, 64); err == nil {
+		return codectools.TokenKind_Int, i, 0, nil
+	}
+	f, err := strconv.ParseFloat(s, 64)
+	return codectools.TokenKind_Float, 0, f, err
+}
+
+// Scan steps are looped over the stream to find how long the number is.
+// A nil step func is returned to indicate the string is done.
+// Actually parsing the string is done by 'parseString()'.
+type numscanStep func(c byte) (numscanStep, error)
+
+// numscan_neg is the state after reading `-` during a number.
+func numscan_neg(c byte) (numscanStep, error) {
+	if c == '0' {
+		return numscan_0, nil
+	}
+	if '1' <= c && c <= '9' {
+		return numscan_1, nil
+	}
+	return nil, fmt.Errorf("invalid byte in numeric literal: 0x%x", c)
+}
+
+// numscan_1 is the state after reading a non-zero integer during a number,
+// such as after reading `1` or `100` but not `0`.
+func numscan_1(c byte) (numscanStep, error) {
+	if '0' <= c && c <= '9' {
+		return numscan_1, nil
+	}
+	return numscan_0(c)
+}
+
+// numscan_0 is the state after reading `0` during a number.
+func numscan_0(c byte) (numscanStep, error) {
+	if c == '.' {
+		return numscan_dot, nil
+	}
+	if c == 'e' || c == 'E' {
+		return numscan_e, nil
+	}
+	return nil, nil
+}
+
+// numscan_dot is the state after reading the integer and decimal point in a number,
+// such as after reading `1.`.
+func numscan_dot(c byte) (numscanStep, error) {
+	if '0' <= c && c <= '9' {
+		return numscan_dot0, nil
+	}
+	return nil, fmt.Errorf("invalid byte after decimal in numeric literal: 0x%x", c)
+}
+
+// numscan_dot0 is the state after reading the integer, decimal point, and subsequent
+// digits of a number, such as after reading `3.14`.
+func numscan_dot0(c byte) (numscanStep, error) {
+	if '0' <= c && c <= '9' {
+		return numscan_dot0, nil
+	}
+	if c == 'e' || c == 'E' {
+		return numscan_e, nil
+	}
+	return nil, nil
+}
+
+// numscan_e is the state after reading the mantissa and e in a number,
+// such as after reading `314e` or `0.314e`.
+func numscan_e(c byte) (numscanStep, error) {
+	if c == '+' || c == '-' {
+		return numscan_eSign, nil
+	}
+	return numscan_eSign(c)
+}
+
+// numscan_eSign is the state after reading the mantissa, e, and sign in a number,
+// such as after reading `314e-` or `0.314e+`.
+func numscan_eSign(c byte) (numscanStep, error) {
+	if '0' <= c && c <= '9' {
+		return numscan_e0, nil
+	}
+	return nil, fmt.Errorf("invalid byte in exponent of numeric literal: 0x%x", c)
+}
+
+// numscan_e0 is the state after reading the mantissa, e, optional sign,
+// and at least one digit of the exponent in a number,
+// such as after reading `314e-2` or `0.314e+1` or `3.14e0`.
+func numscan_e0(c byte) (numscanStep, error) {
+	if '0' <= c && c <= '9' {
+		return numscan_e0, nil
+	}
+	return nil, nil
+}

--- a/codec/dagjson2/token/json_decode_string.go
+++ b/codec/dagjson2/token/json_decode_string.go
@@ -1,0 +1,269 @@
+package jsontoken
+
+import (
+	"fmt"
+	"strconv"
+	"unicode"
+	"unicode/utf16"
+	"unicode/utf8"
+
+	"github.com/ipld/go-ipld-prime/codec/codectools/scratch"
+)
+
+// License note: the string and numeric parsers here borrow
+// heavily from the golang stdlib json parser scanner.
+// That code is originally Copyright 2010 The Go Authors,
+// and is governed by a BSD-style license.
+
+// DecodeString will attempt to decode data in the format of a JSON string from the reader.
+// If the first byte read is not `"`, it is not a string at all, and an error is returned.
+// Any other parse errors of json strings also result in error.
+func DecodeString(r *scratch.Reader) (string, error) {
+	// Check that this actually begins like a string.
+	majorByte, err := r.Readn1()
+	if err != nil {
+		return "", err
+	}
+	if majorByte != '"' {
+		return "", fmt.Errorf("not a string: strings must begin with '\"', not %q", majorByte)
+	}
+	// Decode the string body.
+	s, err := DecodeStringBody(r)
+	if err != nil {
+		return "", err
+	}
+	// Swallow the trailing `"` again (which DecodeStringBody has insured we have).
+	r.Readn1()
+	return s, nil
+}
+
+// DecodeStringBody will attempt to decode data in the format of a JSON string from the reader,
+// except it assumes that the leading `"` has already been consumed,
+// and will similarly leave the trailing `"` unread (although it will check for its presence).
+//
+// Implementation note: you'll find that this method is used in the Decoder's implementation,
+// while DecodeString is actually not.  This is because when doing a whole document parse,
+// the leading `"` is always already consumed because it's how we discovered it's time to parse a string.
+func DecodeStringBody(r *scratch.Reader) (string, error) {
+	// First `"` is presumed already eaten.
+	// Start tracking the byte slice; real string starts here.
+	r.Track()
+	// Scan until scanner tells us end of string.
+	for step := strscan_normal; step != nil; {
+		majorByte, err := r.Readn1()
+		if err != nil {
+			return "", err
+		}
+		step, err = step(majorByte)
+		if err != nil {
+			return "", err
+		}
+	}
+	// Unread one.  The scan loop consumed the trailing quote already,
+	// which we don't want to pass onto the parser.
+	r.Unreadn1()
+	// Parse!
+	s, ok := parseString(r.StopTrack())
+	if !ok {
+		panic("string parse failed") // this is a sanity check; our scan phase should've already excluded any data that would cause this.
+	}
+	return string(s), nil
+}
+
+// strscanStep steps are applied over the data to find how long the string is.
+// A nil step func is returned to indicate the string is done.
+// Actually parsing the string is done by 'parseString()'.
+type strscanStep func(c byte) (strscanStep, error)
+
+// The default string scanning step state.  Starts here.
+func strscan_normal(c byte) (strscanStep, error) {
+	if c == '"' { // done!
+		return nil, nil
+	}
+	if c == '\\' {
+		return strscan_esc, nil
+	}
+	if c < 0x20 { // Unprintable bytes are invalid in a json string.
+		return nil, fmt.Errorf("invalid unprintable byte in string literal: 0x%x", c)
+	}
+	return strscan_normal, nil
+}
+
+// "esc" is the state after reading `"\` during a quoted string.
+func strscan_esc(c byte) (strscanStep, error) {
+	switch c {
+	case 'b', 'f', 'n', 'r', 't', '\\', '/', '"':
+		return strscan_normal, nil
+	case 'u':
+		return strscan_escU, nil
+	}
+	return nil, fmt.Errorf("invalid byte in string escape sequence: 0x%x", c)
+}
+
+// "escU" is the state after reading `"\u` during a quoted string.
+func strscan_escU(c byte) (strscanStep, error) {
+	if '0' <= c && c <= '9' || 'a' <= c && c <= 'f' || 'A' <= c && c <= 'F' {
+		return strscan_escU1, nil
+	}
+	return nil, fmt.Errorf("invalid byte in \\u hexadecimal character escape: 0x%x", c)
+}
+
+// "escU1" is the state after reading `"\u1` during a quoted string.
+func strscan_escU1(c byte) (strscanStep, error) {
+	if '0' <= c && c <= '9' || 'a' <= c && c <= 'f' || 'A' <= c && c <= 'F' {
+		return strscan_escU12, nil
+	}
+	return nil, fmt.Errorf("invalid byte in \\u hexadecimal character escape: 0x%x", c)
+}
+
+// "escU12" is the state after reading `"\u12` during a quoted string.
+func strscan_escU12(c byte) (strscanStep, error) {
+	if '0' <= c && c <= '9' || 'a' <= c && c <= 'f' || 'A' <= c && c <= 'F' {
+		return strscan_escU123, nil
+	}
+	return nil, fmt.Errorf("invalid byte in \\u hexadecimal character escape: 0x%x", c)
+}
+
+// "escU123" is the state after reading `"\u123` during a quoted string.
+func strscan_escU123(c byte) (strscanStep, error) {
+	if '0' <= c && c <= '9' || 'a' <= c && c <= 'f' || 'A' <= c && c <= 'F' {
+		return strscan_normal, nil
+	}
+	return nil, fmt.Errorf("invalid byte in \\u hexadecimal character escape: 0x%x", c)
+}
+
+// Convert a json serial byte sequence that is a complete string body (i.e., quotes from the outside excluded)
+// into a natural byte sequence (escapes, etc, are processed).
+//
+// The given slice should already be the right length.
+// A blithe false for 'ok' is returned if the data is in any way malformed.
+//
+// FUTURE: this is native JSON string parsing, and not as strict as DAG-JSON should be.
+//
+//   - this does not implement UTF8-C8 unescpaing; we may want to do so.
+//   - this transforms invalid surrogates coming from escape sequences into uFFFD; we probably shouldn't.
+//   - this transforms any non-UTF-8 bytes into uFFFD rather than erroring; we might want to think twice about that.
+//   - this parses `\u` escape sequences at all, while also allowing UTF8 chars of the same content; we might want to reject variations.
+//
+// It might be desirable to implement these stricter rules as configurable.
+func parseString(s []byte) (t []byte, ok bool) {
+	// Check for unusual characters. If there are none,
+	// then no unquoting is needed, so return a slice of the
+	// original bytes.
+	r := 0
+	for r < len(s) {
+		c := s[r]
+		if c == '\\' || c == '"' || c < ' ' {
+			break
+		}
+		if c < utf8.RuneSelf {
+			r++
+			continue
+		}
+		rr, size := utf8.DecodeRune(s[r:])
+		if rr == utf8.RuneError && size == 1 {
+			break
+		}
+		r += size
+	}
+	if r == len(s) {
+		return s, true
+	}
+
+	b := make([]byte, len(s)+2*utf8.UTFMax)
+	w := copy(b, s[0:r])
+	for r < len(s) {
+		// Out of room?  Can only happen if s is full of
+		// malformed UTF-8 and we're replacing each
+		// byte with RuneError.
+		if w >= len(b)-2*utf8.UTFMax {
+			nb := make([]byte, (len(b)+utf8.UTFMax)*2)
+			copy(nb, b[0:w])
+			b = nb
+		}
+		switch c := s[r]; {
+		case c == '\\':
+			r++
+			if r >= len(s) {
+				return
+			}
+			switch s[r] {
+			default:
+				return
+			case '"', '\\', '/', '\'':
+				b[w] = s[r]
+				r++
+				w++
+			case 'b':
+				b[w] = '\b'
+				r++
+				w++
+			case 'f':
+				b[w] = '\f'
+				r++
+				w++
+			case 'n':
+				b[w] = '\n'
+				r++
+				w++
+			case 'r':
+				b[w] = '\r'
+				r++
+				w++
+			case 't':
+				b[w] = '\t'
+				r++
+				w++
+			case 'u':
+				r--
+				rr := getu4(s[r:])
+				if rr < 0 {
+					return
+				}
+				r += 6
+				if utf16.IsSurrogate(rr) {
+					rr1 := getu4(s[r:])
+					if dec := utf16.DecodeRune(rr, rr1); dec != unicode.ReplacementChar {
+						// A valid pair; consume.
+						r += 6
+						w += utf8.EncodeRune(b[w:], dec)
+						break
+					}
+					// Invalid surrogate; fall back to replacement rune.
+					rr = unicode.ReplacementChar
+				}
+				w += utf8.EncodeRune(b[w:], rr)
+			}
+
+		// Quote, control characters are invalid.
+		case c == '"', c < ' ':
+			return
+
+		// ASCII
+		case c < utf8.RuneSelf:
+			b[w] = c
+			r++
+			w++
+
+		// Coerce to well-formed UTF-8.
+		default:
+			rr, size := utf8.DecodeRune(s[r:])
+			r += size
+			w += utf8.EncodeRune(b[w:], rr)
+		}
+	}
+	return b[0:w], true
+}
+
+// getu4 decodes \uXXXX from the beginning of s, returning the hex value,
+// or it returns -1.
+func getu4(s []byte) rune {
+	if len(s) < 6 || s[0] != '\\' || s[1] != 'u' {
+		return -1
+	}
+	r, err := strconv.ParseUint(string(s[2:6]), 16, 64)
+	if err != nil {
+		return -1
+	}
+	return rune(r)
+}

--- a/codec/dagjson2/token/json_decode_string_test.go
+++ b/codec/dagjson2/token/json_decode_string_test.go
@@ -1,0 +1,32 @@
+package jsontoken
+
+import (
+	"errors"
+	"io"
+	"testing"
+
+	. "github.com/warpfork/go-wish"
+)
+
+func TestDecodeString(t *testing.T) {
+	t.Run("SimpleString", func(t *testing.T) {
+		s, err := DecodeString(makeReader(`"asdf"`))
+		Wish(t, err, ShouldEqual, nil)
+		Wish(t, s, ShouldEqual, "asdf")
+	})
+	t.Run("NonString", func(t *testing.T) {
+		s, err := DecodeString(makeReader(`not prefixed right`))
+		Wish(t, err, ShouldEqual, errors.New(`not a string: strings must begin with '"', not 'n'`))
+		Wish(t, s, ShouldEqual, "")
+	})
+	t.Run("UnterminatedString", func(t *testing.T) {
+		s, err := DecodeString(makeReader(`"ohno`))
+		Wish(t, err, ShouldEqual, io.ErrUnexpectedEOF)
+		Wish(t, s, ShouldEqual, "")
+	})
+	t.Run("StringWithEscapes", func(t *testing.T) {
+		s, err := DecodeString(makeReader(`"as\tdf\bwow"`))
+		Wish(t, err, ShouldEqual, nil)
+		Wish(t, s, ShouldEqual, "as\tdf\bwow")
+	})
+}

--- a/codec/dagjson2/token/json_decode_test.go
+++ b/codec/dagjson2/token/json_decode_test.go
@@ -1,0 +1,63 @@
+package jsontoken
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	. "github.com/warpfork/go-wish"
+
+	"github.com/ipld/go-ipld-prime/codec/codectools"
+	"github.com/ipld/go-ipld-prime/codec/codectools/scratch"
+)
+
+func makeReader(s string) *scratch.Reader {
+	r := &scratch.Reader{}
+	r.InitSlice([]byte(s))
+	return r
+}
+
+var inf int = 1 << 31
+
+func TestDecode(t *testing.T) {
+	t.Run("SimpleString", func(t *testing.T) {
+		var d Decoder
+		d.Init(strings.NewReader(`"asdf"`))
+		tok, err := d.Step(&inf)
+		Wish(t, err, ShouldEqual, nil)
+		Wish(t, tok.Kind, ShouldEqual, codectools.TokenKind_String)
+		Wish(t, tok.Str, ShouldEqual, "asdf")
+		tok, err = d.Step(&inf)
+		Wish(t, err, ShouldEqual, io.EOF)
+	})
+	t.Run("SingleMap", func(t *testing.T) {
+		var d Decoder
+		d.Init(strings.NewReader(`{"a":"b","c":"d"}`))
+		tok, err := d.Step(&inf)
+		Wish(t, err, ShouldEqual, nil)
+		Wish(t, tok.Kind, ShouldEqual, codectools.TokenKind_MapOpen)
+		Wish(t, d.phase, ShouldEqual, decoderPhase_acceptMapKeyOrEnd)
+		tok, err = d.Step(&inf)
+		Wish(t, err, ShouldEqual, nil)
+		Wish(t, tok.Kind, ShouldEqual, codectools.TokenKind_String)
+		Wish(t, tok.Str, ShouldEqual, "a")
+		Wish(t, d.phase, ShouldEqual, decoderPhase_acceptMapValue)
+		tok, err = d.Step(&inf)
+		Wish(t, err, ShouldEqual, nil)
+		Wish(t, tok.Kind, ShouldEqual, codectools.TokenKind_String)
+		Wish(t, tok.Str, ShouldEqual, "b")
+		tok, err = d.Step(&inf)
+		Wish(t, err, ShouldEqual, nil)
+		Wish(t, tok.Kind, ShouldEqual, codectools.TokenKind_String)
+		Wish(t, tok.Str, ShouldEqual, "c")
+		tok, err = d.Step(&inf)
+		Wish(t, err, ShouldEqual, nil)
+		Wish(t, tok.Kind, ShouldEqual, codectools.TokenKind_String)
+		Wish(t, tok.Str, ShouldEqual, "d")
+		tok, err = d.Step(&inf)
+		Wish(t, err, ShouldEqual, nil)
+		Wish(t, tok.Kind, ShouldEqual, codectools.TokenKind_MapClose)
+		tok, err = d.Step(&inf)
+		Wish(t, err, ShouldEqual, io.EOF)
+	})
+}


### PR DESCRIPTION
Alright, this is kind of a lot.

This introduces some new decoders.  I'll probably keep appending to this PR for a while until it includes encoders as well.

The aim is to, by the end of this revamp, be able to do something about the linking API situation (https://github.com/ipld/go-ipld-prime/issues/55),
and in particular, start approaching the API drafts in https://gist.github.com/warpfork/c0200cc4d99ee36ba5ce5a612f1d1a22 ... which involves normalizing the codec interfaces a bit better than they currently are.

While we're at it... why not fix everything?  Scope control is for chumps, amiright?

(I'll regret saying that, of course.  I already do.  But, the code that bites off a lot of fixes at once is already brewing here, so, here we go...)

So: performance, API consistency, better configurability, improved strictness, and more, are all goals in this changeset.  Whee!
(We'll probably get to some of those, and leave some others as strategically deferred TODOs; hopefully the latter at least get closer into sight for future work.)

---

The first commit in this stach adds a `scratch.Reader` tool, which is helpful for decoders.

The docs in the diff should cover it pretty well.
It's a reader-wrapper that does a lot of extremely common
buffering and small-read operations that parsers tend to need.

The tests include aggressive checks that operations take exactly as
many allocations as planned -- and mostly, that's *zero*.

---

The second commit is a giant revamped DAG-JSON decoder and unmarshaller.

This is added in a new "dagjson2" package for the time being,
but aims to replace the current dagjson package entirely,
and will take over that namespace when complete.

So far only the decoder/unmarshaller is included in this first commit,
and the encoder/marshaller is still coming up.

Note that a lot of the state machine code is partially-evolved code from [refmt/json](https://github.com/polydawn/refmt/tree/master/json) (which is also what backs the old dagjson package we're aiming to replace).  That code is probably not the main focus of interest here, because it's how it _fits together_ that we're working on improving here... but unfortunately I don't see a way to keep the diffs separated for ease of review.

This revamp is making several major strides:

- The decoding system is cleanly separated from the tree building.
  (The tree-building was all introduced in https://github.com/ipld/go-ipld-prime/pull/101 .)

- The tree building reuses the codectools token assembler systems.
  This saves a lot of code, and adds a lot of consistency.
  (By contrast, the older dagjson and dagcbor packages had similar
  outlines, but didn't actually share much code; this was annoying
  to maintain, and meant improvements to one needed to be ported
  to the other manually.  No more.)

- The token type used by this codectools system is more tightly
  associated with the IPLD Data Model.  In practice, what this means
  is links are parsed at the same stage as the rest of parsing,
  rather than being added on in an awkward "parse 1.5" stage.
  This results in much less complicated code than the old token
  system from refmt which the older dagjson package leans on.

- Budgets are more consistently woven through this system.

- The JSON decoder components are in their own sub-package,
  and should be relatively reusable.  Some features like string parsing
  are exported in their own right, in addition to being accessible
  via the full recursive supports-everything decoders.
  (This might not often be compelling, but -- maybe.  I myself wanted
  more reusable access to fine-grained decoder and encoder components
  when I was working on the "JST" experiment, so, I'm scratching my
  own itch here if nothing else.)
  End-users should mostly not need to see this, but library
  implementors might appreciate it.

- The codectools scratch.Reader type is used in all the decoder APIs.
  This results in good performance for either streaming io.Reader or
  already-in-memory bytes slices as data sources, and does it without
  doubling the number of exported functions we need (or pushing the
  need for feature detection into every single exported function).

- The configuration system for the decoder is actually in this repo,
  and it's sanely and clearly settable while also being optional.
  Previously, if you wanted to configure dagjson, you'd have to reach
  into the refmt json package for *those* configuration structs,
  which was workable but just very confusing and gave the end-user a
  lot of different places to look before finding what they need.

- The implementations are very mindful of memory allocation efficiency.
  Almost all of the component structures carefully utilize embedding:
  ReusableUnmarsahller embeds the Decoder; the Decoder embeds the
  scratch.Reader as well as the Token it yields; etc.
  This should result in overall being able to produce fully usable
  codecs with a minimal number of allocations -- much fewer than the
  older implementations required.

Some benefits have yet to be realized, but are on the map now:

- The new Token structure also includes space for position and
  progress tracking, which we want to use to produce better errors.
  (This needs more implementation work, still, though.)

- There are several configuration options for strictness.
  These aren't all backed up by the actual implementation yet
  (I'm porting over old code fast enough to write a demo and make
  sure the whole suite of interfaces works; it'll require further
  work, especially on this strictness front, later), but
  at the very least these are now getting documented,
  and several comment blocks point to where more work is needed.

- The new multicodec registry is alluded to in comments here, but
  isn't implemented yet.  This will be part of the long game big goal
  about API normalization and linking cleanup, though.

---

Benchmarks are still forthcoming.  My recollection from the previous bout of this in refmt was that microbenchmarking (especially of things like `scratch.Reader`) wasn't a great use of time, because when we start benchmarking codecs as a whole, and especially, when looking at the pprof reports from that, we'll see things like `scratch.Reader` showing up plain as day there, and nicely contextualized... so, it's a good use of time to just save our efforts for that point.  (This PR as a whole is probably getting to the point where we could actually start doing those benchmarks over the whole decoder now, but, alas, my brain ran out of gas.  Will retry soon.)

---

As usual, the naming of things should be considered to be a bit in flux.
In particular, a bunch of things are still called "codectools", even though [in that PR, that naming is already in question](https://github.com/ipld/go-ipld-prime/pull/101#discussion_r520704649) and [we're looking for alternatives](https://github.com/ipld/go-ipld-prime/pull/101#issuecomment-726910238).
We might do something about that soon, but this PR is still running forward with those names.  (Maybe by the end of this PR, we'll have figured out enough of the big picture to pick better names, and can then fire lazers on that.  We'll see.)
