### PR TITLE
all: fix a lot of "unkeyed literal" vet warnings

### DIFF
--- a/adl/rot13adl/rot13node.go
+++ b/adl/rot13adl/rot13node.go
@@ -41,16 +41,16 @@ func (*_R13String) ReprKind() ipld.ReprKind {
 	return ipld.ReprKind_String
 }
 func (*_R13String) LookupByString(string) (ipld.Node, error) {
-	return mixins.String{"rot13adl.R13String"}.LookupByString("")
+	return mixins.String{TypeName: "rot13adl.R13String"}.LookupByString("")
 }
 func (*_R13String) LookupByNode(ipld.Node) (ipld.Node, error) {
-	return mixins.String{"rot13adl.R13String"}.LookupByNode(nil)
+	return mixins.String{TypeName: "rot13adl.R13String"}.LookupByNode(nil)
 }
 func (*_R13String) LookupByIndex(idx int) (ipld.Node, error) {
-	return mixins.String{"rot13adl.R13String"}.LookupByIndex(0)
+	return mixins.String{TypeName: "rot13adl.R13String"}.LookupByIndex(0)
 }
 func (*_R13String) LookupBySegment(seg ipld.PathSegment) (ipld.Node, error) {
-	return mixins.String{"rot13adl.R13String"}.LookupBySegment(seg)
+	return mixins.String{TypeName: "rot13adl.R13String"}.LookupBySegment(seg)
 }
 func (*_R13String) MapIterator() ipld.MapIterator {
 	return nil
@@ -68,22 +68,22 @@ func (*_R13String) IsNull() bool {
 	return false
 }
 func (*_R13String) AsBool() (bool, error) {
-	return mixins.String{"rot13adl.R13String"}.AsBool()
+	return mixins.String{TypeName: "rot13adl.R13String"}.AsBool()
 }
 func (*_R13String) AsInt() (int, error) {
-	return mixins.String{"rot13adl.R13String"}.AsInt()
+	return mixins.String{TypeName: "rot13adl.R13String"}.AsInt()
 }
 func (*_R13String) AsFloat() (float64, error) {
-	return mixins.String{"rot13adl.R13String"}.AsFloat()
+	return mixins.String{TypeName: "rot13adl.R13String"}.AsFloat()
 }
 func (n *_R13String) AsString() (string, error) {
 	return n.synthesized, nil
 }
 func (*_R13String) AsBytes() ([]byte, error) {
-	return mixins.String{"rot13adl.R13String"}.AsBytes()
+	return mixins.String{TypeName: "rot13adl.R13String"}.AsBytes()
 }
 func (*_R13String) AsLink() (ipld.Link, error) {
-	return mixins.String{"rot13adl.R13String"}.AsLink()
+	return mixins.String{TypeName: "rot13adl.R13String"}.AsLink()
 }
 func (*_R13String) Prototype() ipld.NodePrototype {
 	return _R13String__Prototype{}
@@ -139,23 +139,23 @@ type _R13String__Assembler struct {
 }
 
 func (_R13String__Assembler) BeginMap(sizeHint int) (ipld.MapAssembler, error) {
-	return mixins.StringAssembler{"rot13adl.R13String"}.BeginMap(0)
+	return mixins.StringAssembler{TypeName: "rot13adl.R13String"}.BeginMap(0)
 }
 func (_R13String__Assembler) BeginList(sizeHint int) (ipld.ListAssembler, error) {
-	return mixins.StringAssembler{"rot13adl.R13String"}.BeginList(0)
+	return mixins.StringAssembler{TypeName: "rot13adl.R13String"}.BeginList(0)
 }
 func (na *_R13String__Assembler) AssignNull() error {
 	// REVIEW: unclear how this might compose with some other context (like a schema) which does allow nulls.  Probably a wrapper type?
-	return mixins.StringAssembler{"rot13adl.R13String"}.AssignNull()
+	return mixins.StringAssembler{TypeName: "rot13adl.R13String"}.AssignNull()
 }
 func (_R13String__Assembler) AssignBool(bool) error {
-	return mixins.StringAssembler{"rot13adl.R13String"}.AssignBool(false)
+	return mixins.StringAssembler{TypeName: "rot13adl.R13String"}.AssignBool(false)
 }
 func (_R13String__Assembler) AssignInt(int) error {
-	return mixins.StringAssembler{"rot13adl.R13String"}.AssignInt(0)
+	return mixins.StringAssembler{TypeName: "rot13adl.R13String"}.AssignInt(0)
 }
 func (_R13String__Assembler) AssignFloat(float64) error {
-	return mixins.StringAssembler{"rot13adl.R13String"}.AssignFloat(0)
+	return mixins.StringAssembler{TypeName: "rot13adl.R13String"}.AssignFloat(0)
 }
 func (na *_R13String__Assembler) AssignString(v string) error {
 	switch na.m {
@@ -170,10 +170,10 @@ func (na *_R13String__Assembler) AssignString(v string) error {
 	return nil
 }
 func (_R13String__Assembler) AssignBytes([]byte) error {
-	return mixins.StringAssembler{"rot13adl.R13String"}.AssignBytes(nil)
+	return mixins.StringAssembler{TypeName: "rot13adl.R13String"}.AssignBytes(nil)
 }
 func (_R13String__Assembler) AssignLink(ipld.Link) error {
-	return mixins.StringAssembler{"rot13adl.R13String"}.AssignLink(nil)
+	return mixins.StringAssembler{TypeName: "rot13adl.R13String"}.AssignLink(nil)
 }
 func (na *_R13String__Assembler) AssignNode(v ipld.Node) error {
 	if v.IsNull() {

--- a/adl/rot13adl/rot13substrate.go
+++ b/adl/rot13adl/rot13substrate.go
@@ -34,16 +34,16 @@ func (*_Substrate) ReprKind() ipld.ReprKind {
 	return ipld.ReprKind_String
 }
 func (*_Substrate) LookupByString(string) (ipld.Node, error) {
-	return mixins.String{"rot13adl.internal.Substrate"}.LookupByString("")
+	return mixins.String{TypeName: "rot13adl.internal.Substrate"}.LookupByString("")
 }
 func (*_Substrate) LookupByNode(ipld.Node) (ipld.Node, error) {
-	return mixins.String{"rot13adl.internal.Substrate"}.LookupByNode(nil)
+	return mixins.String{TypeName: "rot13adl.internal.Substrate"}.LookupByNode(nil)
 }
 func (*_Substrate) LookupByIndex(idx int) (ipld.Node, error) {
-	return mixins.String{"rot13adl.internal.Substrate"}.LookupByIndex(0)
+	return mixins.String{TypeName: "rot13adl.internal.Substrate"}.LookupByIndex(0)
 }
 func (*_Substrate) LookupBySegment(seg ipld.PathSegment) (ipld.Node, error) {
-	return mixins.String{"rot13adl.internal.Substrate"}.LookupBySegment(seg)
+	return mixins.String{TypeName: "rot13adl.internal.Substrate"}.LookupBySegment(seg)
 }
 func (*_Substrate) MapIterator() ipld.MapIterator {
 	return nil
@@ -61,22 +61,22 @@ func (*_Substrate) IsNull() bool {
 	return false
 }
 func (*_Substrate) AsBool() (bool, error) {
-	return mixins.String{"rot13adl.internal.Substrate"}.AsBool()
+	return mixins.String{TypeName: "rot13adl.internal.Substrate"}.AsBool()
 }
 func (*_Substrate) AsInt() (int, error) {
-	return mixins.String{"rot13adl.internal.Substrate"}.AsInt()
+	return mixins.String{TypeName: "rot13adl.internal.Substrate"}.AsInt()
 }
 func (*_Substrate) AsFloat() (float64, error) {
-	return mixins.String{"rot13adl.internal.Substrate"}.AsFloat()
+	return mixins.String{TypeName: "rot13adl.internal.Substrate"}.AsFloat()
 }
 func (n *_Substrate) AsString() (string, error) {
 	return n.raw, nil
 }
 func (*_Substrate) AsBytes() ([]byte, error) {
-	return mixins.String{"rot13adl.internal.Substrate"}.AsBytes()
+	return mixins.String{TypeName: "rot13adl.internal.Substrate"}.AsBytes()
 }
 func (*_Substrate) AsLink() (ipld.Link, error) {
-	return mixins.String{"rot13adl.internal.Substrate"}.AsLink()
+	return mixins.String{TypeName: "rot13adl.internal.Substrate"}.AsLink()
 }
 func (*_Substrate) Prototype() ipld.NodePrototype {
 	return _Substrate__Prototype{}
@@ -122,23 +122,23 @@ type _Substrate__Assembler struct {
 }
 
 func (_Substrate__Assembler) BeginMap(sizeHint int) (ipld.MapAssembler, error) {
-	return mixins.StringAssembler{"rot13adl.internal.Substrate"}.BeginMap(0)
+	return mixins.StringAssembler{TypeName: "rot13adl.internal.Substrate"}.BeginMap(0)
 }
 func (_Substrate__Assembler) BeginList(sizeHint int) (ipld.ListAssembler, error) {
-	return mixins.StringAssembler{"rot13adl.internal.Substrate"}.BeginList(0)
+	return mixins.StringAssembler{TypeName: "rot13adl.internal.Substrate"}.BeginList(0)
 }
 func (na *_Substrate__Assembler) AssignNull() error {
 	// REVIEW: unclear how this might compose with some other context (like a schema) which does allow nulls.  Probably a wrapper type?
-	return mixins.StringAssembler{"rot13adl.internal.Substrate"}.AssignNull()
+	return mixins.StringAssembler{TypeName: "rot13adl.internal.Substrate"}.AssignNull()
 }
 func (_Substrate__Assembler) AssignBool(bool) error {
-	return mixins.StringAssembler{"rot13adl.internal.Substrate"}.AssignBool(false)
+	return mixins.StringAssembler{TypeName: "rot13adl.internal.Substrate"}.AssignBool(false)
 }
 func (_Substrate__Assembler) AssignInt(int) error {
-	return mixins.StringAssembler{"rot13adl.internal.Substrate"}.AssignInt(0)
+	return mixins.StringAssembler{TypeName: "rot13adl.internal.Substrate"}.AssignInt(0)
 }
 func (_Substrate__Assembler) AssignFloat(float64) error {
-	return mixins.StringAssembler{"rot13adl.internal.Substrate"}.AssignFloat(0)
+	return mixins.StringAssembler{TypeName: "rot13adl.internal.Substrate"}.AssignFloat(0)
 }
 func (na *_Substrate__Assembler) AssignString(v string) error {
 	switch na.m {
@@ -153,10 +153,10 @@ func (na *_Substrate__Assembler) AssignString(v string) error {
 	return nil
 }
 func (_Substrate__Assembler) AssignBytes([]byte) error {
-	return mixins.StringAssembler{"rot13adl.internal.Substrate"}.AssignBytes(nil)
+	return mixins.StringAssembler{TypeName: "rot13adl.internal.Substrate"}.AssignBytes(nil)
 }
 func (_Substrate__Assembler) AssignLink(ipld.Link) error {
-	return mixins.StringAssembler{"rot13adl.internal.Substrate"}.AssignLink(nil)
+	return mixins.StringAssembler{TypeName: "rot13adl.internal.Substrate"}.AssignLink(nil)
 }
 func (na *_Substrate__Assembler) AssignNode(v ipld.Node) error {
 	if v.IsNull() {

--- a/node/basic/bool.go
+++ b/node/basic/bool.go
@@ -26,16 +26,16 @@ func (plainBool) ReprKind() ipld.ReprKind {
 	return ipld.ReprKind_Bool
 }
 func (plainBool) LookupByString(string) (ipld.Node, error) {
-	return mixins.Bool{"bool"}.LookupByString("")
+	return mixins.Bool{TypeName: "bool"}.LookupByString("")
 }
 func (plainBool) LookupByNode(key ipld.Node) (ipld.Node, error) {
-	return mixins.Bool{"bool"}.LookupByNode(nil)
+	return mixins.Bool{TypeName: "bool"}.LookupByNode(nil)
 }
 func (plainBool) LookupByIndex(idx int) (ipld.Node, error) {
-	return mixins.Bool{"bool"}.LookupByIndex(0)
+	return mixins.Bool{TypeName: "bool"}.LookupByIndex(0)
 }
 func (plainBool) LookupBySegment(seg ipld.PathSegment) (ipld.Node, error) {
-	return mixins.Bool{"bool"}.LookupBySegment(seg)
+	return mixins.Bool{TypeName: "bool"}.LookupBySegment(seg)
 }
 func (plainBool) MapIterator() ipld.MapIterator {
 	return nil
@@ -56,19 +56,19 @@ func (n plainBool) AsBool() (bool, error) {
 	return bool(n), nil
 }
 func (plainBool) AsInt() (int, error) {
-	return mixins.Bool{"bool"}.AsInt()
+	return mixins.Bool{TypeName: "bool"}.AsInt()
 }
 func (plainBool) AsFloat() (float64, error) {
-	return mixins.Bool{"bool"}.AsFloat()
+	return mixins.Bool{TypeName: "bool"}.AsFloat()
 }
 func (plainBool) AsString() (string, error) {
-	return mixins.Bool{"bool"}.AsString()
+	return mixins.Bool{TypeName: "bool"}.AsString()
 }
 func (plainBool) AsBytes() ([]byte, error) {
-	return mixins.Bool{"bool"}.AsBytes()
+	return mixins.Bool{TypeName: "bool"}.AsBytes()
 }
 func (plainBool) AsLink() (ipld.Link, error) {
-	return mixins.Bool{"bool"}.AsLink()
+	return mixins.Bool{TypeName: "bool"}.AsLink()
 }
 func (plainBool) Prototype() ipld.NodePrototype {
 	return Prototype__Bool{}
@@ -104,32 +104,32 @@ type plainBool__Assembler struct {
 }
 
 func (plainBool__Assembler) BeginMap(sizeHint int) (ipld.MapAssembler, error) {
-	return mixins.BoolAssembler{"bool"}.BeginMap(0)
+	return mixins.BoolAssembler{TypeName: "bool"}.BeginMap(0)
 }
 func (plainBool__Assembler) BeginList(sizeHint int) (ipld.ListAssembler, error) {
-	return mixins.BoolAssembler{"bool"}.BeginList(0)
+	return mixins.BoolAssembler{TypeName: "bool"}.BeginList(0)
 }
 func (plainBool__Assembler) AssignNull() error {
-	return mixins.BoolAssembler{"bool"}.AssignNull()
+	return mixins.BoolAssembler{TypeName: "bool"}.AssignNull()
 }
 func (na *plainBool__Assembler) AssignBool(v bool) error {
 	*na.w = plainBool(v)
 	return nil
 }
 func (plainBool__Assembler) AssignInt(int) error {
-	return mixins.BoolAssembler{"bool"}.AssignInt(0)
+	return mixins.BoolAssembler{TypeName: "bool"}.AssignInt(0)
 }
 func (plainBool__Assembler) AssignFloat(float64) error {
-	return mixins.BoolAssembler{"bool"}.AssignFloat(0)
+	return mixins.BoolAssembler{TypeName: "bool"}.AssignFloat(0)
 }
 func (plainBool__Assembler) AssignString(string) error {
-	return mixins.BoolAssembler{"bool"}.AssignString("")
+	return mixins.BoolAssembler{TypeName: "bool"}.AssignString("")
 }
 func (plainBool__Assembler) AssignBytes([]byte) error {
-	return mixins.BoolAssembler{"bool"}.AssignBytes(nil)
+	return mixins.BoolAssembler{TypeName: "bool"}.AssignBytes(nil)
 }
 func (plainBool__Assembler) AssignLink(ipld.Link) error {
-	return mixins.BoolAssembler{"bool"}.AssignLink(nil)
+	return mixins.BoolAssembler{TypeName: "bool"}.AssignLink(nil)
 }
 func (na *plainBool__Assembler) AssignNode(v ipld.Node) error {
 	if v2, err := v.AsBool(); err != nil {

--- a/node/basic/bytes.go
+++ b/node/basic/bytes.go
@@ -26,16 +26,16 @@ func (plainBytes) ReprKind() ipld.ReprKind {
 	return ipld.ReprKind_Bytes
 }
 func (plainBytes) LookupByString(string) (ipld.Node, error) {
-	return mixins.Bytes{"bytes"}.LookupByString("")
+	return mixins.Bytes{TypeName: "bytes"}.LookupByString("")
 }
 func (plainBytes) LookupByNode(key ipld.Node) (ipld.Node, error) {
-	return mixins.Bytes{"bytes"}.LookupByNode(nil)
+	return mixins.Bytes{TypeName: "bytes"}.LookupByNode(nil)
 }
 func (plainBytes) LookupByIndex(idx int) (ipld.Node, error) {
-	return mixins.Bytes{"bytes"}.LookupByIndex(0)
+	return mixins.Bytes{TypeName: "bytes"}.LookupByIndex(0)
 }
 func (plainBytes) LookupBySegment(seg ipld.PathSegment) (ipld.Node, error) {
-	return mixins.Bytes{"bytes"}.LookupBySegment(seg)
+	return mixins.Bytes{TypeName: "bytes"}.LookupBySegment(seg)
 }
 func (plainBytes) MapIterator() ipld.MapIterator {
 	return nil
@@ -53,22 +53,22 @@ func (plainBytes) IsNull() bool {
 	return false
 }
 func (plainBytes) AsBool() (bool, error) {
-	return mixins.Bytes{"bytes"}.AsBool()
+	return mixins.Bytes{TypeName: "bytes"}.AsBool()
 }
 func (plainBytes) AsInt() (int, error) {
-	return mixins.Bytes{"bytes"}.AsInt()
+	return mixins.Bytes{TypeName: "bytes"}.AsInt()
 }
 func (plainBytes) AsFloat() (float64, error) {
-	return mixins.Bytes{"bytes"}.AsFloat()
+	return mixins.Bytes{TypeName: "bytes"}.AsFloat()
 }
 func (plainBytes) AsString() (string, error) {
-	return mixins.Bytes{"bytes"}.AsString()
+	return mixins.Bytes{TypeName: "bytes"}.AsString()
 }
 func (n plainBytes) AsBytes() ([]byte, error) {
 	return []byte(n), nil
 }
 func (plainBytes) AsLink() (ipld.Link, error) {
-	return mixins.Bytes{"bytes"}.AsLink()
+	return mixins.Bytes{TypeName: "bytes"}.AsLink()
 }
 func (plainBytes) Prototype() ipld.NodePrototype {
 	return Prototype__Bytes{}
@@ -104,32 +104,32 @@ type plainBytes__Assembler struct {
 }
 
 func (plainBytes__Assembler) BeginMap(sizeHint int) (ipld.MapAssembler, error) {
-	return mixins.BytesAssembler{"bytes"}.BeginMap(0)
+	return mixins.BytesAssembler{TypeName: "bytes"}.BeginMap(0)
 }
 func (plainBytes__Assembler) BeginList(sizeHint int) (ipld.ListAssembler, error) {
-	return mixins.BytesAssembler{"bytes"}.BeginList(0)
+	return mixins.BytesAssembler{TypeName: "bytes"}.BeginList(0)
 }
 func (plainBytes__Assembler) AssignNull() error {
-	return mixins.BytesAssembler{"bytes"}.AssignNull()
+	return mixins.BytesAssembler{TypeName: "bytes"}.AssignNull()
 }
 func (plainBytes__Assembler) AssignBool(bool) error {
-	return mixins.BytesAssembler{"bytes"}.AssignBool(false)
+	return mixins.BytesAssembler{TypeName: "bytes"}.AssignBool(false)
 }
 func (plainBytes__Assembler) AssignInt(int) error {
-	return mixins.BytesAssembler{"bytes"}.AssignInt(0)
+	return mixins.BytesAssembler{TypeName: "bytes"}.AssignInt(0)
 }
 func (plainBytes__Assembler) AssignFloat(float64) error {
-	return mixins.BytesAssembler{"bytes"}.AssignFloat(0)
+	return mixins.BytesAssembler{TypeName: "bytes"}.AssignFloat(0)
 }
 func (plainBytes__Assembler) AssignString(string) error {
-	return mixins.BytesAssembler{"bytes"}.AssignString("")
+	return mixins.BytesAssembler{TypeName: "bytes"}.AssignString("")
 }
 func (na *plainBytes__Assembler) AssignBytes(v []byte) error {
 	*na.w = plainBytes(v)
 	return nil
 }
 func (plainBytes__Assembler) AssignLink(ipld.Link) error {
-	return mixins.BytesAssembler{"bytes"}.AssignLink(nil)
+	return mixins.BytesAssembler{TypeName: "bytes"}.AssignLink(nil)
 }
 func (na *plainBytes__Assembler) AssignNode(v ipld.Node) error {
 	if v2, err := v.AsBytes(); err != nil {

--- a/node/basic/float.go
+++ b/node/basic/float.go
@@ -26,16 +26,16 @@ func (plainFloat) ReprKind() ipld.ReprKind {
 	return ipld.ReprKind_Float
 }
 func (plainFloat) LookupByString(string) (ipld.Node, error) {
-	return mixins.Float{"float"}.LookupByString("")
+	return mixins.Float{TypeName: "float"}.LookupByString("")
 }
 func (plainFloat) LookupByNode(key ipld.Node) (ipld.Node, error) {
-	return mixins.Float{"float"}.LookupByNode(nil)
+	return mixins.Float{TypeName: "float"}.LookupByNode(nil)
 }
 func (plainFloat) LookupByIndex(idx int) (ipld.Node, error) {
-	return mixins.Float{"float"}.LookupByIndex(0)
+	return mixins.Float{TypeName: "float"}.LookupByIndex(0)
 }
 func (plainFloat) LookupBySegment(seg ipld.PathSegment) (ipld.Node, error) {
-	return mixins.Float{"float"}.LookupBySegment(seg)
+	return mixins.Float{TypeName: "float"}.LookupBySegment(seg)
 }
 func (plainFloat) MapIterator() ipld.MapIterator {
 	return nil
@@ -53,22 +53,22 @@ func (plainFloat) IsNull() bool {
 	return false
 }
 func (plainFloat) AsBool() (bool, error) {
-	return mixins.Float{"float"}.AsBool()
+	return mixins.Float{TypeName: "float"}.AsBool()
 }
 func (plainFloat) AsInt() (int, error) {
-	return mixins.Float{"float"}.AsInt()
+	return mixins.Float{TypeName: "float"}.AsInt()
 }
 func (n plainFloat) AsFloat() (float64, error) {
 	return float64(n), nil
 }
 func (plainFloat) AsString() (string, error) {
-	return mixins.Float{"float"}.AsString()
+	return mixins.Float{TypeName: "float"}.AsString()
 }
 func (plainFloat) AsBytes() ([]byte, error) {
-	return mixins.Float{"float"}.AsBytes()
+	return mixins.Float{TypeName: "float"}.AsBytes()
 }
 func (plainFloat) AsLink() (ipld.Link, error) {
-	return mixins.Float{"float"}.AsLink()
+	return mixins.Float{TypeName: "float"}.AsLink()
 }
 func (plainFloat) Prototype() ipld.NodePrototype {
 	return Prototype__Float{}
@@ -104,32 +104,32 @@ type plainFloat__Assembler struct {
 }
 
 func (plainFloat__Assembler) BeginMap(sizeHint int) (ipld.MapAssembler, error) {
-	return mixins.FloatAssembler{"float"}.BeginMap(0)
+	return mixins.FloatAssembler{TypeName: "float"}.BeginMap(0)
 }
 func (plainFloat__Assembler) BeginList(sizeHint int) (ipld.ListAssembler, error) {
-	return mixins.FloatAssembler{"float"}.BeginList(0)
+	return mixins.FloatAssembler{TypeName: "float"}.BeginList(0)
 }
 func (plainFloat__Assembler) AssignNull() error {
-	return mixins.FloatAssembler{"float"}.AssignNull()
+	return mixins.FloatAssembler{TypeName: "float"}.AssignNull()
 }
 func (plainFloat__Assembler) AssignBool(bool) error {
-	return mixins.FloatAssembler{"float"}.AssignBool(false)
+	return mixins.FloatAssembler{TypeName: "float"}.AssignBool(false)
 }
 func (plainFloat__Assembler) AssignInt(int) error {
-	return mixins.FloatAssembler{"float"}.AssignInt(0)
+	return mixins.FloatAssembler{TypeName: "float"}.AssignInt(0)
 }
 func (na *plainFloat__Assembler) AssignFloat(v float64) error {
 	*na.w = plainFloat(v)
 	return nil
 }
 func (plainFloat__Assembler) AssignString(string) error {
-	return mixins.FloatAssembler{"float"}.AssignString("")
+	return mixins.FloatAssembler{TypeName: "float"}.AssignString("")
 }
 func (plainFloat__Assembler) AssignBytes([]byte) error {
-	return mixins.FloatAssembler{"float"}.AssignBytes(nil)
+	return mixins.FloatAssembler{TypeName: "float"}.AssignBytes(nil)
 }
 func (plainFloat__Assembler) AssignLink(ipld.Link) error {
-	return mixins.FloatAssembler{"float"}.AssignLink(nil)
+	return mixins.FloatAssembler{TypeName: "float"}.AssignLink(nil)
 }
 func (na *plainFloat__Assembler) AssignNode(v ipld.Node) error {
 	if v2, err := v.AsFloat(); err != nil {

--- a/node/basic/int.go
+++ b/node/basic/int.go
@@ -26,16 +26,16 @@ func (plainInt) ReprKind() ipld.ReprKind {
 	return ipld.ReprKind_Int
 }
 func (plainInt) LookupByString(string) (ipld.Node, error) {
-	return mixins.Int{"int"}.LookupByString("")
+	return mixins.Int{TypeName: "int"}.LookupByString("")
 }
 func (plainInt) LookupByNode(key ipld.Node) (ipld.Node, error) {
-	return mixins.Int{"int"}.LookupByNode(nil)
+	return mixins.Int{TypeName: "int"}.LookupByNode(nil)
 }
 func (plainInt) LookupByIndex(idx int) (ipld.Node, error) {
-	return mixins.Int{"int"}.LookupByIndex(0)
+	return mixins.Int{TypeName: "int"}.LookupByIndex(0)
 }
 func (plainInt) LookupBySegment(seg ipld.PathSegment) (ipld.Node, error) {
-	return mixins.Int{"int"}.LookupBySegment(seg)
+	return mixins.Int{TypeName: "int"}.LookupBySegment(seg)
 }
 func (plainInt) MapIterator() ipld.MapIterator {
 	return nil
@@ -53,22 +53,22 @@ func (plainInt) IsNull() bool {
 	return false
 }
 func (plainInt) AsBool() (bool, error) {
-	return mixins.Int{"int"}.AsBool()
+	return mixins.Int{TypeName: "int"}.AsBool()
 }
 func (n plainInt) AsInt() (int, error) {
 	return int(n), nil
 }
 func (plainInt) AsFloat() (float64, error) {
-	return mixins.Int{"int"}.AsFloat()
+	return mixins.Int{TypeName: "int"}.AsFloat()
 }
 func (plainInt) AsString() (string, error) {
-	return mixins.Int{"int"}.AsString()
+	return mixins.Int{TypeName: "int"}.AsString()
 }
 func (plainInt) AsBytes() ([]byte, error) {
-	return mixins.Int{"int"}.AsBytes()
+	return mixins.Int{TypeName: "int"}.AsBytes()
 }
 func (plainInt) AsLink() (ipld.Link, error) {
-	return mixins.Int{"int"}.AsLink()
+	return mixins.Int{TypeName: "int"}.AsLink()
 }
 func (plainInt) Prototype() ipld.NodePrototype {
 	return Prototype__Int{}
@@ -104,32 +104,32 @@ type plainInt__Assembler struct {
 }
 
 func (plainInt__Assembler) BeginMap(sizeHint int) (ipld.MapAssembler, error) {
-	return mixins.IntAssembler{"int"}.BeginMap(0)
+	return mixins.IntAssembler{TypeName: "int"}.BeginMap(0)
 }
 func (plainInt__Assembler) BeginList(sizeHint int) (ipld.ListAssembler, error) {
-	return mixins.IntAssembler{"int"}.BeginList(0)
+	return mixins.IntAssembler{TypeName: "int"}.BeginList(0)
 }
 func (plainInt__Assembler) AssignNull() error {
-	return mixins.IntAssembler{"int"}.AssignNull()
+	return mixins.IntAssembler{TypeName: "int"}.AssignNull()
 }
 func (plainInt__Assembler) AssignBool(bool) error {
-	return mixins.IntAssembler{"int"}.AssignBool(false)
+	return mixins.IntAssembler{TypeName: "int"}.AssignBool(false)
 }
 func (na *plainInt__Assembler) AssignInt(v int) error {
 	*na.w = plainInt(v)
 	return nil
 }
 func (plainInt__Assembler) AssignFloat(float64) error {
-	return mixins.IntAssembler{"int"}.AssignFloat(0)
+	return mixins.IntAssembler{TypeName: "int"}.AssignFloat(0)
 }
 func (plainInt__Assembler) AssignString(string) error {
-	return mixins.IntAssembler{"int"}.AssignString("")
+	return mixins.IntAssembler{TypeName: "int"}.AssignString("")
 }
 func (plainInt__Assembler) AssignBytes([]byte) error {
-	return mixins.IntAssembler{"int"}.AssignBytes(nil)
+	return mixins.IntAssembler{TypeName: "int"}.AssignBytes(nil)
 }
 func (plainInt__Assembler) AssignLink(ipld.Link) error {
-	return mixins.IntAssembler{"int"}.AssignLink(nil)
+	return mixins.IntAssembler{TypeName: "int"}.AssignLink(nil)
 }
 func (na *plainInt__Assembler) AssignNode(v ipld.Node) error {
 	if v2, err := v.AsInt(); err != nil {

--- a/node/basic/link.go
+++ b/node/basic/link.go
@@ -27,16 +27,16 @@ func (plainLink) ReprKind() ipld.ReprKind {
 	return ipld.ReprKind_Link
 }
 func (plainLink) LookupByString(string) (ipld.Node, error) {
-	return mixins.Link{"link"}.LookupByString("")
+	return mixins.Link{TypeName: "link"}.LookupByString("")
 }
 func (plainLink) LookupByNode(key ipld.Node) (ipld.Node, error) {
-	return mixins.Link{"link"}.LookupByNode(nil)
+	return mixins.Link{TypeName: "link"}.LookupByNode(nil)
 }
 func (plainLink) LookupByIndex(idx int) (ipld.Node, error) {
-	return mixins.Link{"link"}.LookupByIndex(0)
+	return mixins.Link{TypeName: "link"}.LookupByIndex(0)
 }
 func (plainLink) LookupBySegment(seg ipld.PathSegment) (ipld.Node, error) {
-	return mixins.Link{"link"}.LookupBySegment(seg)
+	return mixins.Link{TypeName: "link"}.LookupBySegment(seg)
 }
 func (plainLink) MapIterator() ipld.MapIterator {
 	return nil
@@ -54,19 +54,19 @@ func (plainLink) IsNull() bool {
 	return false
 }
 func (plainLink) AsBool() (bool, error) {
-	return mixins.Link{"link"}.AsBool()
+	return mixins.Link{TypeName: "link"}.AsBool()
 }
 func (plainLink) AsInt() (int, error) {
-	return mixins.Link{"link"}.AsInt()
+	return mixins.Link{TypeName: "link"}.AsInt()
 }
 func (plainLink) AsFloat() (float64, error) {
-	return mixins.Link{"link"}.AsFloat()
+	return mixins.Link{TypeName: "link"}.AsFloat()
 }
 func (plainLink) AsString() (string, error) {
-	return mixins.Link{"link"}.AsString()
+	return mixins.Link{TypeName: "link"}.AsString()
 }
 func (plainLink) AsBytes() ([]byte, error) {
-	return mixins.Link{"link"}.AsBytes()
+	return mixins.Link{TypeName: "link"}.AsBytes()
 }
 func (n *plainLink) AsLink() (ipld.Link, error) {
 	return n.x, nil
@@ -105,28 +105,28 @@ type plainLink__Assembler struct {
 }
 
 func (plainLink__Assembler) BeginMap(sizeHint int) (ipld.MapAssembler, error) {
-	return mixins.LinkAssembler{"link"}.BeginMap(0)
+	return mixins.LinkAssembler{TypeName: "link"}.BeginMap(0)
 }
 func (plainLink__Assembler) BeginList(sizeHint int) (ipld.ListAssembler, error) {
-	return mixins.LinkAssembler{"link"}.BeginList(0)
+	return mixins.LinkAssembler{TypeName: "link"}.BeginList(0)
 }
 func (plainLink__Assembler) AssignNull() error {
-	return mixins.LinkAssembler{"link"}.AssignNull()
+	return mixins.LinkAssembler{TypeName: "link"}.AssignNull()
 }
 func (plainLink__Assembler) AssignBool(bool) error {
-	return mixins.LinkAssembler{"link"}.AssignBool(false)
+	return mixins.LinkAssembler{TypeName: "link"}.AssignBool(false)
 }
 func (plainLink__Assembler) AssignInt(int) error {
-	return mixins.LinkAssembler{"link"}.AssignInt(0)
+	return mixins.LinkAssembler{TypeName: "link"}.AssignInt(0)
 }
 func (plainLink__Assembler) AssignFloat(float64) error {
-	return mixins.LinkAssembler{"link"}.AssignFloat(0)
+	return mixins.LinkAssembler{TypeName: "link"}.AssignFloat(0)
 }
 func (plainLink__Assembler) AssignString(string) error {
-	return mixins.LinkAssembler{"link"}.AssignString("")
+	return mixins.LinkAssembler{TypeName: "link"}.AssignString("")
 }
 func (plainLink__Assembler) AssignBytes([]byte) error {
-	return mixins.LinkAssembler{"link"}.AssignBytes(nil)
+	return mixins.LinkAssembler{TypeName: "link"}.AssignBytes(nil)
 }
 func (na *plainLink__Assembler) AssignLink(v ipld.Link) error {
 	na.w.x = v

--- a/node/basic/list.go
+++ b/node/basic/list.go
@@ -25,10 +25,10 @@ func (plainList) ReprKind() ipld.ReprKind {
 	return ipld.ReprKind_List
 }
 func (plainList) LookupByString(string) (ipld.Node, error) {
-	return mixins.List{"list"}.LookupByString("")
+	return mixins.List{TypeName: "list"}.LookupByString("")
 }
 func (plainList) LookupByNode(ipld.Node) (ipld.Node, error) {
-	return mixins.List{"list"}.LookupByNode(nil)
+	return mixins.List{TypeName: "list"}.LookupByNode(nil)
 }
 func (n *plainList) LookupByIndex(idx int) (ipld.Node, error) {
 	if n.Length() <= idx {
@@ -59,22 +59,22 @@ func (plainList) IsNull() bool {
 	return false
 }
 func (plainList) AsBool() (bool, error) {
-	return mixins.List{"list"}.AsBool()
+	return mixins.List{TypeName: "list"}.AsBool()
 }
 func (plainList) AsInt() (int, error) {
-	return mixins.List{"list"}.AsInt()
+	return mixins.List{TypeName: "list"}.AsInt()
 }
 func (plainList) AsFloat() (float64, error) {
-	return mixins.List{"list"}.AsFloat()
+	return mixins.List{TypeName: "list"}.AsFloat()
 }
 func (plainList) AsString() (string, error) {
-	return mixins.List{"list"}.AsString()
+	return mixins.List{TypeName: "list"}.AsString()
 }
 func (plainList) AsBytes() ([]byte, error) {
-	return mixins.List{"list"}.AsBytes()
+	return mixins.List{TypeName: "list"}.AsBytes()
 }
 func (plainList) AsLink() (ipld.Link, error) {
-	return mixins.List{"list"}.AsLink()
+	return mixins.List{TypeName: "list"}.AsLink()
 }
 func (plainList) Prototype() ipld.NodePrototype {
 	return Prototype__List{}
@@ -148,7 +148,7 @@ const (
 )
 
 func (plainList__Assembler) BeginMap(sizeHint int) (ipld.MapAssembler, error) {
-	return mixins.ListAssembler{"list"}.BeginMap(0)
+	return mixins.ListAssembler{TypeName: "list"}.BeginMap(0)
 }
 func (na *plainList__Assembler) BeginList(sizeHint int) (ipld.ListAssembler, error) {
 	if sizeHint < 0 {
@@ -160,25 +160,25 @@ func (na *plainList__Assembler) BeginList(sizeHint int) (ipld.ListAssembler, err
 	return na, nil
 }
 func (plainList__Assembler) AssignNull() error {
-	return mixins.ListAssembler{"list"}.AssignNull()
+	return mixins.ListAssembler{TypeName: "list"}.AssignNull()
 }
 func (plainList__Assembler) AssignBool(bool) error {
-	return mixins.ListAssembler{"list"}.AssignBool(false)
+	return mixins.ListAssembler{TypeName: "list"}.AssignBool(false)
 }
 func (plainList__Assembler) AssignInt(int) error {
-	return mixins.ListAssembler{"list"}.AssignInt(0)
+	return mixins.ListAssembler{TypeName: "list"}.AssignInt(0)
 }
 func (plainList__Assembler) AssignFloat(float64) error {
-	return mixins.ListAssembler{"list"}.AssignFloat(0)
+	return mixins.ListAssembler{TypeName: "list"}.AssignFloat(0)
 }
 func (plainList__Assembler) AssignString(string) error {
-	return mixins.ListAssembler{"list"}.AssignString("")
+	return mixins.ListAssembler{TypeName: "list"}.AssignString("")
 }
 func (plainList__Assembler) AssignBytes([]byte) error {
-	return mixins.ListAssembler{"list"}.AssignBytes(nil)
+	return mixins.ListAssembler{TypeName: "list"}.AssignBytes(nil)
 }
 func (plainList__Assembler) AssignLink(ipld.Link) error {
-	return mixins.ListAssembler{"list"}.AssignLink(nil)
+	return mixins.ListAssembler{TypeName: "list"}.AssignLink(nil)
 }
 func (na *plainList__Assembler) AssignNode(v ipld.Node) error {
 	// Sanity check, then update, assembler state.

--- a/node/basic/map.go
+++ b/node/basic/map.go
@@ -48,7 +48,7 @@ func (n *plainMap) LookupByNode(key ipld.Node) (ipld.Node, error) {
 	return n.LookupByString(ks)
 }
 func (plainMap) LookupByIndex(idx int) (ipld.Node, error) {
-	return mixins.Map{"map"}.LookupByIndex(0)
+	return mixins.Map{TypeName: "map"}.LookupByIndex(0)
 }
 func (n *plainMap) LookupBySegment(seg ipld.PathSegment) (ipld.Node, error) {
 	return n.LookupByString(seg.String())
@@ -69,22 +69,22 @@ func (plainMap) IsNull() bool {
 	return false
 }
 func (plainMap) AsBool() (bool, error) {
-	return mixins.Map{"map"}.AsBool()
+	return mixins.Map{TypeName: "map"}.AsBool()
 }
 func (plainMap) AsInt() (int, error) {
-	return mixins.Map{"map"}.AsInt()
+	return mixins.Map{TypeName: "map"}.AsInt()
 }
 func (plainMap) AsFloat() (float64, error) {
-	return mixins.Map{"map"}.AsFloat()
+	return mixins.Map{TypeName: "map"}.AsFloat()
 }
 func (plainMap) AsString() (string, error) {
-	return mixins.Map{"map"}.AsString()
+	return mixins.Map{TypeName: "map"}.AsString()
 }
 func (plainMap) AsBytes() ([]byte, error) {
-	return mixins.Map{"map"}.AsBytes()
+	return mixins.Map{TypeName: "map"}.AsBytes()
 }
 func (plainMap) AsLink() (ipld.Link, error) {
-	return mixins.Map{"map"}.AsLink()
+	return mixins.Map{TypeName: "map"}.AsLink()
 }
 func (plainMap) Prototype() ipld.NodePrototype {
 	return Prototype__Map{}
@@ -173,28 +173,28 @@ func (na *plainMap__Assembler) BeginMap(sizeHint int) (ipld.MapAssembler, error)
 	return na, nil
 }
 func (plainMap__Assembler) BeginList(sizeHint int) (ipld.ListAssembler, error) {
-	return mixins.MapAssembler{"map"}.BeginList(0)
+	return mixins.MapAssembler{TypeName: "map"}.BeginList(0)
 }
 func (plainMap__Assembler) AssignNull() error {
-	return mixins.MapAssembler{"map"}.AssignNull()
+	return mixins.MapAssembler{TypeName: "map"}.AssignNull()
 }
 func (plainMap__Assembler) AssignBool(bool) error {
-	return mixins.MapAssembler{"map"}.AssignBool(false)
+	return mixins.MapAssembler{TypeName: "map"}.AssignBool(false)
 }
 func (plainMap__Assembler) AssignInt(int) error {
-	return mixins.MapAssembler{"map"}.AssignInt(0)
+	return mixins.MapAssembler{TypeName: "map"}.AssignInt(0)
 }
 func (plainMap__Assembler) AssignFloat(float64) error {
-	return mixins.MapAssembler{"map"}.AssignFloat(0)
+	return mixins.MapAssembler{TypeName: "map"}.AssignFloat(0)
 }
 func (plainMap__Assembler) AssignString(string) error {
-	return mixins.MapAssembler{"map"}.AssignString("")
+	return mixins.MapAssembler{TypeName: "map"}.AssignString("")
 }
 func (plainMap__Assembler) AssignBytes([]byte) error {
-	return mixins.MapAssembler{"map"}.AssignBytes(nil)
+	return mixins.MapAssembler{TypeName: "map"}.AssignBytes(nil)
 }
 func (plainMap__Assembler) AssignLink(ipld.Link) error {
-	return mixins.MapAssembler{"map"}.AssignLink(nil)
+	return mixins.MapAssembler{TypeName: "map"}.AssignLink(nil)
 }
 func (na *plainMap__Assembler) AssignNode(v ipld.Node) error {
 	// Sanity check assembler state.
@@ -305,22 +305,22 @@ func (plainMap__Assembler) ValuePrototype(_ string) ipld.NodePrototype {
 // -- MapAssembler.KeyAssembler -->
 
 func (plainMap__KeyAssembler) BeginMap(sizeHint int) (ipld.MapAssembler, error) {
-	return mixins.StringAssembler{"string"}.BeginMap(0)
+	return mixins.StringAssembler{TypeName: "string"}.BeginMap(0)
 }
 func (plainMap__KeyAssembler) BeginList(sizeHint int) (ipld.ListAssembler, error) {
-	return mixins.StringAssembler{"string"}.BeginList(0)
+	return mixins.StringAssembler{TypeName: "string"}.BeginList(0)
 }
 func (plainMap__KeyAssembler) AssignNull() error {
-	return mixins.StringAssembler{"string"}.AssignNull()
+	return mixins.StringAssembler{TypeName: "string"}.AssignNull()
 }
 func (plainMap__KeyAssembler) AssignBool(bool) error {
-	return mixins.StringAssembler{"string"}.AssignBool(false)
+	return mixins.StringAssembler{TypeName: "string"}.AssignBool(false)
 }
 func (plainMap__KeyAssembler) AssignInt(int) error {
-	return mixins.StringAssembler{"string"}.AssignInt(0)
+	return mixins.StringAssembler{TypeName: "string"}.AssignInt(0)
 }
 func (plainMap__KeyAssembler) AssignFloat(float64) error {
-	return mixins.StringAssembler{"string"}.AssignFloat(0)
+	return mixins.StringAssembler{TypeName: "string"}.AssignFloat(0)
 }
 func (mka *plainMap__KeyAssembler) AssignString(v string) error {
 	// Check for dup keys; error if so.
@@ -343,10 +343,10 @@ func (mka *plainMap__KeyAssembler) AssignString(v string) error {
 	return nil
 }
 func (plainMap__KeyAssembler) AssignBytes([]byte) error {
-	return mixins.StringAssembler{"string"}.AssignBytes(nil)
+	return mixins.StringAssembler{TypeName: "string"}.AssignBytes(nil)
 }
 func (plainMap__KeyAssembler) AssignLink(ipld.Link) error {
-	return mixins.StringAssembler{"string"}.AssignLink(nil)
+	return mixins.StringAssembler{TypeName: "string"}.AssignLink(nil)
 }
 func (mka *plainMap__KeyAssembler) AssignNode(v ipld.Node) error {
 	vs, err := v.AsString()

--- a/node/basic/string.go
+++ b/node/basic/string.go
@@ -31,16 +31,16 @@ func (plainString) ReprKind() ipld.ReprKind {
 	return ipld.ReprKind_String
 }
 func (plainString) LookupByString(string) (ipld.Node, error) {
-	return mixins.String{"string"}.LookupByString("")
+	return mixins.String{TypeName: "string"}.LookupByString("")
 }
 func (plainString) LookupByNode(key ipld.Node) (ipld.Node, error) {
-	return mixins.String{"string"}.LookupByNode(nil)
+	return mixins.String{TypeName: "string"}.LookupByNode(nil)
 }
 func (plainString) LookupByIndex(idx int) (ipld.Node, error) {
-	return mixins.String{"string"}.LookupByIndex(0)
+	return mixins.String{TypeName: "string"}.LookupByIndex(0)
 }
 func (plainString) LookupBySegment(seg ipld.PathSegment) (ipld.Node, error) {
-	return mixins.String{"string"}.LookupBySegment(seg)
+	return mixins.String{TypeName: "string"}.LookupBySegment(seg)
 }
 func (plainString) MapIterator() ipld.MapIterator {
 	return nil
@@ -58,22 +58,22 @@ func (plainString) IsNull() bool {
 	return false
 }
 func (plainString) AsBool() (bool, error) {
-	return mixins.String{"string"}.AsBool()
+	return mixins.String{TypeName: "string"}.AsBool()
 }
 func (plainString) AsInt() (int, error) {
-	return mixins.String{"string"}.AsInt()
+	return mixins.String{TypeName: "string"}.AsInt()
 }
 func (plainString) AsFloat() (float64, error) {
-	return mixins.String{"string"}.AsFloat()
+	return mixins.String{TypeName: "string"}.AsFloat()
 }
 func (x plainString) AsString() (string, error) {
 	return string(x), nil
 }
 func (plainString) AsBytes() ([]byte, error) {
-	return mixins.String{"string"}.AsBytes()
+	return mixins.String{TypeName: "string"}.AsBytes()
 }
 func (plainString) AsLink() (ipld.Link, error) {
-	return mixins.String{"string"}.AsLink()
+	return mixins.String{TypeName: "string"}.AsLink()
 }
 func (plainString) Prototype() ipld.NodePrototype {
 	return Prototype__String{}
@@ -109,32 +109,32 @@ type plainString__Assembler struct {
 }
 
 func (plainString__Assembler) BeginMap(sizeHint int) (ipld.MapAssembler, error) {
-	return mixins.StringAssembler{"string"}.BeginMap(0)
+	return mixins.StringAssembler{TypeName: "string"}.BeginMap(0)
 }
 func (plainString__Assembler) BeginList(sizeHint int) (ipld.ListAssembler, error) {
-	return mixins.StringAssembler{"string"}.BeginList(0)
+	return mixins.StringAssembler{TypeName: "string"}.BeginList(0)
 }
 func (plainString__Assembler) AssignNull() error {
-	return mixins.StringAssembler{"string"}.AssignNull()
+	return mixins.StringAssembler{TypeName: "string"}.AssignNull()
 }
 func (plainString__Assembler) AssignBool(bool) error {
-	return mixins.StringAssembler{"string"}.AssignBool(false)
+	return mixins.StringAssembler{TypeName: "string"}.AssignBool(false)
 }
 func (plainString__Assembler) AssignInt(int) error {
-	return mixins.StringAssembler{"string"}.AssignInt(0)
+	return mixins.StringAssembler{TypeName: "string"}.AssignInt(0)
 }
 func (plainString__Assembler) AssignFloat(float64) error {
-	return mixins.StringAssembler{"string"}.AssignFloat(0)
+	return mixins.StringAssembler{TypeName: "string"}.AssignFloat(0)
 }
 func (na *plainString__Assembler) AssignString(v string) error {
 	*na.w = plainString(v)
 	return nil
 }
 func (plainString__Assembler) AssignBytes([]byte) error {
-	return mixins.StringAssembler{"string"}.AssignBytes(nil)
+	return mixins.StringAssembler{TypeName: "string"}.AssignBytes(nil)
 }
 func (plainString__Assembler) AssignLink(ipld.Link) error {
-	return mixins.StringAssembler{"string"}.AssignLink(nil)
+	return mixins.StringAssembler{TypeName: "string"}.AssignLink(nil)
 }
 func (na *plainString__Assembler) AssignNode(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {

--- a/node/gendemo/ipldsch_satisfaction.go
+++ b/node/gendemo/ipldsch_satisfaction.go
@@ -136,10 +136,10 @@ type _Int__Assembler struct {
 
 func (na *_Int__Assembler) reset() {}
 func (_Int__Assembler) BeginMap(sizeHint int) (ipld.MapAssembler, error) {
-	return mixins.IntAssembler{"gendemo.Int"}.BeginMap(0)
+	return mixins.IntAssembler{TypeName: "gendemo.Int"}.BeginMap(0)
 }
 func (_Int__Assembler) BeginList(sizeHint int) (ipld.ListAssembler, error) {
-	return mixins.IntAssembler{"gendemo.Int"}.BeginList(0)
+	return mixins.IntAssembler{TypeName: "gendemo.Int"}.BeginList(0)
 }
 func (na *_Int__Assembler) AssignNull() error {
 	switch *na.m {
@@ -147,14 +147,14 @@ func (na *_Int__Assembler) AssignNull() error {
 		*na.m = schema.Maybe_Null
 		return nil
 	case schema.Maybe_Absent:
-		return mixins.IntAssembler{"gendemo.Int"}.AssignNull()
+		return mixins.IntAssembler{TypeName: "gendemo.Int"}.AssignNull()
 	case schema.Maybe_Value, schema.Maybe_Null:
 		panic("invalid state: cannot assign into assembler that's already finished")
 	}
 	panic("unreachable")
 }
 func (_Int__Assembler) AssignBool(bool) error {
-	return mixins.IntAssembler{"gendemo.Int"}.AssignBool(false)
+	return mixins.IntAssembler{TypeName: "gendemo.Int"}.AssignBool(false)
 }
 func (na *_Int__Assembler) AssignInt(v int) error {
 	switch *na.m {
@@ -169,16 +169,16 @@ func (na *_Int__Assembler) AssignInt(v int) error {
 	return nil
 }
 func (_Int__Assembler) AssignFloat(float64) error {
-	return mixins.IntAssembler{"gendemo.Int"}.AssignFloat(0)
+	return mixins.IntAssembler{TypeName: "gendemo.Int"}.AssignFloat(0)
 }
 func (_Int__Assembler) AssignString(string) error {
-	return mixins.IntAssembler{"gendemo.Int"}.AssignString("")
+	return mixins.IntAssembler{TypeName: "gendemo.Int"}.AssignString("")
 }
 func (_Int__Assembler) AssignBytes([]byte) error {
-	return mixins.IntAssembler{"gendemo.Int"}.AssignBytes(nil)
+	return mixins.IntAssembler{TypeName: "gendemo.Int"}.AssignBytes(nil)
 }
 func (_Int__Assembler) AssignLink(ipld.Link) error {
-	return mixins.IntAssembler{"gendemo.Int"}.AssignLink(nil)
+	return mixins.IntAssembler{TypeName: "gendemo.Int"}.AssignLink(nil)
 }
 func (na *_Int__Assembler) AssignNode(v ipld.Node) error {
 	if v.IsNull() {
@@ -448,7 +448,7 @@ func (na *_Map__String__Msg3__Assembler) BeginMap(sizeHint int) (ipld.MapAssembl
 	return na, nil
 }
 func (_Map__String__Msg3__Assembler) BeginList(sizeHint int) (ipld.ListAssembler, error) {
-	return mixins.MapAssembler{"gendemo.Map__String__Msg3"}.BeginList(0)
+	return mixins.MapAssembler{TypeName: "gendemo.Map__String__Msg3"}.BeginList(0)
 }
 func (na *_Map__String__Msg3__Assembler) AssignNull() error {
 	switch *na.m {
@@ -456,7 +456,7 @@ func (na *_Map__String__Msg3__Assembler) AssignNull() error {
 		*na.m = schema.Maybe_Null
 		return nil
 	case schema.Maybe_Absent:
-		return mixins.MapAssembler{"gendemo.Map__String__Msg3"}.AssignNull()
+		return mixins.MapAssembler{TypeName: "gendemo.Map__String__Msg3"}.AssignNull()
 	case schema.Maybe_Value, schema.Maybe_Null:
 		panic("invalid state: cannot assign into assembler that's already finished")
 	case midvalue:
@@ -465,22 +465,22 @@ func (na *_Map__String__Msg3__Assembler) AssignNull() error {
 	panic("unreachable")
 }
 func (_Map__String__Msg3__Assembler) AssignBool(bool) error {
-	return mixins.MapAssembler{"gendemo.Map__String__Msg3"}.AssignBool(false)
+	return mixins.MapAssembler{TypeName: "gendemo.Map__String__Msg3"}.AssignBool(false)
 }
 func (_Map__String__Msg3__Assembler) AssignInt(int) error {
-	return mixins.MapAssembler{"gendemo.Map__String__Msg3"}.AssignInt(0)
+	return mixins.MapAssembler{TypeName: "gendemo.Map__String__Msg3"}.AssignInt(0)
 }
 func (_Map__String__Msg3__Assembler) AssignFloat(float64) error {
-	return mixins.MapAssembler{"gendemo.Map__String__Msg3"}.AssignFloat(0)
+	return mixins.MapAssembler{TypeName: "gendemo.Map__String__Msg3"}.AssignFloat(0)
 }
 func (_Map__String__Msg3__Assembler) AssignString(string) error {
-	return mixins.MapAssembler{"gendemo.Map__String__Msg3"}.AssignString("")
+	return mixins.MapAssembler{TypeName: "gendemo.Map__String__Msg3"}.AssignString("")
 }
 func (_Map__String__Msg3__Assembler) AssignBytes([]byte) error {
-	return mixins.MapAssembler{"gendemo.Map__String__Msg3"}.AssignBytes(nil)
+	return mixins.MapAssembler{TypeName: "gendemo.Map__String__Msg3"}.AssignBytes(nil)
 }
 func (_Map__String__Msg3__Assembler) AssignLink(ipld.Link) error {
-	return mixins.MapAssembler{"gendemo.Map__String__Msg3"}.AssignLink(nil)
+	return mixins.MapAssembler{TypeName: "gendemo.Map__String__Msg3"}.AssignLink(nil)
 }
 func (na *_Map__String__Msg3__Assembler) AssignNode(v ipld.Node) error {
 	if v.IsNull() {
@@ -790,7 +790,7 @@ func (na *_Map__String__Msg3__ReprAssembler) BeginMap(sizeHint int) (ipld.MapAss
 	return na, nil
 }
 func (_Map__String__Msg3__ReprAssembler) BeginList(sizeHint int) (ipld.ListAssembler, error) {
-	return mixins.MapAssembler{"gendemo.Map__String__Msg3.Repr"}.BeginList(0)
+	return mixins.MapAssembler{TypeName: "gendemo.Map__String__Msg3.Repr"}.BeginList(0)
 }
 func (na *_Map__String__Msg3__ReprAssembler) AssignNull() error {
 	switch *na.m {
@@ -798,7 +798,7 @@ func (na *_Map__String__Msg3__ReprAssembler) AssignNull() error {
 		*na.m = schema.Maybe_Null
 		return nil
 	case schema.Maybe_Absent:
-		return mixins.MapAssembler{"gendemo.Map__String__Msg3.Repr.Repr"}.AssignNull()
+		return mixins.MapAssembler{TypeName: "gendemo.Map__String__Msg3.Repr.Repr"}.AssignNull()
 	case schema.Maybe_Value, schema.Maybe_Null:
 		panic("invalid state: cannot assign into assembler that's already finished")
 	case midvalue:
@@ -807,22 +807,22 @@ func (na *_Map__String__Msg3__ReprAssembler) AssignNull() error {
 	panic("unreachable")
 }
 func (_Map__String__Msg3__ReprAssembler) AssignBool(bool) error {
-	return mixins.MapAssembler{"gendemo.Map__String__Msg3.Repr"}.AssignBool(false)
+	return mixins.MapAssembler{TypeName: "gendemo.Map__String__Msg3.Repr"}.AssignBool(false)
 }
 func (_Map__String__Msg3__ReprAssembler) AssignInt(int) error {
-	return mixins.MapAssembler{"gendemo.Map__String__Msg3.Repr"}.AssignInt(0)
+	return mixins.MapAssembler{TypeName: "gendemo.Map__String__Msg3.Repr"}.AssignInt(0)
 }
 func (_Map__String__Msg3__ReprAssembler) AssignFloat(float64) error {
-	return mixins.MapAssembler{"gendemo.Map__String__Msg3.Repr"}.AssignFloat(0)
+	return mixins.MapAssembler{TypeName: "gendemo.Map__String__Msg3.Repr"}.AssignFloat(0)
 }
 func (_Map__String__Msg3__ReprAssembler) AssignString(string) error {
-	return mixins.MapAssembler{"gendemo.Map__String__Msg3.Repr"}.AssignString("")
+	return mixins.MapAssembler{TypeName: "gendemo.Map__String__Msg3.Repr"}.AssignString("")
 }
 func (_Map__String__Msg3__ReprAssembler) AssignBytes([]byte) error {
-	return mixins.MapAssembler{"gendemo.Map__String__Msg3.Repr"}.AssignBytes(nil)
+	return mixins.MapAssembler{TypeName: "gendemo.Map__String__Msg3.Repr"}.AssignBytes(nil)
 }
 func (_Map__String__Msg3__ReprAssembler) AssignLink(ipld.Link) error {
-	return mixins.MapAssembler{"gendemo.Map__String__Msg3.Repr"}.AssignLink(nil)
+	return mixins.MapAssembler{TypeName: "gendemo.Map__String__Msg3.Repr"}.AssignLink(nil)
 }
 func (na *_Map__String__Msg3__ReprAssembler) AssignNode(v ipld.Node) error {
 	if v.IsNull() {
@@ -1203,7 +1203,7 @@ func (na *_Msg3__Assembler) BeginMap(int) (ipld.MapAssembler, error) {
 	return na, nil
 }
 func (_Msg3__Assembler) BeginList(sizeHint int) (ipld.ListAssembler, error) {
-	return mixins.MapAssembler{"gendemo.Msg3"}.BeginList(0)
+	return mixins.MapAssembler{TypeName: "gendemo.Msg3"}.BeginList(0)
 }
 func (na *_Msg3__Assembler) AssignNull() error {
 	switch *na.m {
@@ -1211,7 +1211,7 @@ func (na *_Msg3__Assembler) AssignNull() error {
 		*na.m = schema.Maybe_Null
 		return nil
 	case schema.Maybe_Absent:
-		return mixins.MapAssembler{"gendemo.Msg3"}.AssignNull()
+		return mixins.MapAssembler{TypeName: "gendemo.Msg3"}.AssignNull()
 	case schema.Maybe_Value, schema.Maybe_Null:
 		panic("invalid state: cannot assign into assembler that's already finished")
 	case midvalue:
@@ -1220,22 +1220,22 @@ func (na *_Msg3__Assembler) AssignNull() error {
 	panic("unreachable")
 }
 func (_Msg3__Assembler) AssignBool(bool) error {
-	return mixins.MapAssembler{"gendemo.Msg3"}.AssignBool(false)
+	return mixins.MapAssembler{TypeName: "gendemo.Msg3"}.AssignBool(false)
 }
 func (_Msg3__Assembler) AssignInt(int) error {
-	return mixins.MapAssembler{"gendemo.Msg3"}.AssignInt(0)
+	return mixins.MapAssembler{TypeName: "gendemo.Msg3"}.AssignInt(0)
 }
 func (_Msg3__Assembler) AssignFloat(float64) error {
-	return mixins.MapAssembler{"gendemo.Msg3"}.AssignFloat(0)
+	return mixins.MapAssembler{TypeName: "gendemo.Msg3"}.AssignFloat(0)
 }
 func (_Msg3__Assembler) AssignString(string) error {
-	return mixins.MapAssembler{"gendemo.Msg3"}.AssignString("")
+	return mixins.MapAssembler{TypeName: "gendemo.Msg3"}.AssignString("")
 }
 func (_Msg3__Assembler) AssignBytes([]byte) error {
-	return mixins.MapAssembler{"gendemo.Msg3"}.AssignBytes(nil)
+	return mixins.MapAssembler{TypeName: "gendemo.Msg3"}.AssignBytes(nil)
 }
 func (_Msg3__Assembler) AssignLink(ipld.Link) error {
-	return mixins.MapAssembler{"gendemo.Msg3"}.AssignLink(nil)
+	return mixins.MapAssembler{TypeName: "gendemo.Msg3"}.AssignLink(nil)
 }
 func (na *_Msg3__Assembler) AssignNode(v ipld.Node) error {
 	if v.IsNull() {
@@ -1455,22 +1455,22 @@ func (ma *_Msg3__Assembler) ValuePrototype(k string) ipld.NodePrototype {
 type _Msg3__KeyAssembler _Msg3__Assembler
 
 func (_Msg3__KeyAssembler) BeginMap(sizeHint int) (ipld.MapAssembler, error) {
-	return mixins.StringAssembler{"gendemo.Msg3.KeyAssembler"}.BeginMap(0)
+	return mixins.StringAssembler{TypeName: "gendemo.Msg3.KeyAssembler"}.BeginMap(0)
 }
 func (_Msg3__KeyAssembler) BeginList(sizeHint int) (ipld.ListAssembler, error) {
-	return mixins.StringAssembler{"gendemo.Msg3.KeyAssembler"}.BeginList(0)
+	return mixins.StringAssembler{TypeName: "gendemo.Msg3.KeyAssembler"}.BeginList(0)
 }
 func (na *_Msg3__KeyAssembler) AssignNull() error {
-	return mixins.StringAssembler{"gendemo.Msg3.KeyAssembler"}.AssignNull()
+	return mixins.StringAssembler{TypeName: "gendemo.Msg3.KeyAssembler"}.AssignNull()
 }
 func (_Msg3__KeyAssembler) AssignBool(bool) error {
-	return mixins.StringAssembler{"gendemo.Msg3.KeyAssembler"}.AssignBool(false)
+	return mixins.StringAssembler{TypeName: "gendemo.Msg3.KeyAssembler"}.AssignBool(false)
 }
 func (_Msg3__KeyAssembler) AssignInt(int) error {
-	return mixins.StringAssembler{"gendemo.Msg3.KeyAssembler"}.AssignInt(0)
+	return mixins.StringAssembler{TypeName: "gendemo.Msg3.KeyAssembler"}.AssignInt(0)
 }
 func (_Msg3__KeyAssembler) AssignFloat(float64) error {
-	return mixins.StringAssembler{"gendemo.Msg3.KeyAssembler"}.AssignFloat(0)
+	return mixins.StringAssembler{TypeName: "gendemo.Msg3.KeyAssembler"}.AssignFloat(0)
 }
 func (ka *_Msg3__KeyAssembler) AssignString(k string) error {
 	if ka.state != maState_midKey {
@@ -1504,10 +1504,10 @@ func (ka *_Msg3__KeyAssembler) AssignString(k string) error {
 	return nil
 }
 func (_Msg3__KeyAssembler) AssignBytes([]byte) error {
-	return mixins.StringAssembler{"gendemo.Msg3.KeyAssembler"}.AssignBytes(nil)
+	return mixins.StringAssembler{TypeName: "gendemo.Msg3.KeyAssembler"}.AssignBytes(nil)
 }
 func (_Msg3__KeyAssembler) AssignLink(ipld.Link) error {
-	return mixins.StringAssembler{"gendemo.Msg3.KeyAssembler"}.AssignLink(nil)
+	return mixins.StringAssembler{TypeName: "gendemo.Msg3.KeyAssembler"}.AssignLink(nil)
 }
 func (ka *_Msg3__KeyAssembler) AssignNode(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
@@ -1688,7 +1688,7 @@ func (na *_Msg3__ReprAssembler) BeginMap(int) (ipld.MapAssembler, error) {
 	return na, nil
 }
 func (_Msg3__ReprAssembler) BeginList(sizeHint int) (ipld.ListAssembler, error) {
-	return mixins.MapAssembler{"gendemo.Msg3.Repr"}.BeginList(0)
+	return mixins.MapAssembler{TypeName: "gendemo.Msg3.Repr"}.BeginList(0)
 }
 func (na *_Msg3__ReprAssembler) AssignNull() error {
 	switch *na.m {
@@ -1696,7 +1696,7 @@ func (na *_Msg3__ReprAssembler) AssignNull() error {
 		*na.m = schema.Maybe_Null
 		return nil
 	case schema.Maybe_Absent:
-		return mixins.MapAssembler{"gendemo.Msg3.Repr.Repr"}.AssignNull()
+		return mixins.MapAssembler{TypeName: "gendemo.Msg3.Repr.Repr"}.AssignNull()
 	case schema.Maybe_Value, schema.Maybe_Null:
 		panic("invalid state: cannot assign into assembler that's already finished")
 	case midvalue:
@@ -1705,22 +1705,22 @@ func (na *_Msg3__ReprAssembler) AssignNull() error {
 	panic("unreachable")
 }
 func (_Msg3__ReprAssembler) AssignBool(bool) error {
-	return mixins.MapAssembler{"gendemo.Msg3.Repr"}.AssignBool(false)
+	return mixins.MapAssembler{TypeName: "gendemo.Msg3.Repr"}.AssignBool(false)
 }
 func (_Msg3__ReprAssembler) AssignInt(int) error {
-	return mixins.MapAssembler{"gendemo.Msg3.Repr"}.AssignInt(0)
+	return mixins.MapAssembler{TypeName: "gendemo.Msg3.Repr"}.AssignInt(0)
 }
 func (_Msg3__ReprAssembler) AssignFloat(float64) error {
-	return mixins.MapAssembler{"gendemo.Msg3.Repr"}.AssignFloat(0)
+	return mixins.MapAssembler{TypeName: "gendemo.Msg3.Repr"}.AssignFloat(0)
 }
 func (_Msg3__ReprAssembler) AssignString(string) error {
-	return mixins.MapAssembler{"gendemo.Msg3.Repr"}.AssignString("")
+	return mixins.MapAssembler{TypeName: "gendemo.Msg3.Repr"}.AssignString("")
 }
 func (_Msg3__ReprAssembler) AssignBytes([]byte) error {
-	return mixins.MapAssembler{"gendemo.Msg3.Repr"}.AssignBytes(nil)
+	return mixins.MapAssembler{TypeName: "gendemo.Msg3.Repr"}.AssignBytes(nil)
 }
 func (_Msg3__ReprAssembler) AssignLink(ipld.Link) error {
-	return mixins.MapAssembler{"gendemo.Msg3.Repr"}.AssignLink(nil)
+	return mixins.MapAssembler{TypeName: "gendemo.Msg3.Repr"}.AssignLink(nil)
 }
 func (na *_Msg3__ReprAssembler) AssignNode(v ipld.Node) error {
 	if v.IsNull() {
@@ -1925,22 +1925,22 @@ func (ma *_Msg3__ReprAssembler) ValuePrototype(k string) ipld.NodePrototype {
 type _Msg3__ReprKeyAssembler _Msg3__ReprAssembler
 
 func (_Msg3__ReprKeyAssembler) BeginMap(sizeHint int) (ipld.MapAssembler, error) {
-	return mixins.StringAssembler{"gendemo.Msg3.Repr.KeyAssembler"}.BeginMap(0)
+	return mixins.StringAssembler{TypeName: "gendemo.Msg3.Repr.KeyAssembler"}.BeginMap(0)
 }
 func (_Msg3__ReprKeyAssembler) BeginList(sizeHint int) (ipld.ListAssembler, error) {
-	return mixins.StringAssembler{"gendemo.Msg3.Repr.KeyAssembler"}.BeginList(0)
+	return mixins.StringAssembler{TypeName: "gendemo.Msg3.Repr.KeyAssembler"}.BeginList(0)
 }
 func (na *_Msg3__ReprKeyAssembler) AssignNull() error {
-	return mixins.StringAssembler{"gendemo.Msg3.Repr.KeyAssembler"}.AssignNull()
+	return mixins.StringAssembler{TypeName: "gendemo.Msg3.Repr.KeyAssembler"}.AssignNull()
 }
 func (_Msg3__ReprKeyAssembler) AssignBool(bool) error {
-	return mixins.StringAssembler{"gendemo.Msg3.Repr.KeyAssembler"}.AssignBool(false)
+	return mixins.StringAssembler{TypeName: "gendemo.Msg3.Repr.KeyAssembler"}.AssignBool(false)
 }
 func (_Msg3__ReprKeyAssembler) AssignInt(int) error {
-	return mixins.StringAssembler{"gendemo.Msg3.Repr.KeyAssembler"}.AssignInt(0)
+	return mixins.StringAssembler{TypeName: "gendemo.Msg3.Repr.KeyAssembler"}.AssignInt(0)
 }
 func (_Msg3__ReprKeyAssembler) AssignFloat(float64) error {
-	return mixins.StringAssembler{"gendemo.Msg3.Repr.KeyAssembler"}.AssignFloat(0)
+	return mixins.StringAssembler{TypeName: "gendemo.Msg3.Repr.KeyAssembler"}.AssignFloat(0)
 }
 func (ka *_Msg3__ReprKeyAssembler) AssignString(k string) error {
 	if ka.state != maState_midKey {
@@ -1974,10 +1974,10 @@ func (ka *_Msg3__ReprKeyAssembler) AssignString(k string) error {
 	return nil
 }
 func (_Msg3__ReprKeyAssembler) AssignBytes([]byte) error {
-	return mixins.StringAssembler{"gendemo.Msg3.Repr.KeyAssembler"}.AssignBytes(nil)
+	return mixins.StringAssembler{TypeName: "gendemo.Msg3.Repr.KeyAssembler"}.AssignBytes(nil)
 }
 func (_Msg3__ReprKeyAssembler) AssignLink(ipld.Link) error {
-	return mixins.StringAssembler{"gendemo.Msg3.Repr.KeyAssembler"}.AssignLink(nil)
+	return mixins.StringAssembler{TypeName: "gendemo.Msg3.Repr.KeyAssembler"}.AssignLink(nil)
 }
 func (ka *_Msg3__ReprKeyAssembler) AssignNode(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
@@ -2122,10 +2122,10 @@ type _String__Assembler struct {
 
 func (na *_String__Assembler) reset() {}
 func (_String__Assembler) BeginMap(sizeHint int) (ipld.MapAssembler, error) {
-	return mixins.StringAssembler{"gendemo.String"}.BeginMap(0)
+	return mixins.StringAssembler{TypeName: "gendemo.String"}.BeginMap(0)
 }
 func (_String__Assembler) BeginList(sizeHint int) (ipld.ListAssembler, error) {
-	return mixins.StringAssembler{"gendemo.String"}.BeginList(0)
+	return mixins.StringAssembler{TypeName: "gendemo.String"}.BeginList(0)
 }
 func (na *_String__Assembler) AssignNull() error {
 	switch *na.m {
@@ -2133,20 +2133,20 @@ func (na *_String__Assembler) AssignNull() error {
 		*na.m = schema.Maybe_Null
 		return nil
 	case schema.Maybe_Absent:
-		return mixins.StringAssembler{"gendemo.String"}.AssignNull()
+		return mixins.StringAssembler{TypeName: "gendemo.String"}.AssignNull()
 	case schema.Maybe_Value, schema.Maybe_Null:
 		panic("invalid state: cannot assign into assembler that's already finished")
 	}
 	panic("unreachable")
 }
 func (_String__Assembler) AssignBool(bool) error {
-	return mixins.StringAssembler{"gendemo.String"}.AssignBool(false)
+	return mixins.StringAssembler{TypeName: "gendemo.String"}.AssignBool(false)
 }
 func (_String__Assembler) AssignInt(int) error {
-	return mixins.StringAssembler{"gendemo.String"}.AssignInt(0)
+	return mixins.StringAssembler{TypeName: "gendemo.String"}.AssignInt(0)
 }
 func (_String__Assembler) AssignFloat(float64) error {
-	return mixins.StringAssembler{"gendemo.String"}.AssignFloat(0)
+	return mixins.StringAssembler{TypeName: "gendemo.String"}.AssignFloat(0)
 }
 func (na *_String__Assembler) AssignString(v string) error {
 	switch *na.m {
@@ -2161,10 +2161,10 @@ func (na *_String__Assembler) AssignString(v string) error {
 	return nil
 }
 func (_String__Assembler) AssignBytes([]byte) error {
-	return mixins.StringAssembler{"gendemo.String"}.AssignBytes(nil)
+	return mixins.StringAssembler{TypeName: "gendemo.String"}.AssignBytes(nil)
 }
 func (_String__Assembler) AssignLink(ipld.Link) error {
-	return mixins.StringAssembler{"gendemo.String"}.AssignLink(nil)
+	return mixins.StringAssembler{TypeName: "gendemo.String"}.AssignLink(nil)
 }
 func (na *_String__Assembler) AssignNode(v ipld.Node) error {
 	if v.IsNull() {

--- a/schema/gen/go/genBool.go
+++ b/schema/gen/go/genBool.go
@@ -78,9 +78,9 @@ func (g boolGenerator) GetNodeBuilderGenerator() NodeBuilderGenerator {
 	return boolBuilderGenerator{
 		g.AdjCfg,
 		mixins.BoolAssemblerTraits{
-			g.PkgName,
-			g.TypeName,
-			"_" + g.AdjCfg.TypeSymbol(g.Type) + "__",
+			PkgName:       g.PkgName,
+			TypeName:      g.TypeName,
+			AppliedPrefix: "_" + g.AdjCfg.TypeSymbol(g.Type) + "__",
 		},
 		g.PkgName,
 		g.Type,

--- a/schema/gen/go/genBoolReprBool.go
+++ b/schema/gen/go/genBoolReprBool.go
@@ -14,9 +14,9 @@ func NewBoolReprBoolGenerator(pkgName string, typ *schema.TypeBool, adjCfg *Adju
 		boolGenerator{
 			adjCfg,
 			mixins.BoolTraits{
-				pkgName,
-				string(typ.Name()),
-				adjCfg.TypeSymbol(typ),
+				PkgName:    pkgName,
+				TypeName:   string(typ.Name()),
+				TypeSymbol: adjCfg.TypeSymbol(typ),
 			},
 			pkgName,
 			typ,

--- a/schema/gen/go/genBytes.go
+++ b/schema/gen/go/genBytes.go
@@ -78,9 +78,9 @@ func (g bytesGenerator) GetNodeBuilderGenerator() NodeBuilderGenerator {
 	return bytesBuilderGenerator{
 		g.AdjCfg,
 		mixins.BytesAssemblerTraits{
-			g.PkgName,
-			g.TypeName,
-			"_" + g.AdjCfg.TypeSymbol(g.Type) + "__",
+			PkgName:       g.PkgName,
+			TypeName:      g.TypeName,
+			AppliedPrefix: "_" + g.AdjCfg.TypeSymbol(g.Type) + "__",
 		},
 		g.PkgName,
 		g.Type,

--- a/schema/gen/go/genBytesReprBytes.go
+++ b/schema/gen/go/genBytesReprBytes.go
@@ -14,9 +14,9 @@ func NewBytesReprBytesGenerator(pkgName string, typ *schema.TypeBytes, adjCfg *A
 		bytesGenerator{
 			adjCfg,
 			mixins.BytesTraits{
-				pkgName,
-				string(typ.Name()),
-				adjCfg.TypeSymbol(typ),
+				PkgName:    pkgName,
+				TypeName:   string(typ.Name()),
+				TypeSymbol: adjCfg.TypeSymbol(typ),
 			},
 			pkgName,
 			typ,

--- a/schema/gen/go/genFloat.go
+++ b/schema/gen/go/genFloat.go
@@ -78,9 +78,9 @@ func (g float64Generator) GetNodeBuilderGenerator() NodeBuilderGenerator {
 	return float64BuilderGenerator{
 		g.AdjCfg,
 		mixins.FloatAssemblerTraits{
-			g.PkgName,
-			g.TypeName,
-			"_" + g.AdjCfg.TypeSymbol(g.Type) + "__",
+			PkgName:       g.PkgName,
+			TypeName:      g.TypeName,
+			AppliedPrefix: "_" + g.AdjCfg.TypeSymbol(g.Type) + "__",
 		},
 		g.PkgName,
 		g.Type,

--- a/schema/gen/go/genFloatReprFloat.go
+++ b/schema/gen/go/genFloatReprFloat.go
@@ -14,9 +14,9 @@ func NewFloatReprFloatGenerator(pkgName string, typ *schema.TypeFloat, adjCfg *A
 		float64Generator{
 			adjCfg,
 			mixins.FloatTraits{
-				pkgName,
-				string(typ.Name()),
-				adjCfg.TypeSymbol(typ),
+				PkgName:    pkgName,
+				TypeName:   string(typ.Name()),
+				TypeSymbol: adjCfg.TypeSymbol(typ),
 			},
 			pkgName,
 			typ,

--- a/schema/gen/go/genInt.go
+++ b/schema/gen/go/genInt.go
@@ -78,9 +78,9 @@ func (g intGenerator) GetNodeBuilderGenerator() NodeBuilderGenerator {
 	return intBuilderGenerator{
 		g.AdjCfg,
 		mixins.IntAssemblerTraits{
-			g.PkgName,
-			g.TypeName,
-			"_" + g.AdjCfg.TypeSymbol(g.Type) + "__",
+			PkgName:       g.PkgName,
+			TypeName:      g.TypeName,
+			AppliedPrefix: "_" + g.AdjCfg.TypeSymbol(g.Type) + "__",
 		},
 		g.PkgName,
 		g.Type,

--- a/schema/gen/go/genIntReprInt.go
+++ b/schema/gen/go/genIntReprInt.go
@@ -14,9 +14,9 @@ func NewIntReprIntGenerator(pkgName string, typ *schema.TypeInt, adjCfg *Adjunct
 		intGenerator{
 			adjCfg,
 			mixins.IntTraits{
-				pkgName,
-				string(typ.Name()),
-				adjCfg.TypeSymbol(typ),
+				PkgName:    pkgName,
+				TypeName:   string(typ.Name()),
+				TypeSymbol: adjCfg.TypeSymbol(typ),
 			},
 			pkgName,
 			typ,

--- a/schema/gen/go/genLink.go
+++ b/schema/gen/go/genLink.go
@@ -87,9 +87,9 @@ func (g linkGenerator) GetNodeBuilderGenerator() NodeBuilderGenerator {
 	return linkBuilderGenerator{
 		g.AdjCfg,
 		mixins.LinkAssemblerTraits{
-			g.PkgName,
-			g.TypeName,
-			"_" + g.AdjCfg.TypeSymbol(g.Type) + "__",
+			PkgName:       g.PkgName,
+			TypeName:      g.TypeName,
+			AppliedPrefix: "_" + g.AdjCfg.TypeSymbol(g.Type) + "__",
 		},
 		g.PkgName,
 		g.Type,

--- a/schema/gen/go/genLinkReprLink.go
+++ b/schema/gen/go/genLinkReprLink.go
@@ -14,9 +14,9 @@ func NewLinkReprLinkGenerator(pkgName string, typ *schema.TypeLink, adjCfg *Adju
 		linkGenerator{
 			adjCfg,
 			mixins.LinkTraits{
-				pkgName,
-				string(typ.Name()),
-				adjCfg.TypeSymbol(typ),
+				PkgName:    pkgName,
+				TypeName:   string(typ.Name()),
+				TypeSymbol: adjCfg.TypeSymbol(typ),
 			},
 			pkgName,
 			typ,

--- a/schema/gen/go/genList.go
+++ b/schema/gen/go/genList.go
@@ -234,9 +234,9 @@ func (g listGenerator) GetNodeBuilderGenerator() NodeBuilderGenerator {
 	return listBuilderGenerator{
 		g.AdjCfg,
 		mixins.ListAssemblerTraits{
-			g.PkgName,
-			g.TypeName,
-			"_" + g.AdjCfg.TypeSymbol(g.Type) + "__",
+			PkgName:       g.PkgName,
+			TypeName:      g.TypeName,
+			AppliedPrefix: "_" + g.AdjCfg.TypeSymbol(g.Type) + "__",
 		},
 		g.PkgName,
 		g.Type,

--- a/schema/gen/go/genListReprList.go
+++ b/schema/gen/go/genListReprList.go
@@ -14,9 +14,9 @@ func NewListReprListGenerator(pkgName string, typ *schema.TypeList, adjCfg *Adju
 		listGenerator{
 			adjCfg,
 			mixins.ListTraits{
-				pkgName,
-				string(typ.Name()),
-				adjCfg.TypeSymbol(typ),
+				PkgName:    pkgName,
+				TypeName:   string(typ.Name()),
+				TypeSymbol: adjCfg.TypeSymbol(typ),
 			},
 			pkgName,
 			typ,
@@ -32,9 +32,9 @@ func (g listReprListGenerator) GetRepresentationNodeGen() NodeGenerator {
 	return listReprListReprGenerator{
 		g.AdjCfg,
 		mixins.ListTraits{
-			g.PkgName,
-			string(g.Type.Name()) + ".Repr",
-			"_" + g.AdjCfg.TypeSymbol(g.Type) + "__Repr",
+			PkgName:    g.PkgName,
+			TypeName:   string(g.Type.Name()) + ".Repr",
+			TypeSymbol: "_" + g.AdjCfg.TypeSymbol(g.Type) + "__Repr",
 		},
 		g.PkgName,
 		g.Type,
@@ -140,9 +140,9 @@ func (g listReprListReprGenerator) GetNodeBuilderGenerator() NodeBuilderGenerato
 	return listReprListReprBuilderGenerator{
 		g.AdjCfg,
 		mixins.ListAssemblerTraits{
-			g.PkgName,
-			g.TypeName,
-			"_" + g.AdjCfg.TypeSymbol(g.Type) + "__Repr",
+			PkgName:       g.PkgName,
+			TypeName:      g.TypeName,
+			AppliedPrefix: "_" + g.AdjCfg.TypeSymbol(g.Type) + "__Repr",
 		},
 		g.PkgName,
 		g.Type,

--- a/schema/gen/go/genMap.go
+++ b/schema/gen/go/genMap.go
@@ -279,9 +279,9 @@ func (g mapGenerator) GetNodeBuilderGenerator() NodeBuilderGenerator {
 	return mapBuilderGenerator{
 		g.AdjCfg,
 		mixins.MapAssemblerTraits{
-			g.PkgName,
-			g.TypeName,
-			"_" + g.AdjCfg.TypeSymbol(g.Type) + "__",
+			PkgName:       g.PkgName,
+			TypeName:      g.TypeName,
+			AppliedPrefix: "_" + g.AdjCfg.TypeSymbol(g.Type) + "__",
 		},
 		g.PkgName,
 		g.Type,

--- a/schema/gen/go/genMapReprMap.go
+++ b/schema/gen/go/genMapReprMap.go
@@ -14,9 +14,9 @@ func NewMapReprMapGenerator(pkgName string, typ *schema.TypeMap, adjCfg *Adjunct
 		mapGenerator{
 			adjCfg,
 			mixins.MapTraits{
-				pkgName,
-				string(typ.Name()),
-				adjCfg.TypeSymbol(typ),
+				PkgName:    pkgName,
+				TypeName:   string(typ.Name()),
+				TypeSymbol: adjCfg.TypeSymbol(typ),
 			},
 			pkgName,
 			typ,
@@ -32,9 +32,9 @@ func (g mapReprMapGenerator) GetRepresentationNodeGen() NodeGenerator {
 	return mapReprMapReprGenerator{
 		g.AdjCfg,
 		mixins.MapTraits{
-			g.PkgName,
-			string(g.Type.Name()) + ".Repr",
-			"_" + g.AdjCfg.TypeSymbol(g.Type) + "__Repr",
+			PkgName:    g.PkgName,
+			TypeName:   string(g.Type.Name()) + ".Repr",
+			TypeSymbol: "_" + g.AdjCfg.TypeSymbol(g.Type) + "__Repr",
 		},
 		g.PkgName,
 		g.Type,
@@ -133,9 +133,9 @@ func (g mapReprMapReprGenerator) GetNodeBuilderGenerator() NodeBuilderGenerator 
 	return mapReprMapReprBuilderGenerator{
 		g.AdjCfg,
 		mixins.MapAssemblerTraits{
-			g.PkgName,
-			g.TypeName,
-			"_" + g.AdjCfg.TypeSymbol(g.Type) + "__Repr",
+			PkgName:       g.PkgName,
+			TypeName:      g.TypeName,
+			AppliedPrefix: "_" + g.AdjCfg.TypeSymbol(g.Type) + "__Repr",
 		},
 		g.PkgName,
 		g.Type,

--- a/schema/gen/go/genString.go
+++ b/schema/gen/go/genString.go
@@ -94,9 +94,9 @@ func (g stringGenerator) GetNodeBuilderGenerator() NodeBuilderGenerator {
 	return stringBuilderGenerator{
 		g.AdjCfg,
 		mixins.StringAssemblerTraits{
-			g.PkgName,
-			g.TypeName,
-			"_" + g.AdjCfg.TypeSymbol(g.Type) + "__",
+			PkgName:       g.PkgName,
+			TypeName:      g.TypeName,
+			AppliedPrefix: "_" + g.AdjCfg.TypeSymbol(g.Type) + "__",
 		},
 		g.PkgName,
 		g.Type,

--- a/schema/gen/go/genStringReprString.go
+++ b/schema/gen/go/genStringReprString.go
@@ -14,9 +14,9 @@ func NewStringReprStringGenerator(pkgName string, typ *schema.TypeString, adjCfg
 		stringGenerator{
 			adjCfg,
 			mixins.StringTraits{
-				pkgName,
-				string(typ.Name()),
-				adjCfg.TypeSymbol(typ),
+				PkgName:    pkgName,
+				TypeName:   string(typ.Name()),
+				TypeSymbol: adjCfg.TypeSymbol(typ),
 			},
 			pkgName,
 			typ,

--- a/schema/gen/go/genStruct.go
+++ b/schema/gen/go/genStruct.go
@@ -209,9 +209,9 @@ func (g structGenerator) GetNodeBuilderGenerator() NodeBuilderGenerator {
 	return structBuilderGenerator{
 		g.AdjCfg,
 		mixins.MapAssemblerTraits{
-			g.PkgName,
-			g.TypeName,
-			"_" + g.AdjCfg.TypeSymbol(g.Type) + "__",
+			PkgName:       g.PkgName,
+			TypeName:      g.TypeName,
+			AppliedPrefix: "_" + g.AdjCfg.TypeSymbol(g.Type) + "__",
 		},
 		g.PkgName,
 		g.Type,
@@ -538,9 +538,9 @@ func (g structBuilderGenerator) emitKeyAssembler(w io.Writer) {
 		type _{{ .Type | TypeSymbol }}__KeyAssembler _{{ .Type | TypeSymbol }}__Assembler
 	`, w, g.AdjCfg, g)
 	stubs := mixins.StringAssemblerTraits{
-		g.PkgName,
-		g.TypeName + ".KeyAssembler",
-		"_" + g.AdjCfg.TypeSymbol(g.Type) + "__Key",
+		PkgName:       g.PkgName,
+		TypeName:      g.TypeName + ".KeyAssembler",
+		AppliedPrefix: "_" + g.AdjCfg.TypeSymbol(g.Type) + "__Key",
 	}
 	// This key assembler can disregard any idea of complex keys because it's a struct!
 	//  Struct field names must be strings (and quite simple ones at that).

--- a/schema/gen/go/genStructReprMap.go
+++ b/schema/gen/go/genStructReprMap.go
@@ -15,9 +15,9 @@ func NewStructReprMapGenerator(pkgName string, typ *schema.TypeStruct, adjCfg *A
 		structGenerator{
 			adjCfg,
 			mixins.MapTraits{
-				pkgName,
-				string(typ.Name()),
-				adjCfg.TypeSymbol(typ),
+				PkgName:    pkgName,
+				TypeName:   string(typ.Name()),
+				TypeSymbol: adjCfg.TypeSymbol(typ),
 			},
 			pkgName,
 			typ,
@@ -33,9 +33,9 @@ func (g structReprMapGenerator) GetRepresentationNodeGen() NodeGenerator {
 	return structReprMapReprGenerator{
 		g.AdjCfg,
 		mixins.MapTraits{
-			g.PkgName,
-			string(g.Type.Name()) + ".Repr",
-			"_" + g.AdjCfg.TypeSymbol(g.Type) + "__Repr",
+			PkgName:    g.PkgName,
+			TypeName:   string(g.Type.Name()) + ".Repr",
+			TypeSymbol: "_" + g.AdjCfg.TypeSymbol(g.Type) + "__Repr",
 		},
 		g.PkgName,
 		g.Type,
@@ -267,9 +267,9 @@ func (g structReprMapReprGenerator) GetNodeBuilderGenerator() NodeBuilderGenerat
 	return structReprMapReprBuilderGenerator{
 		g.AdjCfg,
 		mixins.MapAssemblerTraits{
-			g.PkgName,
-			g.TypeName,
-			"_" + g.AdjCfg.TypeSymbol(g.Type) + "__Repr",
+			PkgName:       g.PkgName,
+			TypeName:      g.TypeName,
+			AppliedPrefix: "_" + g.AdjCfg.TypeSymbol(g.Type) + "__Repr",
 		},
 		g.PkgName,
 		g.Type,
@@ -561,9 +561,9 @@ func (g structReprMapReprBuilderGenerator) emitKeyAssembler(w io.Writer) {
 		type _{{ .Type | TypeSymbol }}__ReprKeyAssembler _{{ .Type | TypeSymbol }}__ReprAssembler
 	`, w, g.AdjCfg, g)
 	stubs := mixins.StringAssemblerTraits{
-		g.PkgName,
-		g.TypeName + ".KeyAssembler", // ".Repr" is already in `g.TypeName`, so don't stutter the "Repr" part.
-		"_" + g.AdjCfg.TypeSymbol(g.Type) + "__ReprKey",
+		PkgName:       g.PkgName,
+		TypeName:      g.TypeName + ".KeyAssembler", // ".Repr" is already in `g.TypeName`, so don't stutter the "Repr" part.
+		AppliedPrefix: "_" + g.AdjCfg.TypeSymbol(g.Type) + "__ReprKey",
 	}
 	// This key assembler can disregard any idea of complex keys because it's at the representation level!
 	//  Map keys must always be plain strings at the representation level.

--- a/schema/gen/go/genStructReprStringjoin.go
+++ b/schema/gen/go/genStructReprStringjoin.go
@@ -14,9 +14,9 @@ func NewStructReprStringjoinGenerator(pkgName string, typ *schema.TypeStruct, ad
 		structGenerator{
 			adjCfg,
 			mixins.MapTraits{
-				pkgName,
-				string(typ.Name()),
-				adjCfg.TypeSymbol(typ),
+				PkgName:    pkgName,
+				TypeName:   string(typ.Name()),
+				TypeSymbol: adjCfg.TypeSymbol(typ),
 			},
 			pkgName,
 			typ,
@@ -32,9 +32,9 @@ func (g structReprStringjoinGenerator) GetRepresentationNodeGen() NodeGenerator 
 	return structReprStringjoinReprGenerator{
 		g.AdjCfg,
 		mixins.StringTraits{
-			g.PkgName,
-			string(g.Type.Name()) + ".Repr",
-			"_" + g.AdjCfg.TypeSymbol(g.Type) + "__Repr",
+			PkgName:    g.PkgName,
+			TypeName:   string(g.Type.Name()) + ".Repr",
+			TypeSymbol: "_" + g.AdjCfg.TypeSymbol(g.Type) + "__Repr",
 		},
 		g.PkgName,
 		g.Type,
@@ -127,9 +127,9 @@ func (g structReprStringjoinReprGenerator) GetNodeBuilderGenerator() NodeBuilder
 	return structReprStringjoinReprBuilderGenerator{
 		g.AdjCfg,
 		mixins.StringAssemblerTraits{
-			g.PkgName,
-			g.TypeName,
-			"_" + g.AdjCfg.TypeSymbol(g.Type) + "__Repr",
+			PkgName:       g.PkgName,
+			TypeName:      g.TypeName,
+			AppliedPrefix: "_" + g.AdjCfg.TypeSymbol(g.Type) + "__Repr",
 		},
 		g.PkgName,
 		g.Type,

--- a/schema/gen/go/genStructReprTuple.go
+++ b/schema/gen/go/genStructReprTuple.go
@@ -27,9 +27,9 @@ func NewStructReprTupleGenerator(pkgName string, typ *schema.TypeStruct, adjCfg 
 		structGenerator{
 			adjCfg,
 			mixins.MapTraits{
-				pkgName,
-				string(typ.Name()),
-				adjCfg.TypeSymbol(typ),
+				PkgName:    pkgName,
+				TypeName:   string(typ.Name()),
+				TypeSymbol: adjCfg.TypeSymbol(typ),
 			},
 			pkgName,
 			typ,
@@ -45,9 +45,9 @@ func (g structReprTupleGenerator) GetRepresentationNodeGen() NodeGenerator {
 	return structReprTupleReprGenerator{
 		g.AdjCfg,
 		mixins.ListTraits{
-			g.PkgName,
-			string(g.Type.Name()) + ".Repr",
-			"_" + g.AdjCfg.TypeSymbol(g.Type) + "__Repr",
+			PkgName:    g.PkgName,
+			TypeName:   string(g.Type.Name()) + ".Repr",
+			TypeSymbol: "_" + g.AdjCfg.TypeSymbol(g.Type) + "__Repr",
 		},
 		g.PkgName,
 		g.Type,
@@ -251,9 +251,9 @@ func (g structReprTupleReprGenerator) GetNodeBuilderGenerator() NodeBuilderGener
 	return structReprTupleReprBuilderGenerator{
 		g.AdjCfg,
 		mixins.ListAssemblerTraits{
-			g.PkgName,
-			g.TypeName,
-			"_" + g.AdjCfg.TypeSymbol(g.Type) + "__Repr",
+			PkgName:       g.PkgName,
+			TypeName:      g.TypeName,
+			AppliedPrefix: "_" + g.AdjCfg.TypeSymbol(g.Type) + "__Repr",
 		},
 		g.PkgName,
 		g.Type,

--- a/schema/gen/go/genUnion.go
+++ b/schema/gen/go/genUnion.go
@@ -244,9 +244,9 @@ func (g unionGenerator) GetNodeBuilderGenerator() NodeBuilderGenerator {
 	return unionBuilderGenerator{
 		g.AdjCfg,
 		mixins.MapAssemblerTraits{
-			g.PkgName,
-			g.TypeName,
-			"_" + g.AdjCfg.TypeSymbol(g.Type) + "__",
+			PkgName:       g.PkgName,
+			TypeName:      g.TypeName,
+			AppliedPrefix: "_" + g.AdjCfg.TypeSymbol(g.Type) + "__",
 		},
 		g.PkgName,
 		g.Type,
@@ -602,9 +602,9 @@ func (g unionBuilderGenerator) emitKeyAssembler(w io.Writer) {
 		type _{{ .Type | TypeSymbol }}__KeyAssembler _{{ .Type | TypeSymbol }}__Assembler
 	`, w, g.AdjCfg, g)
 	stubs := mixins.StringAssemblerTraits{
-		g.PkgName,
-		g.TypeName + ".KeyAssembler",
-		"_" + g.AdjCfg.TypeSymbol(g.Type) + "__Key",
+		PkgName:       g.PkgName,
+		TypeName:      g.TypeName + ".KeyAssembler",
+		AppliedPrefix: "_" + g.AdjCfg.TypeSymbol(g.Type) + "__Key",
 	}
 	// This key assembler can disregard any idea of complex keys because we're fronting for a union!
 	//  Union member names must be strings (and quite simple ones at that).

--- a/schema/gen/go/genUnionReprKeyed.go
+++ b/schema/gen/go/genUnionReprKeyed.go
@@ -18,9 +18,9 @@ func NewUnionReprKeyedGenerator(pkgName string, typ *schema.TypeUnion, adjCfg *A
 		unionGenerator{
 			adjCfg,
 			mixins.MapTraits{
-				pkgName,
-				string(typ.Name()),
-				adjCfg.TypeSymbol(typ),
+				PkgName:    pkgName,
+				TypeName:   string(typ.Name()),
+				TypeSymbol: adjCfg.TypeSymbol(typ),
 			},
 			pkgName,
 			typ,
@@ -36,9 +36,9 @@ func (g unionReprKeyedGenerator) GetRepresentationNodeGen() NodeGenerator {
 	return unionReprKeyedReprGenerator{
 		g.AdjCfg,
 		mixins.MapTraits{
-			g.PkgName,
-			string(g.Type.Name()) + ".Repr",
-			"_" + g.AdjCfg.TypeSymbol(g.Type) + "__Repr",
+			PkgName:    g.PkgName,
+			TypeName:   string(g.Type.Name()) + ".Repr",
+			TypeSymbol: "_" + g.AdjCfg.TypeSymbol(g.Type) + "__Repr",
 		},
 		g.PkgName,
 		g.Type,
@@ -180,9 +180,9 @@ func (g unionReprKeyedReprGenerator) GetNodeBuilderGenerator() NodeBuilderGenera
 	return unionReprKeyedReprBuilderGenerator{
 		g.AdjCfg,
 		mixins.MapAssemblerTraits{
-			g.PkgName,
-			g.TypeName,
-			"_" + g.AdjCfg.TypeSymbol(g.Type) + "__Repr",
+			PkgName:       g.PkgName,
+			TypeName:      g.TypeName,
+			AppliedPrefix: "_" + g.AdjCfg.TypeSymbol(g.Type) + "__Repr",
 		},
 		g.PkgName,
 		g.Type,
@@ -471,9 +471,9 @@ func (g unionReprKeyedReprBuilderGenerator) emitKeyAssembler(w io.Writer) {
 		type _{{ .Type | TypeSymbol }}__ReprKeyAssembler _{{ .Type | TypeSymbol }}__ReprAssembler
 	`, w, g.AdjCfg, g)
 	stubs := mixins.StringAssemblerTraits{
-		g.PkgName,
-		g.TypeName + ".KeyAssembler", // ".Repr" is already in `g.TypeName`, so don't stutter the "Repr" part.
-		"_" + g.AdjCfg.TypeSymbol(g.Type) + "__ReprKey",
+		PkgName:       g.PkgName,
+		TypeName:      g.TypeName + ".KeyAssembler", // ".Repr" is already in `g.TypeName`, so don't stutter the "Repr" part.
+		AppliedPrefix: "_" + g.AdjCfg.TypeSymbol(g.Type) + "__ReprKey",
 	}
 	// This key assembler can disregard any idea of complex keys because we know that our discriminants are just strings!
 	stubs.EmitNodeAssemblerMethodBeginMap(w)

--- a/schema/gen/go/genUnionReprKinded.go
+++ b/schema/gen/go/genUnionReprKinded.go
@@ -23,9 +23,9 @@ func NewUnionReprKindedGenerator(pkgName string, typ *schema.TypeUnion, adjCfg *
 		unionGenerator{
 			adjCfg,
 			mixins.MapTraits{
-				pkgName,
-				string(typ.Name()),
-				adjCfg.TypeSymbol(typ),
+				PkgName:    pkgName,
+				TypeName:   string(typ.Name()),
+				TypeSymbol: adjCfg.TypeSymbol(typ),
 			},
 			pkgName,
 			typ,


### PR DESCRIPTION
Reduces the output of 'go vet ./...' from 374 lines to 96. Many warnings
remain, but I have lost my patience for today.

Most of the changes below were automated, especially the single-line
mixins expressions. Unfortunately, many of the Traits structs required
manual copy-pasting.