### PR TITLE
schema/gen/go: remove two common subtest levels

### DIFF
--- a/schema/gen/go/testEngine_test.go
+++ b/schema/gen/go/testEngine_test.go
@@ -29,58 +29,54 @@ func genAndCompileAndTest(
 	adjCfg *AdjunctCfg,
 	testsFn behavioralTests,
 ) {
-	t.Run("generate", func(t *testing.T) {
-		// Make directories for the package we're about to generate.
-		//  Everything will be prefixed with "./_test".
-		// You can rm-rf the whole "./_test" dir at your leisure.
-		//  We don't by default because it's nicer to let go's builds of things cache.
-		//  If you change the names of types, though, you'll have garbage files leftover,
-		//   and that's currently a manual cleanup problem.  Sorry.
-		os.Mkdir("./_test/", 0755)
-		os.Mkdir("./_test/"+prefix, 0755)
+	// Make directories for the package we're about to generate.
+	//  Everything will be prefixed with "./_test".
+	// You can rm-rf the whole "./_test" dir at your leisure.
+	//  We don't by default because it's nicer to let go's builds of things cache.
+	//  If you change the names of types, though, you'll have garbage files leftover,
+	//   and that's currently a manual cleanup problem.  Sorry.
+	os.Mkdir("./_test/", 0755)
+	os.Mkdir("./_test/"+prefix, 0755)
 
-		// Generate... everything, really.
-		Generate("./_test/"+prefix, pkgName, ts, adjCfg)
+	// Generate... everything, really.
+	Generate("./_test/"+prefix, pkgName, ts, adjCfg)
 
-		// Emit an exported top level function for getting NodePrototype.
-		//  This part isn't necessary except for a special need we have with this plugin trick;
-		//   normally, user code uses the `{pkgname}.Prototype.{TypeName}` constant (so-to-speak, anyway) to get a hold of NodePrototypes...
-		//   but for plugins, we need a top-level exported symbol to grab ahold of, and we can't easily look through the `Prototype` value
-		//    without an interface... so we generate this function to fit the bill instead.
-		withFile("./_test/"+prefix+"/prototypeGetter.go", func(w io.Writer) {
-			doTemplate(`
-				package `+pkgName+`
+	// Emit an exported top level function for getting NodePrototype.
+	//  This part isn't necessary except for a special need we have with this plugin trick;
+	//   normally, user code uses the `{pkgname}.Prototype.{TypeName}` constant (so-to-speak, anyway) to get a hold of NodePrototypes...
+	//   but for plugins, we need a top-level exported symbol to grab ahold of, and we can't easily look through the `Prototype` value
+	//    without an interface... so we generate this function to fit the bill instead.
+	withFile("./_test/"+prefix+"/prototypeGetter.go", func(w io.Writer) {
+		doTemplate(`
+			package `+pkgName+`
 
-				import "github.com/ipld/go-ipld-prime"
+			import "github.com/ipld/go-ipld-prime"
 
-				func GetPrototypeByName(name string) ipld.NodePrototype {
-					switch name {
-					{{- range . }}
-					case "{{ .Name }}":
-						return _{{ . | TypeSymbol }}__Prototype{}
-					case "{{ .Name }}.Repr":
-						return _{{ . | TypeSymbol }}__ReprPrototype{}
-					{{- end}}
-					default:
-						return nil
-					}
+			func GetPrototypeByName(name string) ipld.NodePrototype {
+				switch name {
+				{{- range . }}
+				case "{{ .Name }}":
+					return _{{ . | TypeSymbol }}__Prototype{}
+				case "{{ .Name }}.Repr":
+					return _{{ . | TypeSymbol }}__ReprPrototype{}
+				{{- end}}
+				default:
+					return nil
 				}
-			`, w, adjCfg, ts.GetTypes())
-		})
-
-		t.Run("compile", func(t *testing.T) {
-			// Build the genned code.
-			//  This will either make a plugin (which we can run behavioral tests on next!),
-			//  or just build it quietly just to see if there are compile-time errors,
-			//  depending on your build tags.
-			// See 'HACKME_testing.md' for discussion.
-			buildGennedCode(t, prefix, pkgName)
-
-			// This will either load the plugin and run behavioral tests,
-			//  or emit a dummy t.Run and a skip,
-			//  depending on your build tags.
-			// See 'HACKME_testing.md' for discussion.
-			runBehavioralTests(t, prefix, testsFn)
-		})
+			}
+		`, w, adjCfg, ts.GetTypes())
 	})
+
+	// Build the genned code.
+	//  This will either make a plugin (which we can run behavioral tests on next!),
+	//  or just build it quietly just to see if there are compile-time errors,
+	//  depending on your build tags.
+	// See 'HACKME_testing.md' for discussion.
+	buildGennedCode(t, prefix, pkgName)
+
+	// This will either load the plugin and run behavioral tests,
+	//  or emit a dummy t.Run and a skip,
+	//  depending on your build tags.
+	// See 'HACKME_testing.md' for discussion.
+	runBehavioralTests(t, prefix, testsFn)
 }


### PR DESCRIPTION
Practically every subtest ends up at 7 or so levels of names, like:

	TestMapsContainingMaybe/maybe-using-ptr/generate/compile/bhvtest/non-nullable/typed-create

However, note that the "generate" and "compile" levels are always there,
so their presence just adds verbosity in the output and makes the
developer's life more difficult.

Extremely nested sub-tests are already rare, so at least we can just
keep the components that add useful information in the output.

"bhvtest" is also pretty redundant, but that one actually matters - its
subtest can be skipped depending on build tags.