### PR TITLE
all: rename AssignNode to ConvertFrom

### DIFF
--- a/adl/rot13adl/rot13node.go
+++ b/adl/rot13adl/rot13node.go
@@ -175,7 +175,7 @@ func (_R13String__Assembler) AssignBytes([]byte) error {
 func (_R13String__Assembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{TypeName: "rot13adl.R13String"}.AssignLink(nil)
 }
-func (na *_R13String__Assembler) AssignNode(v ipld.Node) error {
+func (na *_R13String__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}

--- a/adl/rot13adl/rot13reification.go
+++ b/adl/rot13adl/rot13reification.go
@@ -49,9 +49,9 @@ func Reify(maybeSubstrateRoot ipld.Node) (ipld.Node, error) {
 	//  and assign into it from the raw node, validating in the process,
 	//   which again just leans directly on the shape validation logic already given to us by the schema logic on that type.
 	// (Checking the concrete type of maybeSubstrateRoot in search of a shortcut is seemingly a tad redundant,
-	//  because the AssignNode path later also has such a check!
+	//  because the ConvertFrom path later also has such a check!
 	//  However, doing it earlier allows us to avoid an allocation;
-	//   the AssignNode path doesn't become available until after NewBuilder is invoked, and NewBuilder is where allocations happen.)
+	//   the ConvertFrom path doesn't become available until after NewBuilder is invoked, and NewBuilder is where allocations happen.)
 
 	// Check if we can recognize the maybeSubstrateRoot as being our own substrate types;
 	//  if it is, we can shortcut pretty drastically.
@@ -63,9 +63,9 @@ func Reify(maybeSubstrateRoot ipld.Node) (ipld.Node, error) {
 	}
 
 	// Shortcut didn't work.  Process via the data model.
-	//  The AssignNode method on the substrate type already contains all the logic necessary for this, so we use that.
+	//  The ConvertFrom method on the substrate type already contains all the logic necessary for this, so we use that.
 	nb := Prototype.SubstrateRoot.NewBuilder()
-	if err := nb.AssignNode(maybeSubstrateRoot); err != nil {
+	if err := nb.ConvertFrom(maybeSubstrateRoot); err != nil {
 		fmt.Errorf("rot13adl.Reify failed: data does not match expected shape for substrate: %w", err)
 	}
 	return (*_R13String)(nb.Build().(*_Substrate)), nil

--- a/adl/rot13adl/rot13substrate.go
+++ b/adl/rot13adl/rot13substrate.go
@@ -158,7 +158,7 @@ func (_Substrate__Assembler) AssignBytes([]byte) error {
 func (_Substrate__Assembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{TypeName: "rot13adl.internal.Substrate"}.AssignLink(nil)
 }
-func (na *_Substrate__Assembler) AssignNode(v ipld.Node) error {
+func (na *_Substrate__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}

--- a/fluent/fluentBuilder.go
+++ b/fluent/fluentBuilder.go
@@ -53,7 +53,7 @@ type NodeAssembler interface {
 	AssignString(string)
 	AssignBytes([]byte)
 	AssignLink(ipld.Link)
-	AssignNode(ipld.Node)
+	ConvertFrom(ipld.Node)
 
 	Prototype() ipld.NodePrototype
 }
@@ -143,8 +143,8 @@ func (fna *nodeAssembler) AssignLink(v ipld.Link) {
 		panic(Error{err})
 	}
 }
-func (fna *nodeAssembler) AssignNode(v ipld.Node) {
-	if err := fna.na.AssignNode(v); err != nil {
+func (fna *nodeAssembler) ConvertFrom(v ipld.Node) {
+	if err := fna.na.ConvertFrom(v); err != nil {
 		panic(Error{err})
 	}
 }

--- a/node/basic/any.go
+++ b/node/basic/any.go
@@ -148,7 +148,7 @@ func (nb *anyBuilder) AssignLink(v ipld.Link) error {
 	nb.scalarNode = NewLink(v)
 	return nil
 }
-func (nb *anyBuilder) AssignNode(v ipld.Node) error {
+func (nb *anyBuilder) ConvertFrom(v ipld.Node) error {
 	if nb.kind != ipld.ReprKind_Invalid {
 		panic("misuse")
 	}

--- a/node/basic/bool.go
+++ b/node/basic/bool.go
@@ -131,7 +131,7 @@ func (plainBool__Assembler) AssignBytes([]byte) error {
 func (plainBool__Assembler) AssignLink(ipld.Link) error {
 	return mixins.BoolAssembler{TypeName: "bool"}.AssignLink(nil)
 }
-func (na *plainBool__Assembler) AssignNode(v ipld.Node) error {
+func (na *plainBool__Assembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsBool(); err != nil {
 		return err
 	} else {

--- a/node/basic/bytes.go
+++ b/node/basic/bytes.go
@@ -131,7 +131,7 @@ func (na *plainBytes__Assembler) AssignBytes(v []byte) error {
 func (plainBytes__Assembler) AssignLink(ipld.Link) error {
 	return mixins.BytesAssembler{TypeName: "bytes"}.AssignLink(nil)
 }
-func (na *plainBytes__Assembler) AssignNode(v ipld.Node) error {
+func (na *plainBytes__Assembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsBytes(); err != nil {
 		return err
 	} else {

--- a/node/basic/float.go
+++ b/node/basic/float.go
@@ -131,7 +131,7 @@ func (plainFloat__Assembler) AssignBytes([]byte) error {
 func (plainFloat__Assembler) AssignLink(ipld.Link) error {
 	return mixins.FloatAssembler{TypeName: "float"}.AssignLink(nil)
 }
-func (na *plainFloat__Assembler) AssignNode(v ipld.Node) error {
+func (na *plainFloat__Assembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsFloat(); err != nil {
 		return err
 	} else {

--- a/node/basic/int.go
+++ b/node/basic/int.go
@@ -131,7 +131,7 @@ func (plainInt__Assembler) AssignBytes([]byte) error {
 func (plainInt__Assembler) AssignLink(ipld.Link) error {
 	return mixins.IntAssembler{TypeName: "int"}.AssignLink(nil)
 }
-func (na *plainInt__Assembler) AssignNode(v ipld.Node) error {
+func (na *plainInt__Assembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsInt(); err != nil {
 		return err
 	} else {

--- a/node/basic/link.go
+++ b/node/basic/link.go
@@ -132,7 +132,7 @@ func (na *plainLink__Assembler) AssignLink(v ipld.Link) error {
 	na.w.x = v
 	return nil
 }
-func (na *plainLink__Assembler) AssignNode(v ipld.Node) error {
+func (na *plainLink__Assembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsLink(); err != nil {
 		return err
 	} else {

--- a/node/basic/list.go
+++ b/node/basic/list.go
@@ -180,7 +180,7 @@ func (plainList__Assembler) AssignBytes([]byte) error {
 func (plainList__Assembler) AssignLink(ipld.Link) error {
 	return mixins.ListAssembler{TypeName: "list"}.AssignLink(nil)
 }
-func (na *plainList__Assembler) AssignNode(v ipld.Node) error {
+func (na *plainList__Assembler) ConvertFrom(v ipld.Node) error {
 	// Sanity check, then update, assembler state.
 	//  Update of state to 'finished' comes later; where exactly depends on if shortcuts apply.
 	if na.state != laState_initial {
@@ -197,9 +197,9 @@ func (na *plainList__Assembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	// If the above shortcut didn't work, resort to a generic copy.
-	//  We call AssignNode for all the child values, giving them a chance to hit shortcuts even if we didn't.
+	//  We call ConvertFrom for all the child values, giving them a chance to hit shortcuts even if we didn't.
 	if v.ReprKind() != ipld.ReprKind_List {
-		return ipld.ErrWrongKind{TypeName: "list", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "list", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: v.ReprKind()}
 	}
 	itr := v.ListIterator()
 	for !itr.Done() {
@@ -207,7 +207,7 @@ func (na *plainList__Assembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -264,33 +264,33 @@ func (lva *plainList__ValueAssembler) BeginList(sizeHint int64) (ipld.ListAssemb
 	return &la, err
 }
 func (lva *plainList__ValueAssembler) AssignNull() error {
-	return lva.AssignNode(ipld.Null)
+	return lva.ConvertFrom(ipld.Null)
 }
 func (lva *plainList__ValueAssembler) AssignBool(v bool) error {
 	vb := plainBool(v)
-	return lva.AssignNode(&vb)
+	return lva.ConvertFrom(&vb)
 }
 func (lva *plainList__ValueAssembler) AssignInt(v int64) error {
 	vb := plainInt(v)
-	return lva.AssignNode(&vb)
+	return lva.ConvertFrom(&vb)
 }
 func (lva *plainList__ValueAssembler) AssignFloat(v float64) error {
 	vb := plainFloat(v)
-	return lva.AssignNode(&vb)
+	return lva.ConvertFrom(&vb)
 }
 func (lva *plainList__ValueAssembler) AssignString(v string) error {
 	vb := plainString(v)
-	return lva.AssignNode(&vb)
+	return lva.ConvertFrom(&vb)
 }
 func (lva *plainList__ValueAssembler) AssignBytes(v []byte) error {
 	vb := plainBytes(v)
-	return lva.AssignNode(&vb)
+	return lva.ConvertFrom(&vb)
 }
 func (lva *plainList__ValueAssembler) AssignLink(v ipld.Link) error {
 	vb := plainLink{v}
-	return lva.AssignNode(&vb)
+	return lva.ConvertFrom(&vb)
 }
-func (lva *plainList__ValueAssembler) AssignNode(v ipld.Node) error {
+func (lva *plainList__ValueAssembler) ConvertFrom(v ipld.Node) error {
 	lva.la.w.x = append(lva.la.w.x, v)
 	lva.la.state = laState_initial
 	lva.la = nil // invalidate self to prevent further incorrect use.
@@ -331,7 +331,7 @@ func (ma *plainList__ValueAssemblerMap) Finish() error {
 	}
 	w := ma.ca.w
 	ma.ca.w = nil
-	return ma.p.va.AssignNode(w)
+	return ma.p.va.ConvertFrom(w)
 }
 
 type plainList__ValueAssemblerList struct {
@@ -356,5 +356,5 @@ func (la *plainList__ValueAssemblerList) Finish() error {
 	}
 	w := la.ca.w
 	la.ca.w = nil
-	return la.p.va.AssignNode(w)
+	return la.p.va.ConvertFrom(w)
 }

--- a/node/basic/map.go
+++ b/node/basic/map.go
@@ -196,7 +196,7 @@ func (plainMap__Assembler) AssignBytes([]byte) error {
 func (plainMap__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{TypeName: "map"}.AssignLink(nil)
 }
-func (na *plainMap__Assembler) AssignNode(v ipld.Node) error {
+func (na *plainMap__Assembler) ConvertFrom(v ipld.Node) error {
 	// Sanity check assembler state.
 	//  Update of state to 'finished' comes later; where exactly depends on if shortcuts apply.
 	if na.state != maState_initial {
@@ -213,9 +213,9 @@ func (na *plainMap__Assembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	// If the above shortcut didn't work, resort to a generic copy.
-	//  We call AssignNode for all the child values, giving them a chance to hit shortcuts even if we didn't.
+	//  We call ConvertFrom for all the child values, giving them a chance to hit shortcuts even if we didn't.
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "map", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "map", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -223,10 +223,10 @@ func (na *plainMap__Assembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -348,7 +348,7 @@ func (plainMap__KeyAssembler) AssignBytes([]byte) error {
 func (plainMap__KeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{TypeName: "string"}.AssignLink(nil)
 }
-func (mka *plainMap__KeyAssembler) AssignNode(v ipld.Node) error {
+func (mka *plainMap__KeyAssembler) ConvertFrom(v ipld.Node) error {
 	vs, err := v.AsString()
 	if err != nil {
 		return fmt.Errorf("cannot assign non-string node into map key assembler") // FIXME:errors: this doesn't quite fit in ErrWrongKind cleanly; new error type?
@@ -376,33 +376,33 @@ func (mva *plainMap__ValueAssembler) BeginList(sizeHint int64) (ipld.ListAssembl
 	return &la, err
 }
 func (mva *plainMap__ValueAssembler) AssignNull() error {
-	return mva.AssignNode(ipld.Null)
+	return mva.ConvertFrom(ipld.Null)
 }
 func (mva *plainMap__ValueAssembler) AssignBool(v bool) error {
 	vb := plainBool(v)
-	return mva.AssignNode(&vb)
+	return mva.ConvertFrom(&vb)
 }
 func (mva *plainMap__ValueAssembler) AssignInt(v int64) error {
 	vb := plainInt(v)
-	return mva.AssignNode(&vb)
+	return mva.ConvertFrom(&vb)
 }
 func (mva *plainMap__ValueAssembler) AssignFloat(v float64) error {
 	vb := plainFloat(v)
-	return mva.AssignNode(&vb)
+	return mva.ConvertFrom(&vb)
 }
 func (mva *plainMap__ValueAssembler) AssignString(v string) error {
 	vb := plainString(v)
-	return mva.AssignNode(&vb)
+	return mva.ConvertFrom(&vb)
 }
 func (mva *plainMap__ValueAssembler) AssignBytes(v []byte) error {
 	vb := plainBytes(v)
-	return mva.AssignNode(&vb)
+	return mva.ConvertFrom(&vb)
 }
 func (mva *plainMap__ValueAssembler) AssignLink(v ipld.Link) error {
 	vb := plainLink{v}
-	return mva.AssignNode(&vb)
+	return mva.ConvertFrom(&vb)
 }
-func (mva *plainMap__ValueAssembler) AssignNode(v ipld.Node) error {
+func (mva *plainMap__ValueAssembler) ConvertFrom(v ipld.Node) error {
 	l := len(mva.ma.w.t) - 1
 	mva.ma.w.t[l].v = v
 	mva.ma.w.m[string(mva.ma.w.t[l].k)] = v
@@ -445,7 +445,7 @@ func (ma *plainMap__ValueAssemblerMap) Finish() error {
 	}
 	w := ma.ca.w
 	ma.ca.w = nil
-	return ma.p.va.AssignNode(w)
+	return ma.p.va.ConvertFrom(w)
 }
 
 type plainMap__ValueAssemblerList struct {
@@ -470,5 +470,5 @@ func (la *plainMap__ValueAssemblerList) Finish() error {
 	}
 	w := la.ca.w
 	la.ca.w = nil
-	return la.p.va.AssignNode(w)
+	return la.p.va.ConvertFrom(w)
 }

--- a/node/basic/string.go
+++ b/node/basic/string.go
@@ -136,7 +136,7 @@ func (plainString__Assembler) AssignBytes([]byte) error {
 func (plainString__Assembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{TypeName: "string"}.AssignLink(nil)
 }
-func (na *plainString__Assembler) AssignNode(v ipld.Node) error {
+func (na *plainString__Assembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {

--- a/node/gendemo/ipldsch_minima.go
+++ b/node/gendemo/ipldsch_minima.go
@@ -45,7 +45,7 @@ func (ea _ErrorThunkAssembler) AssignFloat(float64) error                     { 
 func (ea _ErrorThunkAssembler) AssignString(string) error                     { return ea.e }
 func (ea _ErrorThunkAssembler) AssignBytes([]byte) error                      { return ea.e }
 func (ea _ErrorThunkAssembler) AssignLink(ipld.Link) error                    { return ea.e }
-func (ea _ErrorThunkAssembler) AssignNode(ipld.Node) error                    { return ea.e }
+func (ea _ErrorThunkAssembler) ConvertFrom(ipld.Node) error                    { return ea.e }
 func (ea _ErrorThunkAssembler) Prototype() ipld.NodePrototype {
 	panic(fmt.Errorf("cannot get prototype from error-carrying assembler: already derailed with error: %w", ea.e))
 }

--- a/node/gendemo/ipldsch_satisfaction.go
+++ b/node/gendemo/ipldsch_satisfaction.go
@@ -180,7 +180,7 @@ func (_Int__Assembler) AssignBytes([]byte) error {
 func (_Int__Assembler) AssignLink(ipld.Link) error {
 	return mixins.IntAssembler{"gendemo.Int"}.AssignLink(nil)
 }
-func (na *_Int__Assembler) AssignNode(v ipld.Node) error {
+func (na *_Int__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -482,7 +482,7 @@ func (_Map__String__Msg3__Assembler) AssignBytes([]byte) error {
 func (_Map__String__Msg3__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"gendemo.Map__String__Msg3"}.AssignLink(nil)
 }
-func (na *_Map__String__Msg3__Assembler) AssignNode(v ipld.Node) error {
+func (na *_Map__String__Msg3__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -503,7 +503,7 @@ func (na *_Map__String__Msg3__Assembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "gendemo.Map__String__Msg3", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "gendemo.Map__String__Msg3", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -511,10 +511,10 @@ func (na *_Map__String__Msg3__Assembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -824,7 +824,7 @@ func (_Map__String__Msg3__ReprAssembler) AssignBytes([]byte) error {
 func (_Map__String__Msg3__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"gendemo.Map__String__Msg3.Repr"}.AssignLink(nil)
 }
-func (na *_Map__String__Msg3__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_Map__String__Msg3__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -845,7 +845,7 @@ func (na *_Map__String__Msg3__ReprAssembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "gendemo.Map__String__Msg3.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "gendemo.Map__String__Msg3.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -853,10 +853,10 @@ func (na *_Map__String__Msg3__ReprAssembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -1237,7 +1237,7 @@ func (_Msg3__Assembler) AssignBytes([]byte) error {
 func (_Msg3__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"gendemo.Msg3"}.AssignLink(nil)
 }
-func (na *_Msg3__Assembler) AssignNode(v ipld.Node) error {
+func (na *_Msg3__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -1258,7 +1258,7 @@ func (na *_Msg3__Assembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "gendemo.Msg3", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "gendemo.Msg3", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -1266,10 +1266,10 @@ func (na *_Msg3__Assembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -1509,7 +1509,7 @@ func (_Msg3__KeyAssembler) AssignBytes([]byte) error {
 func (_Msg3__KeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"gendemo.Msg3.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_Msg3__KeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_Msg3__KeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -1722,7 +1722,7 @@ func (_Msg3__ReprAssembler) AssignBytes([]byte) error {
 func (_Msg3__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"gendemo.Msg3.Repr"}.AssignLink(nil)
 }
-func (na *_Msg3__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_Msg3__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -1743,7 +1743,7 @@ func (na *_Msg3__ReprAssembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "gendemo.Msg3.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "gendemo.Msg3.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -1751,10 +1751,10 @@ func (na *_Msg3__ReprAssembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -1991,7 +1991,7 @@ func (_Msg3__ReprKeyAssembler) AssignBytes([]byte) error {
 func (_Msg3__ReprKeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"gendemo.Msg3.Repr.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_Msg3__ReprKeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_Msg3__ReprKeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -2178,7 +2178,7 @@ func (_String__Assembler) AssignBytes([]byte) error {
 func (_String__Assembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"gendemo.String"}.AssignLink(nil)
 }
-func (na *_String__Assembler) AssignNode(v ipld.Node) error {
+func (na *_String__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}

--- a/nodeBuilder.go
+++ b/nodeBuilder.go
@@ -26,7 +26,7 @@ type NodeAssembler interface {
 	AssignBytes([]byte) error
 	AssignLink(Link) error
 
-	AssignNode(Node) error // if you already have a completely constructed subtree, this method puts the whole thing in place at once.
+	ConvertFrom(Node) error // if you already have a completely constructed subtree, this method puts the whole thing in place at once.
 
 	// Prototype returns a NodePrototype describing what kind of value we're assembling.
 	//
@@ -34,9 +34,9 @@ type NodeAssembler interface {
 	// just feed data and check errors), but it's here.
 	//
 	// Using `this.Prototype().NewBuilder()` to produce a new `Node`,
-	// then giving that node to `this.AssignNode(n)` should always work.
+	// then giving that node to `this.ConvertFrom(n)` should always work.
 	// (Note that this is not necessarily an _exclusive_ statement on what
-	// sort of values will be accepted by `this.AssignNode(n)`.)
+	// sort of values will be accepted by `this.ConvertFrom(n)`.)
 	Prototype() NodePrototype
 }
 

--- a/schema/dmt/ipldsch_minima.go
+++ b/schema/dmt/ipldsch_minima.go
@@ -45,7 +45,7 @@ func (ea _ErrorThunkAssembler) AssignFloat(float64) error                     { 
 func (ea _ErrorThunkAssembler) AssignString(string) error                     { return ea.e }
 func (ea _ErrorThunkAssembler) AssignBytes([]byte) error                      { return ea.e }
 func (ea _ErrorThunkAssembler) AssignLink(ipld.Link) error                    { return ea.e }
-func (ea _ErrorThunkAssembler) AssignNode(ipld.Node) error                    { return ea.e }
+func (ea _ErrorThunkAssembler) ConvertFrom(ipld.Node) error                    { return ea.e }
 func (ea _ErrorThunkAssembler) Prototype() ipld.NodePrototype {
 	panic(fmt.Errorf("cannot get prototype from error-carrying assembler: already derailed with error: %w", ea.e))
 }

--- a/schema/dmt/ipldsch_satisfaction.go
+++ b/schema/dmt/ipldsch_satisfaction.go
@@ -299,7 +299,7 @@ func (_AnyScalar__Assembler) AssignBytes([]byte) error {
 func (_AnyScalar__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.AnyScalar"}.AssignLink(nil)
 }
-func (na *_AnyScalar__Assembler) AssignNode(v ipld.Node) error {
+func (na *_AnyScalar__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -320,7 +320,7 @@ func (na *_AnyScalar__Assembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.AnyScalar", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.AnyScalar", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -328,10 +328,10 @@ func (na *_AnyScalar__Assembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -570,7 +570,7 @@ func (_AnyScalar__KeyAssembler) AssignBytes([]byte) error {
 func (_AnyScalar__KeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.AnyScalar.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_AnyScalar__KeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_AnyScalar__KeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -856,7 +856,7 @@ func (na *_AnyScalar__ReprAssembler) AssignLink(v ipld.Link) error {
 	}
 	return schema.ErrNotUnionStructure{TypeName: "schemadmt.AnyScalar.Repr", Detail: "AssignLink called but is not valid for any of the kinds that are valid members of this union"}
 }
-func (na *_AnyScalar__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_AnyScalar__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -903,10 +903,10 @@ func (na *_AnyScalar__ReprAssembler) AssignNode(v ipld.Node) error {
 			if err != nil {
 				return err
 			}
-			if err := na.AssembleKey().AssignNode(k); err != nil {
+			if err := na.AssembleKey().ConvertFrom(k); err != nil {
 				return err
 			}
-			if err := na.AssembleValue().AssignNode(v); err != nil {
+			if err := na.AssembleValue().ConvertFrom(v); err != nil {
 				return err
 			}
 		}
@@ -922,7 +922,7 @@ func (na *_AnyScalar__ReprAssembler) AssignNode(v ipld.Node) error {
 			if err != nil {
 				return err
 			}
-			if err := na.AssembleValue().AssignNode(v); err != nil {
+			if err := na.AssembleValue().ConvertFrom(v); err != nil {
 				return err
 			}
 		}
@@ -1110,7 +1110,7 @@ func (_Bool__Assembler) AssignBytes([]byte) error {
 func (_Bool__Assembler) AssignLink(ipld.Link) error {
 	return mixins.BoolAssembler{"schemadmt.Bool"}.AssignLink(nil)
 }
-func (na *_Bool__Assembler) AssignNode(v ipld.Node) error {
+func (na *_Bool__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -1323,7 +1323,7 @@ func (na *_Bytes__Assembler) AssignBytes(v []byte) error {
 func (_Bytes__Assembler) AssignLink(ipld.Link) error {
 	return mixins.BytesAssembler{"schemadmt.Bytes"}.AssignLink(nil)
 }
-func (na *_Bytes__Assembler) AssignNode(v ipld.Node) error {
+func (na *_Bytes__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -1610,7 +1610,7 @@ func (_EnumRepresentation__Assembler) AssignBytes([]byte) error {
 func (_EnumRepresentation__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.EnumRepresentation"}.AssignLink(nil)
 }
-func (na *_EnumRepresentation__Assembler) AssignNode(v ipld.Node) error {
+func (na *_EnumRepresentation__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -1631,7 +1631,7 @@ func (na *_EnumRepresentation__Assembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.EnumRepresentation", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.EnumRepresentation", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -1639,10 +1639,10 @@ func (na *_EnumRepresentation__Assembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -1827,7 +1827,7 @@ func (_EnumRepresentation__KeyAssembler) AssignBytes([]byte) error {
 func (_EnumRepresentation__KeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.EnumRepresentation.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_EnumRepresentation__KeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_EnumRepresentation__KeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -2046,7 +2046,7 @@ func (_EnumRepresentation__ReprAssembler) AssignBytes([]byte) error {
 func (_EnumRepresentation__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.EnumRepresentation.Repr"}.AssignLink(nil)
 }
-func (na *_EnumRepresentation__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_EnumRepresentation__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -2067,7 +2067,7 @@ func (na *_EnumRepresentation__ReprAssembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.EnumRepresentation.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.EnumRepresentation.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -2075,10 +2075,10 @@ func (na *_EnumRepresentation__ReprAssembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -2263,7 +2263,7 @@ func (_EnumRepresentation__ReprKeyAssembler) AssignBytes([]byte) error {
 func (_EnumRepresentation__ReprKeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.EnumRepresentation.Repr.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_EnumRepresentation__ReprKeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_EnumRepresentation__ReprKeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -2535,7 +2535,7 @@ func (_EnumRepresentation_Int__Assembler) AssignBytes([]byte) error {
 func (_EnumRepresentation_Int__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.EnumRepresentation_Int"}.AssignLink(nil)
 }
-func (na *_EnumRepresentation_Int__Assembler) AssignNode(v ipld.Node) error {
+func (na *_EnumRepresentation_Int__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -2556,7 +2556,7 @@ func (na *_EnumRepresentation_Int__Assembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.EnumRepresentation_Int", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.EnumRepresentation_Int", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -2564,10 +2564,10 @@ func (na *_EnumRepresentation_Int__Assembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -2877,7 +2877,7 @@ func (_EnumRepresentation_Int__ReprAssembler) AssignBytes([]byte) error {
 func (_EnumRepresentation_Int__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.EnumRepresentation_Int.Repr"}.AssignLink(nil)
 }
-func (na *_EnumRepresentation_Int__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_EnumRepresentation_Int__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -2898,7 +2898,7 @@ func (na *_EnumRepresentation_Int__ReprAssembler) AssignNode(v ipld.Node) error 
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.EnumRepresentation_Int.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.EnumRepresentation_Int.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -2906,10 +2906,10 @@ func (na *_EnumRepresentation_Int__ReprAssembler) AssignNode(v ipld.Node) error 
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -3304,7 +3304,7 @@ func (_EnumRepresentation_String__Assembler) AssignBytes([]byte) error {
 func (_EnumRepresentation_String__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.EnumRepresentation_String"}.AssignLink(nil)
 }
-func (na *_EnumRepresentation_String__Assembler) AssignNode(v ipld.Node) error {
+func (na *_EnumRepresentation_String__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -3325,7 +3325,7 @@ func (na *_EnumRepresentation_String__Assembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.EnumRepresentation_String", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.EnumRepresentation_String", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -3333,10 +3333,10 @@ func (na *_EnumRepresentation_String__Assembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -3646,7 +3646,7 @@ func (_EnumRepresentation_String__ReprAssembler) AssignBytes([]byte) error {
 func (_EnumRepresentation_String__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.EnumRepresentation_String.Repr"}.AssignLink(nil)
 }
-func (na *_EnumRepresentation_String__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_EnumRepresentation_String__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -3667,7 +3667,7 @@ func (na *_EnumRepresentation_String__ReprAssembler) AssignNode(v ipld.Node) err
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.EnumRepresentation_String.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.EnumRepresentation_String.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -3675,10 +3675,10 @@ func (na *_EnumRepresentation_String__ReprAssembler) AssignNode(v ipld.Node) err
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -3988,7 +3988,7 @@ func (_EnumValue__Assembler) AssignBytes([]byte) error {
 func (_EnumValue__Assembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.EnumValue"}.AssignLink(nil)
 }
-func (na *_EnumValue__Assembler) AssignNode(v ipld.Node) error {
+func (na *_EnumValue__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -4205,7 +4205,7 @@ func (_FieldName__Assembler) AssignBytes([]byte) error {
 func (_FieldName__Assembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.FieldName"}.AssignLink(nil)
 }
-func (na *_FieldName__Assembler) AssignNode(v ipld.Node) error {
+func (na *_FieldName__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -4418,7 +4418,7 @@ func (_Float__Assembler) AssignBytes([]byte) error {
 func (_Float__Assembler) AssignLink(ipld.Link) error {
 	return mixins.FloatAssembler{"schemadmt.Float"}.AssignLink(nil)
 }
-func (na *_Float__Assembler) AssignNode(v ipld.Node) error {
+func (na *_Float__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -4631,7 +4631,7 @@ func (_Int__Assembler) AssignBytes([]byte) error {
 func (_Int__Assembler) AssignLink(ipld.Link) error {
 	return mixins.IntAssembler{"schemadmt.Int"}.AssignLink(nil)
 }
-func (na *_Int__Assembler) AssignNode(v ipld.Node) error {
+func (na *_Int__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -4903,7 +4903,7 @@ func (_ListRepresentation__Assembler) AssignBytes([]byte) error {
 func (_ListRepresentation__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.ListRepresentation"}.AssignLink(nil)
 }
-func (na *_ListRepresentation__Assembler) AssignNode(v ipld.Node) error {
+func (na *_ListRepresentation__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -4924,7 +4924,7 @@ func (na *_ListRepresentation__Assembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.ListRepresentation", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.ListRepresentation", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -4932,10 +4932,10 @@ func (na *_ListRepresentation__Assembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -5102,7 +5102,7 @@ func (_ListRepresentation__KeyAssembler) AssignBytes([]byte) error {
 func (_ListRepresentation__KeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.ListRepresentation.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_ListRepresentation__KeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_ListRepresentation__KeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -5308,7 +5308,7 @@ func (_ListRepresentation__ReprAssembler) AssignBytes([]byte) error {
 func (_ListRepresentation__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.ListRepresentation.Repr"}.AssignLink(nil)
 }
-func (na *_ListRepresentation__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_ListRepresentation__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -5329,7 +5329,7 @@ func (na *_ListRepresentation__ReprAssembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.ListRepresentation.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.ListRepresentation.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -5337,10 +5337,10 @@ func (na *_ListRepresentation__ReprAssembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -5507,7 +5507,7 @@ func (_ListRepresentation__ReprKeyAssembler) AssignBytes([]byte) error {
 func (_ListRepresentation__ReprKeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.ListRepresentation.Repr.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_ListRepresentation__ReprKeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_ListRepresentation__ReprKeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -5727,7 +5727,7 @@ func (_ListRepresentation_List__Assembler) AssignBytes([]byte) error {
 func (_ListRepresentation_List__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.ListRepresentation_List"}.AssignLink(nil)
 }
-func (na *_ListRepresentation_List__Assembler) AssignNode(v ipld.Node) error {
+func (na *_ListRepresentation_List__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -5748,7 +5748,7 @@ func (na *_ListRepresentation_List__Assembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.ListRepresentation_List", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.ListRepresentation_List", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -5756,10 +5756,10 @@ func (na *_ListRepresentation_List__Assembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -5897,7 +5897,7 @@ func (_ListRepresentation_List__KeyAssembler) AssignBytes([]byte) error {
 func (_ListRepresentation_List__KeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.ListRepresentation_List.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_ListRepresentation_List__KeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_ListRepresentation_List__KeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -6085,7 +6085,7 @@ func (_ListRepresentation_List__ReprAssembler) AssignBytes([]byte) error {
 func (_ListRepresentation_List__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.ListRepresentation_List.Repr"}.AssignLink(nil)
 }
-func (na *_ListRepresentation_List__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_ListRepresentation_List__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -6106,7 +6106,7 @@ func (na *_ListRepresentation_List__ReprAssembler) AssignNode(v ipld.Node) error
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.ListRepresentation_List.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.ListRepresentation_List.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -6114,10 +6114,10 @@ func (na *_ListRepresentation_List__ReprAssembler) AssignNode(v ipld.Node) error
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -6255,7 +6255,7 @@ func (_ListRepresentation_List__ReprKeyAssembler) AssignBytes([]byte) error {
 func (_ListRepresentation_List__ReprKeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.ListRepresentation_List.Repr.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_ListRepresentation_List__ReprKeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_ListRepresentation_List__ReprKeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -6520,7 +6520,7 @@ func (_List__FieldName__Assembler) AssignBytes([]byte) error {
 func (_List__FieldName__Assembler) AssignLink(ipld.Link) error {
 	return mixins.ListAssembler{"schemadmt.List__FieldName"}.AssignLink(nil)
 }
-func (na *_List__FieldName__Assembler) AssignNode(v ipld.Node) error {
+func (na *_List__FieldName__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -6541,7 +6541,7 @@ func (na *_List__FieldName__Assembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_List {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.List__FieldName", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.List__FieldName", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: v.ReprKind()}
 	}
 	itr := v.ListIterator()
 	for !itr.Done() {
@@ -6549,7 +6549,7 @@ func (na *_List__FieldName__Assembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -6786,7 +6786,7 @@ func (_List__FieldName__ReprAssembler) AssignBytes([]byte) error {
 func (_List__FieldName__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.ListAssembler{"schemadmt.List__FieldName.Repr"}.AssignLink(nil)
 }
-func (na *_List__FieldName__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_List__FieldName__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -6807,7 +6807,7 @@ func (na *_List__FieldName__ReprAssembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_List {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.List__FieldName.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.List__FieldName.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: v.ReprKind()}
 	}
 	itr := v.ListIterator()
 	for !itr.Done() {
@@ -6815,7 +6815,7 @@ func (na *_List__FieldName__ReprAssembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -7127,7 +7127,7 @@ func (_List__TypeName__Assembler) AssignBytes([]byte) error {
 func (_List__TypeName__Assembler) AssignLink(ipld.Link) error {
 	return mixins.ListAssembler{"schemadmt.List__TypeName"}.AssignLink(nil)
 }
-func (na *_List__TypeName__Assembler) AssignNode(v ipld.Node) error {
+func (na *_List__TypeName__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -7148,7 +7148,7 @@ func (na *_List__TypeName__Assembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_List {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.List__TypeName", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.List__TypeName", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: v.ReprKind()}
 	}
 	itr := v.ListIterator()
 	for !itr.Done() {
@@ -7156,7 +7156,7 @@ func (na *_List__TypeName__Assembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -7393,7 +7393,7 @@ func (_List__TypeName__ReprAssembler) AssignBytes([]byte) error {
 func (_List__TypeName__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.ListAssembler{"schemadmt.List__TypeName.Repr"}.AssignLink(nil)
 }
-func (na *_List__TypeName__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_List__TypeName__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -7414,7 +7414,7 @@ func (na *_List__TypeName__ReprAssembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_List {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.List__TypeName.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.List__TypeName.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: v.ReprKind()}
 	}
 	itr := v.ListIterator()
 	for !itr.Done() {
@@ -7422,7 +7422,7 @@ func (na *_List__TypeName__ReprAssembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -7741,7 +7741,7 @@ func (_MapRepresentation__Assembler) AssignBytes([]byte) error {
 func (_MapRepresentation__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.MapRepresentation"}.AssignLink(nil)
 }
-func (na *_MapRepresentation__Assembler) AssignNode(v ipld.Node) error {
+func (na *_MapRepresentation__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -7762,7 +7762,7 @@ func (na *_MapRepresentation__Assembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.MapRepresentation", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.MapRepresentation", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -7770,10 +7770,10 @@ func (na *_MapRepresentation__Assembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -7976,7 +7976,7 @@ func (_MapRepresentation__KeyAssembler) AssignBytes([]byte) error {
 func (_MapRepresentation__KeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.MapRepresentation.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_MapRepresentation__KeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_MapRepresentation__KeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -8208,7 +8208,7 @@ func (_MapRepresentation__ReprAssembler) AssignBytes([]byte) error {
 func (_MapRepresentation__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.MapRepresentation.Repr"}.AssignLink(nil)
 }
-func (na *_MapRepresentation__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_MapRepresentation__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -8229,7 +8229,7 @@ func (na *_MapRepresentation__ReprAssembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.MapRepresentation.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.MapRepresentation.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -8237,10 +8237,10 @@ func (na *_MapRepresentation__ReprAssembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -8443,7 +8443,7 @@ func (_MapRepresentation__ReprKeyAssembler) AssignBytes([]byte) error {
 func (_MapRepresentation__ReprKeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.MapRepresentation.Repr.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_MapRepresentation__ReprKeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_MapRepresentation__ReprKeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -8663,7 +8663,7 @@ func (_MapRepresentation_Listpairs__Assembler) AssignBytes([]byte) error {
 func (_MapRepresentation_Listpairs__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.MapRepresentation_Listpairs"}.AssignLink(nil)
 }
-func (na *_MapRepresentation_Listpairs__Assembler) AssignNode(v ipld.Node) error {
+func (na *_MapRepresentation_Listpairs__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -8684,7 +8684,7 @@ func (na *_MapRepresentation_Listpairs__Assembler) AssignNode(v ipld.Node) error
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.MapRepresentation_Listpairs", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.MapRepresentation_Listpairs", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -8692,10 +8692,10 @@ func (na *_MapRepresentation_Listpairs__Assembler) AssignNode(v ipld.Node) error
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -8833,7 +8833,7 @@ func (_MapRepresentation_Listpairs__KeyAssembler) AssignBytes([]byte) error {
 func (_MapRepresentation_Listpairs__KeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.MapRepresentation_Listpairs.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_MapRepresentation_Listpairs__KeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_MapRepresentation_Listpairs__KeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -9021,7 +9021,7 @@ func (_MapRepresentation_Listpairs__ReprAssembler) AssignBytes([]byte) error {
 func (_MapRepresentation_Listpairs__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.MapRepresentation_Listpairs.Repr"}.AssignLink(nil)
 }
-func (na *_MapRepresentation_Listpairs__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_MapRepresentation_Listpairs__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -9042,7 +9042,7 @@ func (na *_MapRepresentation_Listpairs__ReprAssembler) AssignNode(v ipld.Node) e
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.MapRepresentation_Listpairs.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.MapRepresentation_Listpairs.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -9050,10 +9050,10 @@ func (na *_MapRepresentation_Listpairs__ReprAssembler) AssignNode(v ipld.Node) e
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -9191,7 +9191,7 @@ func (_MapRepresentation_Listpairs__ReprKeyAssembler) AssignBytes([]byte) error 
 func (_MapRepresentation_Listpairs__ReprKeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.MapRepresentation_Listpairs.Repr.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_MapRepresentation_Listpairs__ReprKeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_MapRepresentation_Listpairs__ReprKeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -9411,7 +9411,7 @@ func (_MapRepresentation_Map__Assembler) AssignBytes([]byte) error {
 func (_MapRepresentation_Map__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.MapRepresentation_Map"}.AssignLink(nil)
 }
-func (na *_MapRepresentation_Map__Assembler) AssignNode(v ipld.Node) error {
+func (na *_MapRepresentation_Map__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -9432,7 +9432,7 @@ func (na *_MapRepresentation_Map__Assembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.MapRepresentation_Map", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.MapRepresentation_Map", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -9440,10 +9440,10 @@ func (na *_MapRepresentation_Map__Assembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -9581,7 +9581,7 @@ func (_MapRepresentation_Map__KeyAssembler) AssignBytes([]byte) error {
 func (_MapRepresentation_Map__KeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.MapRepresentation_Map.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_MapRepresentation_Map__KeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_MapRepresentation_Map__KeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -9769,7 +9769,7 @@ func (_MapRepresentation_Map__ReprAssembler) AssignBytes([]byte) error {
 func (_MapRepresentation_Map__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.MapRepresentation_Map.Repr"}.AssignLink(nil)
 }
-func (na *_MapRepresentation_Map__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_MapRepresentation_Map__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -9790,7 +9790,7 @@ func (na *_MapRepresentation_Map__ReprAssembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.MapRepresentation_Map.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.MapRepresentation_Map.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -9798,10 +9798,10 @@ func (na *_MapRepresentation_Map__ReprAssembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -9939,7 +9939,7 @@ func (_MapRepresentation_Map__ReprKeyAssembler) AssignBytes([]byte) error {
 func (_MapRepresentation_Map__ReprKeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.MapRepresentation_Map.Repr.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_MapRepresentation_Map__ReprKeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_MapRepresentation_Map__ReprKeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -10185,7 +10185,7 @@ func (_MapRepresentation_Stringpairs__Assembler) AssignBytes([]byte) error {
 func (_MapRepresentation_Stringpairs__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.MapRepresentation_Stringpairs"}.AssignLink(nil)
 }
-func (na *_MapRepresentation_Stringpairs__Assembler) AssignNode(v ipld.Node) error {
+func (na *_MapRepresentation_Stringpairs__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -10206,7 +10206,7 @@ func (na *_MapRepresentation_Stringpairs__Assembler) AssignNode(v ipld.Node) err
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.MapRepresentation_Stringpairs", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.MapRepresentation_Stringpairs", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -10214,10 +10214,10 @@ func (na *_MapRepresentation_Stringpairs__Assembler) AssignNode(v ipld.Node) err
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -10423,7 +10423,7 @@ func (_MapRepresentation_Stringpairs__KeyAssembler) AssignBytes([]byte) error {
 func (_MapRepresentation_Stringpairs__KeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.MapRepresentation_Stringpairs.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_MapRepresentation_Stringpairs__KeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_MapRepresentation_Stringpairs__KeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -10628,7 +10628,7 @@ func (_MapRepresentation_Stringpairs__ReprAssembler) AssignBytes([]byte) error {
 func (_MapRepresentation_Stringpairs__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.MapRepresentation_Stringpairs.Repr"}.AssignLink(nil)
 }
-func (na *_MapRepresentation_Stringpairs__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_MapRepresentation_Stringpairs__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -10649,7 +10649,7 @@ func (na *_MapRepresentation_Stringpairs__ReprAssembler) AssignNode(v ipld.Node)
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.MapRepresentation_Stringpairs.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.MapRepresentation_Stringpairs.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -10657,10 +10657,10 @@ func (na *_MapRepresentation_Stringpairs__ReprAssembler) AssignNode(v ipld.Node)
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -10864,7 +10864,7 @@ func (_MapRepresentation_Stringpairs__ReprKeyAssembler) AssignBytes([]byte) erro
 func (_MapRepresentation_Stringpairs__ReprKeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.MapRepresentation_Stringpairs.Repr.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_MapRepresentation_Stringpairs__ReprKeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_MapRepresentation_Stringpairs__ReprKeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -11136,7 +11136,7 @@ func (_Map__EnumValue__Unit__Assembler) AssignBytes([]byte) error {
 func (_Map__EnumValue__Unit__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.Map__EnumValue__Unit"}.AssignLink(nil)
 }
-func (na *_Map__EnumValue__Unit__Assembler) AssignNode(v ipld.Node) error {
+func (na *_Map__EnumValue__Unit__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -11157,7 +11157,7 @@ func (na *_Map__EnumValue__Unit__Assembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.Map__EnumValue__Unit", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.Map__EnumValue__Unit", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -11165,10 +11165,10 @@ func (na *_Map__EnumValue__Unit__Assembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -11478,7 +11478,7 @@ func (_Map__EnumValue__Unit__ReprAssembler) AssignBytes([]byte) error {
 func (_Map__EnumValue__Unit__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.Map__EnumValue__Unit.Repr"}.AssignLink(nil)
 }
-func (na *_Map__EnumValue__Unit__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_Map__EnumValue__Unit__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -11499,7 +11499,7 @@ func (na *_Map__EnumValue__Unit__ReprAssembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.Map__EnumValue__Unit.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.Map__EnumValue__Unit.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -11507,10 +11507,10 @@ func (na *_Map__EnumValue__Unit__ReprAssembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -11905,7 +11905,7 @@ func (_Map__FieldName__StructField__Assembler) AssignBytes([]byte) error {
 func (_Map__FieldName__StructField__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.Map__FieldName__StructField"}.AssignLink(nil)
 }
-func (na *_Map__FieldName__StructField__Assembler) AssignNode(v ipld.Node) error {
+func (na *_Map__FieldName__StructField__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -11926,7 +11926,7 @@ func (na *_Map__FieldName__StructField__Assembler) AssignNode(v ipld.Node) error
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.Map__FieldName__StructField", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.Map__FieldName__StructField", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -11934,10 +11934,10 @@ func (na *_Map__FieldName__StructField__Assembler) AssignNode(v ipld.Node) error
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -12247,7 +12247,7 @@ func (_Map__FieldName__StructField__ReprAssembler) AssignBytes([]byte) error {
 func (_Map__FieldName__StructField__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.Map__FieldName__StructField.Repr"}.AssignLink(nil)
 }
-func (na *_Map__FieldName__StructField__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_Map__FieldName__StructField__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -12268,7 +12268,7 @@ func (na *_Map__FieldName__StructField__ReprAssembler) AssignNode(v ipld.Node) e
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.Map__FieldName__StructField.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.Map__FieldName__StructField.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -12276,10 +12276,10 @@ func (na *_Map__FieldName__StructField__ReprAssembler) AssignNode(v ipld.Node) e
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -12674,7 +12674,7 @@ func (_Map__FieldName__StructRepresentation_Map_FieldDetails__Assembler) AssignB
 func (_Map__FieldName__StructRepresentation_Map_FieldDetails__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.Map__FieldName__StructRepresentation_Map_FieldDetails"}.AssignLink(nil)
 }
-func (na *_Map__FieldName__StructRepresentation_Map_FieldDetails__Assembler) AssignNode(v ipld.Node) error {
+func (na *_Map__FieldName__StructRepresentation_Map_FieldDetails__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -12695,7 +12695,7 @@ func (na *_Map__FieldName__StructRepresentation_Map_FieldDetails__Assembler) Ass
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.Map__FieldName__StructRepresentation_Map_FieldDetails", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.Map__FieldName__StructRepresentation_Map_FieldDetails", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -12703,10 +12703,10 @@ func (na *_Map__FieldName__StructRepresentation_Map_FieldDetails__Assembler) Ass
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -13016,7 +13016,7 @@ func (_Map__FieldName__StructRepresentation_Map_FieldDetails__ReprAssembler) Ass
 func (_Map__FieldName__StructRepresentation_Map_FieldDetails__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.Map__FieldName__StructRepresentation_Map_FieldDetails.Repr"}.AssignLink(nil)
 }
-func (na *_Map__FieldName__StructRepresentation_Map_FieldDetails__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_Map__FieldName__StructRepresentation_Map_FieldDetails__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -13037,7 +13037,7 @@ func (na *_Map__FieldName__StructRepresentation_Map_FieldDetails__ReprAssembler)
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.Map__FieldName__StructRepresentation_Map_FieldDetails.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.Map__FieldName__StructRepresentation_Map_FieldDetails.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -13045,10 +13045,10 @@ func (na *_Map__FieldName__StructRepresentation_Map_FieldDetails__ReprAssembler)
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -13443,7 +13443,7 @@ func (_Map__String__TypeName__Assembler) AssignBytes([]byte) error {
 func (_Map__String__TypeName__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.Map__String__TypeName"}.AssignLink(nil)
 }
-func (na *_Map__String__TypeName__Assembler) AssignNode(v ipld.Node) error {
+func (na *_Map__String__TypeName__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -13464,7 +13464,7 @@ func (na *_Map__String__TypeName__Assembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.Map__String__TypeName", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.Map__String__TypeName", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -13472,10 +13472,10 @@ func (na *_Map__String__TypeName__Assembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -13785,7 +13785,7 @@ func (_Map__String__TypeName__ReprAssembler) AssignBytes([]byte) error {
 func (_Map__String__TypeName__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.Map__String__TypeName.Repr"}.AssignLink(nil)
 }
-func (na *_Map__String__TypeName__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_Map__String__TypeName__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -13806,7 +13806,7 @@ func (na *_Map__String__TypeName__ReprAssembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.Map__String__TypeName.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.Map__String__TypeName.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -13814,10 +13814,10 @@ func (na *_Map__String__TypeName__ReprAssembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -14212,7 +14212,7 @@ func (_Map__TypeName__Int__Assembler) AssignBytes([]byte) error {
 func (_Map__TypeName__Int__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.Map__TypeName__Int"}.AssignLink(nil)
 }
-func (na *_Map__TypeName__Int__Assembler) AssignNode(v ipld.Node) error {
+func (na *_Map__TypeName__Int__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -14233,7 +14233,7 @@ func (na *_Map__TypeName__Int__Assembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.Map__TypeName__Int", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.Map__TypeName__Int", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -14241,10 +14241,10 @@ func (na *_Map__TypeName__Int__Assembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -14554,7 +14554,7 @@ func (_Map__TypeName__Int__ReprAssembler) AssignBytes([]byte) error {
 func (_Map__TypeName__Int__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.Map__TypeName__Int.Repr"}.AssignLink(nil)
 }
-func (na *_Map__TypeName__Int__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_Map__TypeName__Int__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -14575,7 +14575,7 @@ func (na *_Map__TypeName__Int__ReprAssembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.Map__TypeName__Int.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.Map__TypeName__Int.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -14583,10 +14583,10 @@ func (na *_Map__TypeName__Int__ReprAssembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -14896,7 +14896,7 @@ func (_RepresentationKind__Assembler) AssignBytes([]byte) error {
 func (_RepresentationKind__Assembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.RepresentationKind"}.AssignLink(nil)
 }
-func (na *_RepresentationKind__Assembler) AssignNode(v ipld.Node) error {
+func (na *_RepresentationKind__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -15160,7 +15160,7 @@ func (_Schema__Assembler) AssignBytes([]byte) error {
 func (_Schema__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.Schema"}.AssignLink(nil)
 }
-func (na *_Schema__Assembler) AssignNode(v ipld.Node) error {
+func (na *_Schema__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -15181,7 +15181,7 @@ func (na *_Schema__Assembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.Schema", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.Schema", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -15189,10 +15189,10 @@ func (na *_Schema__Assembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -15364,7 +15364,7 @@ func (_Schema__KeyAssembler) AssignBytes([]byte) error {
 func (_Schema__KeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.Schema.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_Schema__KeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_Schema__KeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -15561,7 +15561,7 @@ func (_Schema__ReprAssembler) AssignBytes([]byte) error {
 func (_Schema__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.Schema.Repr"}.AssignLink(nil)
 }
-func (na *_Schema__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_Schema__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -15582,7 +15582,7 @@ func (na *_Schema__ReprAssembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.Schema.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.Schema.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -15590,10 +15590,10 @@ func (na *_Schema__ReprAssembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -15764,7 +15764,7 @@ func (_Schema__ReprKeyAssembler) AssignBytes([]byte) error {
 func (_Schema__ReprKeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.Schema.Repr.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_Schema__ReprKeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_Schema__ReprKeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -16036,7 +16036,7 @@ func (_SchemaMap__Assembler) AssignBytes([]byte) error {
 func (_SchemaMap__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.SchemaMap"}.AssignLink(nil)
 }
-func (na *_SchemaMap__Assembler) AssignNode(v ipld.Node) error {
+func (na *_SchemaMap__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -16057,7 +16057,7 @@ func (na *_SchemaMap__Assembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.SchemaMap", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.SchemaMap", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -16065,10 +16065,10 @@ func (na *_SchemaMap__Assembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -16378,7 +16378,7 @@ func (_SchemaMap__ReprAssembler) AssignBytes([]byte) error {
 func (_SchemaMap__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.SchemaMap.Repr"}.AssignLink(nil)
 }
-func (na *_SchemaMap__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_SchemaMap__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -16399,7 +16399,7 @@ func (na *_SchemaMap__ReprAssembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.SchemaMap.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.SchemaMap.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -16407,10 +16407,10 @@ func (na *_SchemaMap__ReprAssembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -16720,7 +16720,7 @@ func (_String__Assembler) AssignBytes([]byte) error {
 func (_String__Assembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.String"}.AssignLink(nil)
 }
-func (na *_String__Assembler) AssignNode(v ipld.Node) error {
+func (na *_String__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -17008,7 +17008,7 @@ func (_StructField__Assembler) AssignBytes([]byte) error {
 func (_StructField__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.StructField"}.AssignLink(nil)
 }
-func (na *_StructField__Assembler) AssignNode(v ipld.Node) error {
+func (na *_StructField__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -17029,7 +17029,7 @@ func (na *_StructField__Assembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.StructField", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.StructField", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -17037,10 +17037,10 @@ func (na *_StructField__Assembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -17280,7 +17280,7 @@ func (_StructField__KeyAssembler) AssignBytes([]byte) error {
 func (_StructField__KeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.StructField.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_StructField__KeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_StructField__KeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -17493,7 +17493,7 @@ func (_StructField__ReprAssembler) AssignBytes([]byte) error {
 func (_StructField__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.StructField.Repr"}.AssignLink(nil)
 }
-func (na *_StructField__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_StructField__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -17514,7 +17514,7 @@ func (na *_StructField__ReprAssembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.StructField.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.StructField.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -17522,10 +17522,10 @@ func (na *_StructField__ReprAssembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -17762,7 +17762,7 @@ func (_StructField__ReprKeyAssembler) AssignBytes([]byte) error {
 func (_StructField__ReprKeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.StructField.Repr.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_StructField__ReprKeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_StructField__ReprKeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -18064,7 +18064,7 @@ func (_StructRepresentation__Assembler) AssignBytes([]byte) error {
 func (_StructRepresentation__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.StructRepresentation"}.AssignLink(nil)
 }
-func (na *_StructRepresentation__Assembler) AssignNode(v ipld.Node) error {
+func (na *_StructRepresentation__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -18085,7 +18085,7 @@ func (na *_StructRepresentation__Assembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.StructRepresentation", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.StructRepresentation", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -18093,10 +18093,10 @@ func (na *_StructRepresentation__Assembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -18335,7 +18335,7 @@ func (_StructRepresentation__KeyAssembler) AssignBytes([]byte) error {
 func (_StructRepresentation__KeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.StructRepresentation.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_StructRepresentation__KeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_StructRepresentation__KeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -18593,7 +18593,7 @@ func (_StructRepresentation__ReprAssembler) AssignBytes([]byte) error {
 func (_StructRepresentation__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.StructRepresentation.Repr"}.AssignLink(nil)
 }
-func (na *_StructRepresentation__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_StructRepresentation__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -18614,7 +18614,7 @@ func (na *_StructRepresentation__ReprAssembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.StructRepresentation.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.StructRepresentation.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -18622,10 +18622,10 @@ func (na *_StructRepresentation__ReprAssembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -18864,7 +18864,7 @@ func (_StructRepresentation__ReprKeyAssembler) AssignBytes([]byte) error {
 func (_StructRepresentation__ReprKeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.StructRepresentation.Repr.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_StructRepresentation__ReprKeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_StructRepresentation__ReprKeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -19084,7 +19084,7 @@ func (_StructRepresentation_Listpairs__Assembler) AssignBytes([]byte) error {
 func (_StructRepresentation_Listpairs__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.StructRepresentation_Listpairs"}.AssignLink(nil)
 }
-func (na *_StructRepresentation_Listpairs__Assembler) AssignNode(v ipld.Node) error {
+func (na *_StructRepresentation_Listpairs__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -19105,7 +19105,7 @@ func (na *_StructRepresentation_Listpairs__Assembler) AssignNode(v ipld.Node) er
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.StructRepresentation_Listpairs", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.StructRepresentation_Listpairs", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -19113,10 +19113,10 @@ func (na *_StructRepresentation_Listpairs__Assembler) AssignNode(v ipld.Node) er
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -19254,7 +19254,7 @@ func (_StructRepresentation_Listpairs__KeyAssembler) AssignBytes([]byte) error {
 func (_StructRepresentation_Listpairs__KeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.StructRepresentation_Listpairs.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_StructRepresentation_Listpairs__KeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_StructRepresentation_Listpairs__KeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -19442,7 +19442,7 @@ func (_StructRepresentation_Listpairs__ReprAssembler) AssignBytes([]byte) error 
 func (_StructRepresentation_Listpairs__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.StructRepresentation_Listpairs.Repr"}.AssignLink(nil)
 }
-func (na *_StructRepresentation_Listpairs__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_StructRepresentation_Listpairs__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -19463,7 +19463,7 @@ func (na *_StructRepresentation_Listpairs__ReprAssembler) AssignNode(v ipld.Node
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.StructRepresentation_Listpairs.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.StructRepresentation_Listpairs.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -19471,10 +19471,10 @@ func (na *_StructRepresentation_Listpairs__ReprAssembler) AssignNode(v ipld.Node
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -19612,7 +19612,7 @@ func (_StructRepresentation_Listpairs__ReprKeyAssembler) AssignBytes([]byte) err
 func (_StructRepresentation_Listpairs__ReprKeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.StructRepresentation_Listpairs.Repr.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_StructRepresentation_Listpairs__ReprKeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_StructRepresentation_Listpairs__ReprKeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -19853,7 +19853,7 @@ func (_StructRepresentation_Map__Assembler) AssignBytes([]byte) error {
 func (_StructRepresentation_Map__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.StructRepresentation_Map"}.AssignLink(nil)
 }
-func (na *_StructRepresentation_Map__Assembler) AssignNode(v ipld.Node) error {
+func (na *_StructRepresentation_Map__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -19874,7 +19874,7 @@ func (na *_StructRepresentation_Map__Assembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.StructRepresentation_Map", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.StructRepresentation_Map", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -19882,10 +19882,10 @@ func (na *_StructRepresentation_Map__Assembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -20053,7 +20053,7 @@ func (_StructRepresentation_Map__KeyAssembler) AssignBytes([]byte) error {
 func (_StructRepresentation_Map__KeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.StructRepresentation_Map.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_StructRepresentation_Map__KeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_StructRepresentation_Map__KeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -20269,7 +20269,7 @@ func (_StructRepresentation_Map__ReprAssembler) AssignBytes([]byte) error {
 func (_StructRepresentation_Map__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.StructRepresentation_Map.Repr"}.AssignLink(nil)
 }
-func (na *_StructRepresentation_Map__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_StructRepresentation_Map__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -20290,7 +20290,7 @@ func (na *_StructRepresentation_Map__ReprAssembler) AssignNode(v ipld.Node) erro
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.StructRepresentation_Map.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.StructRepresentation_Map.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -20298,10 +20298,10 @@ func (na *_StructRepresentation_Map__ReprAssembler) AssignNode(v ipld.Node) erro
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -20471,7 +20471,7 @@ func (_StructRepresentation_Map__ReprKeyAssembler) AssignBytes([]byte) error {
 func (_StructRepresentation_Map__ReprKeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.StructRepresentation_Map.Repr.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_StructRepresentation_Map__ReprKeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_StructRepresentation_Map__ReprKeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -20731,7 +20731,7 @@ func (_StructRepresentation_Map_FieldDetails__Assembler) AssignBytes([]byte) err
 func (_StructRepresentation_Map_FieldDetails__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.StructRepresentation_Map_FieldDetails"}.AssignLink(nil)
 }
-func (na *_StructRepresentation_Map_FieldDetails__Assembler) AssignNode(v ipld.Node) error {
+func (na *_StructRepresentation_Map_FieldDetails__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -20752,7 +20752,7 @@ func (na *_StructRepresentation_Map_FieldDetails__Assembler) AssignNode(v ipld.N
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.StructRepresentation_Map_FieldDetails", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.StructRepresentation_Map_FieldDetails", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -20760,10 +20760,10 @@ func (na *_StructRepresentation_Map_FieldDetails__Assembler) AssignNode(v ipld.N
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -20961,7 +20961,7 @@ func (_StructRepresentation_Map_FieldDetails__KeyAssembler) AssignBytes([]byte) 
 func (_StructRepresentation_Map_FieldDetails__KeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.StructRepresentation_Map_FieldDetails.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_StructRepresentation_Map_FieldDetails__KeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_StructRepresentation_Map_FieldDetails__KeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -21200,7 +21200,7 @@ func (_StructRepresentation_Map_FieldDetails__ReprAssembler) AssignBytes([]byte)
 func (_StructRepresentation_Map_FieldDetails__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.StructRepresentation_Map_FieldDetails.Repr"}.AssignLink(nil)
 }
-func (na *_StructRepresentation_Map_FieldDetails__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_StructRepresentation_Map_FieldDetails__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -21221,7 +21221,7 @@ func (na *_StructRepresentation_Map_FieldDetails__ReprAssembler) AssignNode(v ip
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.StructRepresentation_Map_FieldDetails.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.StructRepresentation_Map_FieldDetails.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -21229,10 +21229,10 @@ func (na *_StructRepresentation_Map_FieldDetails__ReprAssembler) AssignNode(v ip
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -21434,7 +21434,7 @@ func (_StructRepresentation_Map_FieldDetails__ReprKeyAssembler) AssignBytes([]by
 func (_StructRepresentation_Map_FieldDetails__ReprKeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.StructRepresentation_Map_FieldDetails.Repr.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_StructRepresentation_Map_FieldDetails__ReprKeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_StructRepresentation_Map_FieldDetails__ReprKeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -21687,7 +21687,7 @@ func (_StructRepresentation_Stringjoin__Assembler) AssignBytes([]byte) error {
 func (_StructRepresentation_Stringjoin__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.StructRepresentation_Stringjoin"}.AssignLink(nil)
 }
-func (na *_StructRepresentation_Stringjoin__Assembler) AssignNode(v ipld.Node) error {
+func (na *_StructRepresentation_Stringjoin__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -21708,7 +21708,7 @@ func (na *_StructRepresentation_Stringjoin__Assembler) AssignNode(v ipld.Node) e
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.StructRepresentation_Stringjoin", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.StructRepresentation_Stringjoin", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -21716,10 +21716,10 @@ func (na *_StructRepresentation_Stringjoin__Assembler) AssignNode(v ipld.Node) e
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -21921,7 +21921,7 @@ func (_StructRepresentation_Stringjoin__KeyAssembler) AssignBytes([]byte) error 
 func (_StructRepresentation_Stringjoin__KeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.StructRepresentation_Stringjoin.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_StructRepresentation_Stringjoin__KeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_StructRepresentation_Stringjoin__KeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -22145,7 +22145,7 @@ func (_StructRepresentation_Stringjoin__ReprAssembler) AssignBytes([]byte) error
 func (_StructRepresentation_Stringjoin__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.StructRepresentation_Stringjoin.Repr"}.AssignLink(nil)
 }
-func (na *_StructRepresentation_Stringjoin__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_StructRepresentation_Stringjoin__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -22166,7 +22166,7 @@ func (na *_StructRepresentation_Stringjoin__ReprAssembler) AssignNode(v ipld.Nod
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.StructRepresentation_Stringjoin.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.StructRepresentation_Stringjoin.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -22174,10 +22174,10 @@ func (na *_StructRepresentation_Stringjoin__ReprAssembler) AssignNode(v ipld.Nod
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -22380,7 +22380,7 @@ func (_StructRepresentation_Stringjoin__ReprKeyAssembler) AssignBytes([]byte) er
 func (_StructRepresentation_Stringjoin__ReprKeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.StructRepresentation_Stringjoin.Repr.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_StructRepresentation_Stringjoin__ReprKeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_StructRepresentation_Stringjoin__ReprKeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -22626,7 +22626,7 @@ func (_StructRepresentation_Stringpairs__Assembler) AssignBytes([]byte) error {
 func (_StructRepresentation_Stringpairs__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.StructRepresentation_Stringpairs"}.AssignLink(nil)
 }
-func (na *_StructRepresentation_Stringpairs__Assembler) AssignNode(v ipld.Node) error {
+func (na *_StructRepresentation_Stringpairs__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -22647,7 +22647,7 @@ func (na *_StructRepresentation_Stringpairs__Assembler) AssignNode(v ipld.Node) 
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.StructRepresentation_Stringpairs", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.StructRepresentation_Stringpairs", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -22655,10 +22655,10 @@ func (na *_StructRepresentation_Stringpairs__Assembler) AssignNode(v ipld.Node) 
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -22864,7 +22864,7 @@ func (_StructRepresentation_Stringpairs__KeyAssembler) AssignBytes([]byte) error
 func (_StructRepresentation_Stringpairs__KeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.StructRepresentation_Stringpairs.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_StructRepresentation_Stringpairs__KeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_StructRepresentation_Stringpairs__KeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -23069,7 +23069,7 @@ func (_StructRepresentation_Stringpairs__ReprAssembler) AssignBytes([]byte) erro
 func (_StructRepresentation_Stringpairs__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.StructRepresentation_Stringpairs.Repr"}.AssignLink(nil)
 }
-func (na *_StructRepresentation_Stringpairs__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_StructRepresentation_Stringpairs__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -23090,7 +23090,7 @@ func (na *_StructRepresentation_Stringpairs__ReprAssembler) AssignNode(v ipld.No
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.StructRepresentation_Stringpairs.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.StructRepresentation_Stringpairs.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -23098,10 +23098,10 @@ func (na *_StructRepresentation_Stringpairs__ReprAssembler) AssignNode(v ipld.No
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -23305,7 +23305,7 @@ func (_StructRepresentation_Stringpairs__ReprKeyAssembler) AssignBytes([]byte) e
 func (_StructRepresentation_Stringpairs__ReprKeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.StructRepresentation_Stringpairs.Repr.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_StructRepresentation_Stringpairs__ReprKeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_StructRepresentation_Stringpairs__ReprKeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -23546,7 +23546,7 @@ func (_StructRepresentation_Tuple__Assembler) AssignBytes([]byte) error {
 func (_StructRepresentation_Tuple__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.StructRepresentation_Tuple"}.AssignLink(nil)
 }
-func (na *_StructRepresentation_Tuple__Assembler) AssignNode(v ipld.Node) error {
+func (na *_StructRepresentation_Tuple__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -23567,7 +23567,7 @@ func (na *_StructRepresentation_Tuple__Assembler) AssignNode(v ipld.Node) error 
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.StructRepresentation_Tuple", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.StructRepresentation_Tuple", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -23575,10 +23575,10 @@ func (na *_StructRepresentation_Tuple__Assembler) AssignNode(v ipld.Node) error 
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -23746,7 +23746,7 @@ func (_StructRepresentation_Tuple__KeyAssembler) AssignBytes([]byte) error {
 func (_StructRepresentation_Tuple__KeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.StructRepresentation_Tuple.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_StructRepresentation_Tuple__KeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_StructRepresentation_Tuple__KeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -23962,7 +23962,7 @@ func (_StructRepresentation_Tuple__ReprAssembler) AssignBytes([]byte) error {
 func (_StructRepresentation_Tuple__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.StructRepresentation_Tuple.Repr"}.AssignLink(nil)
 }
-func (na *_StructRepresentation_Tuple__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_StructRepresentation_Tuple__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -23983,7 +23983,7 @@ func (na *_StructRepresentation_Tuple__ReprAssembler) AssignNode(v ipld.Node) er
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.StructRepresentation_Tuple.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.StructRepresentation_Tuple.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -23991,10 +23991,10 @@ func (na *_StructRepresentation_Tuple__ReprAssembler) AssignNode(v ipld.Node) er
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -24164,7 +24164,7 @@ func (_StructRepresentation_Tuple__ReprKeyAssembler) AssignBytes([]byte) error {
 func (_StructRepresentation_Tuple__ReprKeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.StructRepresentation_Tuple.Repr.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_StructRepresentation_Tuple__ReprKeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_StructRepresentation_Tuple__ReprKeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -24384,7 +24384,7 @@ func (_TypeBool__Assembler) AssignBytes([]byte) error {
 func (_TypeBool__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.TypeBool"}.AssignLink(nil)
 }
-func (na *_TypeBool__Assembler) AssignNode(v ipld.Node) error {
+func (na *_TypeBool__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -24405,7 +24405,7 @@ func (na *_TypeBool__Assembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeBool", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeBool", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -24413,10 +24413,10 @@ func (na *_TypeBool__Assembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -24554,7 +24554,7 @@ func (_TypeBool__KeyAssembler) AssignBytes([]byte) error {
 func (_TypeBool__KeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.TypeBool.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_TypeBool__KeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_TypeBool__KeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -24742,7 +24742,7 @@ func (_TypeBool__ReprAssembler) AssignBytes([]byte) error {
 func (_TypeBool__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.TypeBool.Repr"}.AssignLink(nil)
 }
-func (na *_TypeBool__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_TypeBool__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -24763,7 +24763,7 @@ func (na *_TypeBool__ReprAssembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeBool.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeBool.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -24771,10 +24771,10 @@ func (na *_TypeBool__ReprAssembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -24912,7 +24912,7 @@ func (_TypeBool__ReprKeyAssembler) AssignBytes([]byte) error {
 func (_TypeBool__ReprKeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.TypeBool.Repr.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_TypeBool__ReprKeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_TypeBool__ReprKeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -25132,7 +25132,7 @@ func (_TypeBytes__Assembler) AssignBytes([]byte) error {
 func (_TypeBytes__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.TypeBytes"}.AssignLink(nil)
 }
-func (na *_TypeBytes__Assembler) AssignNode(v ipld.Node) error {
+func (na *_TypeBytes__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -25153,7 +25153,7 @@ func (na *_TypeBytes__Assembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeBytes", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeBytes", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -25161,10 +25161,10 @@ func (na *_TypeBytes__Assembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -25302,7 +25302,7 @@ func (_TypeBytes__KeyAssembler) AssignBytes([]byte) error {
 func (_TypeBytes__KeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.TypeBytes.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_TypeBytes__KeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_TypeBytes__KeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -25490,7 +25490,7 @@ func (_TypeBytes__ReprAssembler) AssignBytes([]byte) error {
 func (_TypeBytes__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.TypeBytes.Repr"}.AssignLink(nil)
 }
-func (na *_TypeBytes__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_TypeBytes__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -25511,7 +25511,7 @@ func (na *_TypeBytes__ReprAssembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeBytes.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeBytes.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -25519,10 +25519,10 @@ func (na *_TypeBytes__ReprAssembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -25660,7 +25660,7 @@ func (_TypeBytes__ReprKeyAssembler) AssignBytes([]byte) error {
 func (_TypeBytes__ReprKeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.TypeBytes.Repr.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_TypeBytes__ReprKeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_TypeBytes__ReprKeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -25894,7 +25894,7 @@ func (_TypeCopy__Assembler) AssignBytes([]byte) error {
 func (_TypeCopy__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.TypeCopy"}.AssignLink(nil)
 }
-func (na *_TypeCopy__Assembler) AssignNode(v ipld.Node) error {
+func (na *_TypeCopy__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -25915,7 +25915,7 @@ func (na *_TypeCopy__Assembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeCopy", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeCopy", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -25923,10 +25923,10 @@ func (na *_TypeCopy__Assembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -26098,7 +26098,7 @@ func (_TypeCopy__KeyAssembler) AssignBytes([]byte) error {
 func (_TypeCopy__KeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.TypeCopy.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_TypeCopy__KeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_TypeCopy__KeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -26295,7 +26295,7 @@ func (_TypeCopy__ReprAssembler) AssignBytes([]byte) error {
 func (_TypeCopy__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.TypeCopy.Repr"}.AssignLink(nil)
 }
-func (na *_TypeCopy__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_TypeCopy__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -26316,7 +26316,7 @@ func (na *_TypeCopy__ReprAssembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeCopy.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeCopy.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -26324,10 +26324,10 @@ func (na *_TypeCopy__ReprAssembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -26498,7 +26498,7 @@ func (_TypeCopy__ReprKeyAssembler) AssignBytes([]byte) error {
 func (_TypeCopy__ReprKeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.TypeCopy.Repr.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_TypeCopy__ReprKeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_TypeCopy__ReprKeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -26905,7 +26905,7 @@ func (_TypeDefn__Assembler) AssignBytes([]byte) error {
 func (_TypeDefn__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.TypeDefn"}.AssignLink(nil)
 }
-func (na *_TypeDefn__Assembler) AssignNode(v ipld.Node) error {
+func (na *_TypeDefn__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -26926,7 +26926,7 @@ func (na *_TypeDefn__Assembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeDefn", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeDefn", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -26934,10 +26934,10 @@ func (na *_TypeDefn__Assembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -27302,7 +27302,7 @@ func (_TypeDefn__KeyAssembler) AssignBytes([]byte) error {
 func (_TypeDefn__KeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.TypeDefn.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_TypeDefn__KeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_TypeDefn__KeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -27651,7 +27651,7 @@ func (_TypeDefn__ReprAssembler) AssignBytes([]byte) error {
 func (_TypeDefn__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.TypeDefn.Repr"}.AssignLink(nil)
 }
-func (na *_TypeDefn__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_TypeDefn__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -27672,7 +27672,7 @@ func (na *_TypeDefn__ReprAssembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeDefn.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeDefn.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -27680,10 +27680,10 @@ func (na *_TypeDefn__ReprAssembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -28048,7 +28048,7 @@ func (_TypeDefn__ReprKeyAssembler) AssignBytes([]byte) error {
 func (_TypeDefn__ReprKeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.TypeDefn.Repr.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_TypeDefn__ReprKeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_TypeDefn__ReprKeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -28300,7 +28300,7 @@ func (_TypeDefnInline__Assembler) AssignBytes([]byte) error {
 func (_TypeDefnInline__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.TypeDefnInline"}.AssignLink(nil)
 }
-func (na *_TypeDefnInline__Assembler) AssignNode(v ipld.Node) error {
+func (na *_TypeDefnInline__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -28321,7 +28321,7 @@ func (na *_TypeDefnInline__Assembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeDefnInline", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeDefnInline", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -28329,10 +28329,10 @@ func (na *_TypeDefnInline__Assembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -28533,7 +28533,7 @@ func (_TypeDefnInline__KeyAssembler) AssignBytes([]byte) error {
 func (_TypeDefnInline__KeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.TypeDefnInline.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_TypeDefnInline__KeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_TypeDefnInline__KeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -28754,7 +28754,7 @@ func (_TypeDefnInline__ReprAssembler) AssignBytes([]byte) error {
 func (_TypeDefnInline__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.TypeDefnInline.Repr"}.AssignLink(nil)
 }
-func (na *_TypeDefnInline__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_TypeDefnInline__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -28775,7 +28775,7 @@ func (na *_TypeDefnInline__ReprAssembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeDefnInline.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeDefnInline.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -28783,10 +28783,10 @@ func (na *_TypeDefnInline__ReprAssembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -28987,7 +28987,7 @@ func (_TypeDefnInline__ReprKeyAssembler) AssignBytes([]byte) error {
 func (_TypeDefnInline__ReprKeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.TypeDefnInline.Repr.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_TypeDefnInline__ReprKeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_TypeDefnInline__ReprKeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -29233,7 +29233,7 @@ func (_TypeEnum__Assembler) AssignBytes([]byte) error {
 func (_TypeEnum__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.TypeEnum"}.AssignLink(nil)
 }
-func (na *_TypeEnum__Assembler) AssignNode(v ipld.Node) error {
+func (na *_TypeEnum__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -29254,7 +29254,7 @@ func (na *_TypeEnum__Assembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeEnum", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeEnum", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -29262,10 +29262,10 @@ func (na *_TypeEnum__Assembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -29471,7 +29471,7 @@ func (_TypeEnum__KeyAssembler) AssignBytes([]byte) error {
 func (_TypeEnum__KeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.TypeEnum.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_TypeEnum__KeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_TypeEnum__KeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -29676,7 +29676,7 @@ func (_TypeEnum__ReprAssembler) AssignBytes([]byte) error {
 func (_TypeEnum__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.TypeEnum.Repr"}.AssignLink(nil)
 }
-func (na *_TypeEnum__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_TypeEnum__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -29697,7 +29697,7 @@ func (na *_TypeEnum__ReprAssembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeEnum.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeEnum.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -29705,10 +29705,10 @@ func (na *_TypeEnum__ReprAssembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -29912,7 +29912,7 @@ func (_TypeEnum__ReprKeyAssembler) AssignBytes([]byte) error {
 func (_TypeEnum__ReprKeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.TypeEnum.Repr.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_TypeEnum__ReprKeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_TypeEnum__ReprKeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -30132,7 +30132,7 @@ func (_TypeFloat__Assembler) AssignBytes([]byte) error {
 func (_TypeFloat__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.TypeFloat"}.AssignLink(nil)
 }
-func (na *_TypeFloat__Assembler) AssignNode(v ipld.Node) error {
+func (na *_TypeFloat__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -30153,7 +30153,7 @@ func (na *_TypeFloat__Assembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeFloat", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeFloat", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -30161,10 +30161,10 @@ func (na *_TypeFloat__Assembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -30302,7 +30302,7 @@ func (_TypeFloat__KeyAssembler) AssignBytes([]byte) error {
 func (_TypeFloat__KeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.TypeFloat.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_TypeFloat__KeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_TypeFloat__KeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -30490,7 +30490,7 @@ func (_TypeFloat__ReprAssembler) AssignBytes([]byte) error {
 func (_TypeFloat__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.TypeFloat.Repr"}.AssignLink(nil)
 }
-func (na *_TypeFloat__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_TypeFloat__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -30511,7 +30511,7 @@ func (na *_TypeFloat__ReprAssembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeFloat.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeFloat.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -30519,10 +30519,10 @@ func (na *_TypeFloat__ReprAssembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -30660,7 +30660,7 @@ func (_TypeFloat__ReprKeyAssembler) AssignBytes([]byte) error {
 func (_TypeFloat__ReprKeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.TypeFloat.Repr.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_TypeFloat__ReprKeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_TypeFloat__ReprKeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -30880,7 +30880,7 @@ func (_TypeInt__Assembler) AssignBytes([]byte) error {
 func (_TypeInt__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.TypeInt"}.AssignLink(nil)
 }
-func (na *_TypeInt__Assembler) AssignNode(v ipld.Node) error {
+func (na *_TypeInt__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -30901,7 +30901,7 @@ func (na *_TypeInt__Assembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeInt", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeInt", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -30909,10 +30909,10 @@ func (na *_TypeInt__Assembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -31050,7 +31050,7 @@ func (_TypeInt__KeyAssembler) AssignBytes([]byte) error {
 func (_TypeInt__KeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.TypeInt.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_TypeInt__KeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_TypeInt__KeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -31238,7 +31238,7 @@ func (_TypeInt__ReprAssembler) AssignBytes([]byte) error {
 func (_TypeInt__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.TypeInt.Repr"}.AssignLink(nil)
 }
-func (na *_TypeInt__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_TypeInt__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -31259,7 +31259,7 @@ func (na *_TypeInt__ReprAssembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeInt.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeInt.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -31267,10 +31267,10 @@ func (na *_TypeInt__ReprAssembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -31408,7 +31408,7 @@ func (_TypeInt__ReprKeyAssembler) AssignBytes([]byte) error {
 func (_TypeInt__ReprKeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.TypeInt.Repr.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_TypeInt__ReprKeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_TypeInt__ReprKeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -31649,7 +31649,7 @@ func (_TypeLink__Assembler) AssignBytes([]byte) error {
 func (_TypeLink__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.TypeLink"}.AssignLink(nil)
 }
-func (na *_TypeLink__Assembler) AssignNode(v ipld.Node) error {
+func (na *_TypeLink__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -31670,7 +31670,7 @@ func (na *_TypeLink__Assembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeLink", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeLink", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -31678,10 +31678,10 @@ func (na *_TypeLink__Assembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -31849,7 +31849,7 @@ func (_TypeLink__KeyAssembler) AssignBytes([]byte) error {
 func (_TypeLink__KeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.TypeLink.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_TypeLink__KeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_TypeLink__KeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -32065,7 +32065,7 @@ func (_TypeLink__ReprAssembler) AssignBytes([]byte) error {
 func (_TypeLink__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.TypeLink.Repr"}.AssignLink(nil)
 }
-func (na *_TypeLink__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_TypeLink__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -32086,7 +32086,7 @@ func (na *_TypeLink__ReprAssembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeLink.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeLink.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -32094,10 +32094,10 @@ func (na *_TypeLink__ReprAssembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -32267,7 +32267,7 @@ func (_TypeLink__ReprKeyAssembler) AssignBytes([]byte) error {
 func (_TypeLink__ReprKeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.TypeLink.Repr.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_TypeLink__ReprKeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_TypeLink__ReprKeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -32525,7 +32525,7 @@ func (_TypeList__Assembler) AssignBytes([]byte) error {
 func (_TypeList__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.TypeList"}.AssignLink(nil)
 }
-func (na *_TypeList__Assembler) AssignNode(v ipld.Node) error {
+func (na *_TypeList__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -32546,7 +32546,7 @@ func (na *_TypeList__Assembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeList", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeList", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -32554,10 +32554,10 @@ func (na *_TypeList__Assembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -32797,7 +32797,7 @@ func (_TypeList__KeyAssembler) AssignBytes([]byte) error {
 func (_TypeList__KeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.TypeList.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_TypeList__KeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_TypeList__KeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -33010,7 +33010,7 @@ func (_TypeList__ReprAssembler) AssignBytes([]byte) error {
 func (_TypeList__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.TypeList.Repr"}.AssignLink(nil)
 }
-func (na *_TypeList__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_TypeList__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -33031,7 +33031,7 @@ func (na *_TypeList__ReprAssembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeList.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeList.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -33039,10 +33039,10 @@ func (na *_TypeList__ReprAssembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -33279,7 +33279,7 @@ func (_TypeList__ReprKeyAssembler) AssignBytes([]byte) error {
 func (_TypeList__ReprKeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.TypeList.Repr.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_TypeList__ReprKeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_TypeList__ReprKeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -33549,7 +33549,7 @@ func (_TypeMap__Assembler) AssignBytes([]byte) error {
 func (_TypeMap__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.TypeMap"}.AssignLink(nil)
 }
-func (na *_TypeMap__Assembler) AssignNode(v ipld.Node) error {
+func (na *_TypeMap__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -33570,7 +33570,7 @@ func (na *_TypeMap__Assembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeMap", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeMap", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -33578,10 +33578,10 @@ func (na *_TypeMap__Assembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -33855,7 +33855,7 @@ func (_TypeMap__KeyAssembler) AssignBytes([]byte) error {
 func (_TypeMap__KeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.TypeMap.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_TypeMap__KeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_TypeMap__KeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -34076,7 +34076,7 @@ func (_TypeMap__ReprAssembler) AssignBytes([]byte) error {
 func (_TypeMap__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.TypeMap.Repr"}.AssignLink(nil)
 }
-func (na *_TypeMap__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_TypeMap__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -34097,7 +34097,7 @@ func (na *_TypeMap__ReprAssembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeMap.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeMap.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -34105,10 +34105,10 @@ func (na *_TypeMap__ReprAssembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -34378,7 +34378,7 @@ func (_TypeMap__ReprKeyAssembler) AssignBytes([]byte) error {
 func (_TypeMap__ReprKeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.TypeMap.Repr.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_TypeMap__ReprKeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_TypeMap__ReprKeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -34565,7 +34565,7 @@ func (_TypeName__Assembler) AssignBytes([]byte) error {
 func (_TypeName__Assembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.TypeName"}.AssignLink(nil)
 }
-func (na *_TypeName__Assembler) AssignNode(v ipld.Node) error {
+func (na *_TypeName__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -34852,7 +34852,7 @@ func (_TypeNameOrInlineDefn__Assembler) AssignBytes([]byte) error {
 func (_TypeNameOrInlineDefn__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.TypeNameOrInlineDefn"}.AssignLink(nil)
 }
-func (na *_TypeNameOrInlineDefn__Assembler) AssignNode(v ipld.Node) error {
+func (na *_TypeNameOrInlineDefn__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -34873,7 +34873,7 @@ func (na *_TypeNameOrInlineDefn__Assembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeNameOrInlineDefn", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeNameOrInlineDefn", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -34881,10 +34881,10 @@ func (na *_TypeNameOrInlineDefn__Assembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -35069,7 +35069,7 @@ func (_TypeNameOrInlineDefn__KeyAssembler) AssignBytes([]byte) error {
 func (_TypeNameOrInlineDefn__KeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.TypeNameOrInlineDefn.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_TypeNameOrInlineDefn__KeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_TypeNameOrInlineDefn__KeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -35321,7 +35321,7 @@ func (na *_TypeNameOrInlineDefn__ReprAssembler) AssignLink(v ipld.Link) error {
 	}
 	return schema.ErrNotUnionStructure{TypeName: "schemadmt.TypeNameOrInlineDefn.Repr", Detail: "AssignLink called but is not valid for any of the kinds that are valid members of this union"}
 }
-func (na *_TypeNameOrInlineDefn__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_TypeNameOrInlineDefn__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -35368,10 +35368,10 @@ func (na *_TypeNameOrInlineDefn__ReprAssembler) AssignNode(v ipld.Node) error {
 			if err != nil {
 				return err
 			}
-			if err := na.AssembleKey().AssignNode(k); err != nil {
+			if err := na.AssembleKey().ConvertFrom(k); err != nil {
 				return err
 			}
-			if err := na.AssembleValue().AssignNode(v); err != nil {
+			if err := na.AssembleValue().ConvertFrom(v); err != nil {
 				return err
 			}
 		}
@@ -35387,7 +35387,7 @@ func (na *_TypeNameOrInlineDefn__ReprAssembler) AssignNode(v ipld.Node) error {
 			if err != nil {
 				return err
 			}
-			if err := na.AssembleValue().AssignNode(v); err != nil {
+			if err := na.AssembleValue().ConvertFrom(v); err != nil {
 				return err
 			}
 		}
@@ -35612,7 +35612,7 @@ func (_TypeString__Assembler) AssignBytes([]byte) error {
 func (_TypeString__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.TypeString"}.AssignLink(nil)
 }
-func (na *_TypeString__Assembler) AssignNode(v ipld.Node) error {
+func (na *_TypeString__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -35633,7 +35633,7 @@ func (na *_TypeString__Assembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeString", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeString", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -35641,10 +35641,10 @@ func (na *_TypeString__Assembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -35782,7 +35782,7 @@ func (_TypeString__KeyAssembler) AssignBytes([]byte) error {
 func (_TypeString__KeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.TypeString.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_TypeString__KeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_TypeString__KeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -35970,7 +35970,7 @@ func (_TypeString__ReprAssembler) AssignBytes([]byte) error {
 func (_TypeString__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.TypeString.Repr"}.AssignLink(nil)
 }
-func (na *_TypeString__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_TypeString__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -35991,7 +35991,7 @@ func (na *_TypeString__ReprAssembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeString.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeString.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -35999,10 +35999,10 @@ func (na *_TypeString__ReprAssembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -36140,7 +36140,7 @@ func (_TypeString__ReprKeyAssembler) AssignBytes([]byte) error {
 func (_TypeString__ReprKeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.TypeString.Repr.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_TypeString__ReprKeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_TypeString__ReprKeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -36386,7 +36386,7 @@ func (_TypeStruct__Assembler) AssignBytes([]byte) error {
 func (_TypeStruct__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.TypeStruct"}.AssignLink(nil)
 }
-func (na *_TypeStruct__Assembler) AssignNode(v ipld.Node) error {
+func (na *_TypeStruct__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -36407,7 +36407,7 @@ func (na *_TypeStruct__Assembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeStruct", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeStruct", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -36415,10 +36415,10 @@ func (na *_TypeStruct__Assembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -36624,7 +36624,7 @@ func (_TypeStruct__KeyAssembler) AssignBytes([]byte) error {
 func (_TypeStruct__KeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.TypeStruct.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_TypeStruct__KeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_TypeStruct__KeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -36829,7 +36829,7 @@ func (_TypeStruct__ReprAssembler) AssignBytes([]byte) error {
 func (_TypeStruct__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.TypeStruct.Repr"}.AssignLink(nil)
 }
-func (na *_TypeStruct__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_TypeStruct__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -36850,7 +36850,7 @@ func (na *_TypeStruct__ReprAssembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeStruct.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeStruct.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -36858,10 +36858,10 @@ func (na *_TypeStruct__ReprAssembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -37065,7 +37065,7 @@ func (_TypeStruct__ReprKeyAssembler) AssignBytes([]byte) error {
 func (_TypeStruct__ReprKeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.TypeStruct.Repr.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_TypeStruct__ReprKeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_TypeStruct__ReprKeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -37311,7 +37311,7 @@ func (_TypeUnion__Assembler) AssignBytes([]byte) error {
 func (_TypeUnion__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.TypeUnion"}.AssignLink(nil)
 }
-func (na *_TypeUnion__Assembler) AssignNode(v ipld.Node) error {
+func (na *_TypeUnion__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -37332,7 +37332,7 @@ func (na *_TypeUnion__Assembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeUnion", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeUnion", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -37340,10 +37340,10 @@ func (na *_TypeUnion__Assembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -37549,7 +37549,7 @@ func (_TypeUnion__KeyAssembler) AssignBytes([]byte) error {
 func (_TypeUnion__KeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.TypeUnion.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_TypeUnion__KeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_TypeUnion__KeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -37754,7 +37754,7 @@ func (_TypeUnion__ReprAssembler) AssignBytes([]byte) error {
 func (_TypeUnion__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.TypeUnion.Repr"}.AssignLink(nil)
 }
-func (na *_TypeUnion__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_TypeUnion__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -37775,7 +37775,7 @@ func (na *_TypeUnion__ReprAssembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeUnion.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.TypeUnion.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -37783,10 +37783,10 @@ func (na *_TypeUnion__ReprAssembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -37990,7 +37990,7 @@ func (_TypeUnion__ReprKeyAssembler) AssignBytes([]byte) error {
 func (_TypeUnion__ReprKeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.TypeUnion.Repr.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_TypeUnion__ReprKeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_TypeUnion__ReprKeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -38307,7 +38307,7 @@ func (_UnionRepresentation__Assembler) AssignBytes([]byte) error {
 func (_UnionRepresentation__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.UnionRepresentation"}.AssignLink(nil)
 }
-func (na *_UnionRepresentation__Assembler) AssignNode(v ipld.Node) error {
+func (na *_UnionRepresentation__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -38328,7 +38328,7 @@ func (na *_UnionRepresentation__Assembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.UnionRepresentation", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.UnionRepresentation", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -38336,10 +38336,10 @@ func (na *_UnionRepresentation__Assembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -38596,7 +38596,7 @@ func (_UnionRepresentation__KeyAssembler) AssignBytes([]byte) error {
 func (_UnionRepresentation__KeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.UnionRepresentation.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_UnionRepresentation__KeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_UnionRepresentation__KeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -38867,7 +38867,7 @@ func (_UnionRepresentation__ReprAssembler) AssignBytes([]byte) error {
 func (_UnionRepresentation__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.UnionRepresentation.Repr"}.AssignLink(nil)
 }
-func (na *_UnionRepresentation__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_UnionRepresentation__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -38888,7 +38888,7 @@ func (na *_UnionRepresentation__ReprAssembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.UnionRepresentation.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.UnionRepresentation.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -38896,10 +38896,10 @@ func (na *_UnionRepresentation__ReprAssembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -39156,7 +39156,7 @@ func (_UnionRepresentation__ReprKeyAssembler) AssignBytes([]byte) error {
 func (_UnionRepresentation__ReprKeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.UnionRepresentation.Repr.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_UnionRepresentation__ReprKeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_UnionRepresentation__ReprKeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -39390,7 +39390,7 @@ func (_UnionRepresentation_BytePrefix__Assembler) AssignBytes([]byte) error {
 func (_UnionRepresentation_BytePrefix__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.UnionRepresentation_BytePrefix"}.AssignLink(nil)
 }
-func (na *_UnionRepresentation_BytePrefix__Assembler) AssignNode(v ipld.Node) error {
+func (na *_UnionRepresentation_BytePrefix__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -39411,7 +39411,7 @@ func (na *_UnionRepresentation_BytePrefix__Assembler) AssignNode(v ipld.Node) er
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.UnionRepresentation_BytePrefix", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.UnionRepresentation_BytePrefix", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -39419,10 +39419,10 @@ func (na *_UnionRepresentation_BytePrefix__Assembler) AssignNode(v ipld.Node) er
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -39594,7 +39594,7 @@ func (_UnionRepresentation_BytePrefix__KeyAssembler) AssignBytes([]byte) error {
 func (_UnionRepresentation_BytePrefix__KeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.UnionRepresentation_BytePrefix.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_UnionRepresentation_BytePrefix__KeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_UnionRepresentation_BytePrefix__KeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -39791,7 +39791,7 @@ func (_UnionRepresentation_BytePrefix__ReprAssembler) AssignBytes([]byte) error 
 func (_UnionRepresentation_BytePrefix__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.UnionRepresentation_BytePrefix.Repr"}.AssignLink(nil)
 }
-func (na *_UnionRepresentation_BytePrefix__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_UnionRepresentation_BytePrefix__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -39812,7 +39812,7 @@ func (na *_UnionRepresentation_BytePrefix__ReprAssembler) AssignNode(v ipld.Node
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.UnionRepresentation_BytePrefix.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.UnionRepresentation_BytePrefix.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -39820,10 +39820,10 @@ func (na *_UnionRepresentation_BytePrefix__ReprAssembler) AssignNode(v ipld.Node
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -39994,7 +39994,7 @@ func (_UnionRepresentation_BytePrefix__ReprKeyAssembler) AssignBytes([]byte) err
 func (_UnionRepresentation_BytePrefix__ReprKeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.UnionRepresentation_BytePrefix.Repr.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_UnionRepresentation_BytePrefix__ReprKeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_UnionRepresentation_BytePrefix__ReprKeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -40252,7 +40252,7 @@ func (_UnionRepresentation_Envelope__Assembler) AssignBytes([]byte) error {
 func (_UnionRepresentation_Envelope__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.UnionRepresentation_Envelope"}.AssignLink(nil)
 }
-func (na *_UnionRepresentation_Envelope__Assembler) AssignNode(v ipld.Node) error {
+func (na *_UnionRepresentation_Envelope__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -40273,7 +40273,7 @@ func (na *_UnionRepresentation_Envelope__Assembler) AssignNode(v ipld.Node) erro
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.UnionRepresentation_Envelope", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.UnionRepresentation_Envelope", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -40281,10 +40281,10 @@ func (na *_UnionRepresentation_Envelope__Assembler) AssignNode(v ipld.Node) erro
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -40524,7 +40524,7 @@ func (_UnionRepresentation_Envelope__KeyAssembler) AssignBytes([]byte) error {
 func (_UnionRepresentation_Envelope__KeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.UnionRepresentation_Envelope.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_UnionRepresentation_Envelope__KeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_UnionRepresentation_Envelope__KeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -40737,7 +40737,7 @@ func (_UnionRepresentation_Envelope__ReprAssembler) AssignBytes([]byte) error {
 func (_UnionRepresentation_Envelope__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.UnionRepresentation_Envelope.Repr"}.AssignLink(nil)
 }
-func (na *_UnionRepresentation_Envelope__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_UnionRepresentation_Envelope__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -40758,7 +40758,7 @@ func (na *_UnionRepresentation_Envelope__ReprAssembler) AssignNode(v ipld.Node) 
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.UnionRepresentation_Envelope.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.UnionRepresentation_Envelope.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -40766,10 +40766,10 @@ func (na *_UnionRepresentation_Envelope__ReprAssembler) AssignNode(v ipld.Node) 
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -41006,7 +41006,7 @@ func (_UnionRepresentation_Envelope__ReprKeyAssembler) AssignBytes([]byte) error
 func (_UnionRepresentation_Envelope__ReprKeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.UnionRepresentation_Envelope.Repr.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_UnionRepresentation_Envelope__ReprKeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_UnionRepresentation_Envelope__ReprKeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -41252,7 +41252,7 @@ func (_UnionRepresentation_Inline__Assembler) AssignBytes([]byte) error {
 func (_UnionRepresentation_Inline__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.UnionRepresentation_Inline"}.AssignLink(nil)
 }
-func (na *_UnionRepresentation_Inline__Assembler) AssignNode(v ipld.Node) error {
+func (na *_UnionRepresentation_Inline__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -41273,7 +41273,7 @@ func (na *_UnionRepresentation_Inline__Assembler) AssignNode(v ipld.Node) error 
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.UnionRepresentation_Inline", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.UnionRepresentation_Inline", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -41281,10 +41281,10 @@ func (na *_UnionRepresentation_Inline__Assembler) AssignNode(v ipld.Node) error 
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -41490,7 +41490,7 @@ func (_UnionRepresentation_Inline__KeyAssembler) AssignBytes([]byte) error {
 func (_UnionRepresentation_Inline__KeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.UnionRepresentation_Inline.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_UnionRepresentation_Inline__KeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_UnionRepresentation_Inline__KeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -41695,7 +41695,7 @@ func (_UnionRepresentation_Inline__ReprAssembler) AssignBytes([]byte) error {
 func (_UnionRepresentation_Inline__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.UnionRepresentation_Inline.Repr"}.AssignLink(nil)
 }
-func (na *_UnionRepresentation_Inline__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_UnionRepresentation_Inline__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -41716,7 +41716,7 @@ func (na *_UnionRepresentation_Inline__ReprAssembler) AssignNode(v ipld.Node) er
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.UnionRepresentation_Inline.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.UnionRepresentation_Inline.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -41724,10 +41724,10 @@ func (na *_UnionRepresentation_Inline__ReprAssembler) AssignNode(v ipld.Node) er
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -41931,7 +41931,7 @@ func (_UnionRepresentation_Inline__ReprKeyAssembler) AssignBytes([]byte) error {
 func (_UnionRepresentation_Inline__ReprKeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.UnionRepresentation_Inline.Repr.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_UnionRepresentation_Inline__ReprKeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_UnionRepresentation_Inline__ReprKeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -42203,7 +42203,7 @@ func (_UnionRepresentation_Keyed__Assembler) AssignBytes([]byte) error {
 func (_UnionRepresentation_Keyed__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.UnionRepresentation_Keyed"}.AssignLink(nil)
 }
-func (na *_UnionRepresentation_Keyed__Assembler) AssignNode(v ipld.Node) error {
+func (na *_UnionRepresentation_Keyed__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -42224,7 +42224,7 @@ func (na *_UnionRepresentation_Keyed__Assembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.UnionRepresentation_Keyed", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.UnionRepresentation_Keyed", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -42232,10 +42232,10 @@ func (na *_UnionRepresentation_Keyed__Assembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -42545,7 +42545,7 @@ func (_UnionRepresentation_Keyed__ReprAssembler) AssignBytes([]byte) error {
 func (_UnionRepresentation_Keyed__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.UnionRepresentation_Keyed.Repr"}.AssignLink(nil)
 }
-func (na *_UnionRepresentation_Keyed__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_UnionRepresentation_Keyed__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -42566,7 +42566,7 @@ func (na *_UnionRepresentation_Keyed__ReprAssembler) AssignNode(v ipld.Node) err
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.UnionRepresentation_Keyed.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.UnionRepresentation_Keyed.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -42574,10 +42574,10 @@ func (na *_UnionRepresentation_Keyed__ReprAssembler) AssignNode(v ipld.Node) err
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -42972,7 +42972,7 @@ func (_UnionRepresentation_Kinded__Assembler) AssignBytes([]byte) error {
 func (_UnionRepresentation_Kinded__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.UnionRepresentation_Kinded"}.AssignLink(nil)
 }
-func (na *_UnionRepresentation_Kinded__Assembler) AssignNode(v ipld.Node) error {
+func (na *_UnionRepresentation_Kinded__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -42993,7 +42993,7 @@ func (na *_UnionRepresentation_Kinded__Assembler) AssignNode(v ipld.Node) error 
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.UnionRepresentation_Kinded", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.UnionRepresentation_Kinded", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -43001,10 +43001,10 @@ func (na *_UnionRepresentation_Kinded__Assembler) AssignNode(v ipld.Node) error 
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -43314,7 +43314,7 @@ func (_UnionRepresentation_Kinded__ReprAssembler) AssignBytes([]byte) error {
 func (_UnionRepresentation_Kinded__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.UnionRepresentation_Kinded.Repr"}.AssignLink(nil)
 }
-func (na *_UnionRepresentation_Kinded__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_UnionRepresentation_Kinded__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -43335,7 +43335,7 @@ func (na *_UnionRepresentation_Kinded__ReprAssembler) AssignNode(v ipld.Node) er
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.UnionRepresentation_Kinded.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.UnionRepresentation_Kinded.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -43343,10 +43343,10 @@ func (na *_UnionRepresentation_Kinded__ReprAssembler) AssignNode(v ipld.Node) er
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -43703,7 +43703,7 @@ func (_UnionRepresentation_StringPrefix__Assembler) AssignBytes([]byte) error {
 func (_UnionRepresentation_StringPrefix__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.UnionRepresentation_StringPrefix"}.AssignLink(nil)
 }
-func (na *_UnionRepresentation_StringPrefix__Assembler) AssignNode(v ipld.Node) error {
+func (na *_UnionRepresentation_StringPrefix__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -43724,7 +43724,7 @@ func (na *_UnionRepresentation_StringPrefix__Assembler) AssignNode(v ipld.Node) 
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.UnionRepresentation_StringPrefix", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.UnionRepresentation_StringPrefix", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -43732,10 +43732,10 @@ func (na *_UnionRepresentation_StringPrefix__Assembler) AssignNode(v ipld.Node) 
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -43907,7 +43907,7 @@ func (_UnionRepresentation_StringPrefix__KeyAssembler) AssignBytes([]byte) error
 func (_UnionRepresentation_StringPrefix__KeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.UnionRepresentation_StringPrefix.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_UnionRepresentation_StringPrefix__KeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_UnionRepresentation_StringPrefix__KeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -44104,7 +44104,7 @@ func (_UnionRepresentation_StringPrefix__ReprAssembler) AssignBytes([]byte) erro
 func (_UnionRepresentation_StringPrefix__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.UnionRepresentation_StringPrefix.Repr"}.AssignLink(nil)
 }
-func (na *_UnionRepresentation_StringPrefix__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_UnionRepresentation_StringPrefix__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -44125,7 +44125,7 @@ func (na *_UnionRepresentation_StringPrefix__ReprAssembler) AssignNode(v ipld.No
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.UnionRepresentation_StringPrefix.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.UnionRepresentation_StringPrefix.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -44133,10 +44133,10 @@ func (na *_UnionRepresentation_StringPrefix__ReprAssembler) AssignNode(v ipld.No
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -44307,7 +44307,7 @@ func (_UnionRepresentation_StringPrefix__ReprKeyAssembler) AssignBytes([]byte) e
 func (_UnionRepresentation_StringPrefix__ReprKeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.UnionRepresentation_StringPrefix.Repr.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_UnionRepresentation_StringPrefix__ReprKeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_UnionRepresentation_StringPrefix__ReprKeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -44527,7 +44527,7 @@ func (_Unit__Assembler) AssignBytes([]byte) error {
 func (_Unit__Assembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.Unit"}.AssignLink(nil)
 }
-func (na *_Unit__Assembler) AssignNode(v ipld.Node) error {
+func (na *_Unit__Assembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -44548,7 +44548,7 @@ func (na *_Unit__Assembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.Unit", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.Unit", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -44556,10 +44556,10 @@ func (na *_Unit__Assembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -44697,7 +44697,7 @@ func (_Unit__KeyAssembler) AssignBytes([]byte) error {
 func (_Unit__KeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.Unit.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_Unit__KeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_Unit__KeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {
@@ -44885,7 +44885,7 @@ func (_Unit__ReprAssembler) AssignBytes([]byte) error {
 func (_Unit__ReprAssembler) AssignLink(ipld.Link) error {
 	return mixins.MapAssembler{"schemadmt.Unit.Repr"}.AssignLink(nil)
 }
-func (na *_Unit__ReprAssembler) AssignNode(v ipld.Node) error {
+func (na *_Unit__ReprAssembler) ConvertFrom(v ipld.Node) error {
 	if v.IsNull() {
 		return na.AssignNull()
 	}
@@ -44906,7 +44906,7 @@ func (na *_Unit__ReprAssembler) AssignNode(v ipld.Node) error {
 		return nil
 	}
 	if v.ReprKind() != ipld.ReprKind_Map {
-		return ipld.ErrWrongKind{TypeName: "schemadmt.Unit.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+		return ipld.ErrWrongKind{TypeName: "schemadmt.Unit.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 	}
 	itr := v.MapIterator()
 	for !itr.Done() {
@@ -44914,10 +44914,10 @@ func (na *_Unit__ReprAssembler) AssignNode(v ipld.Node) error {
 		if err != nil {
 			return err
 		}
-		if err := na.AssembleKey().AssignNode(k); err != nil {
+		if err := na.AssembleKey().ConvertFrom(k); err != nil {
 			return err
 		}
-		if err := na.AssembleValue().AssignNode(v); err != nil {
+		if err := na.AssembleValue().ConvertFrom(v); err != nil {
 			return err
 		}
 	}
@@ -45055,7 +45055,7 @@ func (_Unit__ReprKeyAssembler) AssignBytes([]byte) error {
 func (_Unit__ReprKeyAssembler) AssignLink(ipld.Link) error {
 	return mixins.StringAssembler{"schemadmt.Unit.Repr.KeyAssembler"}.AssignLink(nil)
 }
-func (ka *_Unit__ReprKeyAssembler) AssignNode(v ipld.Node) error {
+func (ka *_Unit__ReprKeyAssembler) ConvertFrom(v ipld.Node) error {
 	if v2, err := v.AsString(); err != nil {
 		return err
 	} else {

--- a/schema/gen/go/genBool.go
+++ b/schema/gen/go/genBool.go
@@ -111,8 +111,8 @@ func (g boolBuilderGenerator) EmitNodeAssemblerMethodAssignNull(w io.Writer) {
 func (g boolBuilderGenerator) EmitNodeAssemblerMethodAssignBool(w io.Writer) {
 	emitNodeAssemblerMethodAssignKind_scalar(w, g.AdjCfg, g)
 }
-func (g boolBuilderGenerator) EmitNodeAssemblerMethodAssignNode(w io.Writer) {
-	emitNodeAssemblerMethodAssignNode_scalar(w, g.AdjCfg, g)
+func (g boolBuilderGenerator) EmitNodeAssemblerMethodConvertFrom(w io.Writer) {
+	emitNodeAssemblerMethodConvertFrom_scalar(w, g.AdjCfg, g)
 }
 func (g boolBuilderGenerator) EmitNodeAssemblerOtherBits(w io.Writer) {
 	// Nothing needed here for bool kinds.

--- a/schema/gen/go/genBoolReprBool.go
+++ b/schema/gen/go/genBoolReprBool.go
@@ -103,6 +103,6 @@ func (boolReprBoolReprBuilderGenerator) EmitNodeAssemblerMethodAssignFloat(io.Wr
 func (boolReprBoolReprBuilderGenerator) EmitNodeAssemblerMethodAssignString(io.Writer) {}
 func (boolReprBoolReprBuilderGenerator) EmitNodeAssemblerMethodAssignBytes(io.Writer)  {}
 func (boolReprBoolReprBuilderGenerator) EmitNodeAssemblerMethodAssignLink(io.Writer)   {}
-func (boolReprBoolReprBuilderGenerator) EmitNodeAssemblerMethodAssignNode(io.Writer)   {}
+func (boolReprBoolReprBuilderGenerator) EmitNodeAssemblerMethodConvertFrom(io.Writer)   {}
 func (boolReprBoolReprBuilderGenerator) EmitNodeAssemblerMethodPrototype(io.Writer)    {}
 func (boolReprBoolReprBuilderGenerator) EmitNodeAssemblerOtherBits(io.Writer)          {}

--- a/schema/gen/go/genBytes.go
+++ b/schema/gen/go/genBytes.go
@@ -111,8 +111,8 @@ func (g bytesBuilderGenerator) EmitNodeAssemblerMethodAssignNull(w io.Writer) {
 func (g bytesBuilderGenerator) EmitNodeAssemblerMethodAssignBytes(w io.Writer) {
 	emitNodeAssemblerMethodAssignKind_scalar(w, g.AdjCfg, g)
 }
-func (g bytesBuilderGenerator) EmitNodeAssemblerMethodAssignNode(w io.Writer) {
-	emitNodeAssemblerMethodAssignNode_scalar(w, g.AdjCfg, g)
+func (g bytesBuilderGenerator) EmitNodeAssemblerMethodConvertFrom(w io.Writer) {
+	emitNodeAssemblerMethodConvertFrom_scalar(w, g.AdjCfg, g)
 }
 func (g bytesBuilderGenerator) EmitNodeAssemblerOtherBits(w io.Writer) {
 	// Nothing needed here for bytes kinds.

--- a/schema/gen/go/genBytesReprBytes.go
+++ b/schema/gen/go/genBytesReprBytes.go
@@ -103,6 +103,6 @@ func (bytesReprBytesReprBuilderGenerator) EmitNodeAssemblerMethodAssignFloat(io.
 func (bytesReprBytesReprBuilderGenerator) EmitNodeAssemblerMethodAssignString(io.Writer) {}
 func (bytesReprBytesReprBuilderGenerator) EmitNodeAssemblerMethodAssignBytes(io.Writer)  {}
 func (bytesReprBytesReprBuilderGenerator) EmitNodeAssemblerMethodAssignLink(io.Writer)   {}
-func (bytesReprBytesReprBuilderGenerator) EmitNodeAssemblerMethodAssignNode(io.Writer)   {}
+func (bytesReprBytesReprBuilderGenerator) EmitNodeAssemblerMethodConvertFrom(io.Writer)   {}
 func (bytesReprBytesReprBuilderGenerator) EmitNodeAssemblerMethodPrototype(io.Writer)    {}
 func (bytesReprBytesReprBuilderGenerator) EmitNodeAssemblerOtherBits(io.Writer)          {}

--- a/schema/gen/go/genFloat.go
+++ b/schema/gen/go/genFloat.go
@@ -111,8 +111,8 @@ func (g float64BuilderGenerator) EmitNodeAssemblerMethodAssignNull(w io.Writer) 
 func (g float64BuilderGenerator) EmitNodeAssemblerMethodAssignFloat(w io.Writer) {
 	emitNodeAssemblerMethodAssignKind_scalar(w, g.AdjCfg, g)
 }
-func (g float64BuilderGenerator) EmitNodeAssemblerMethodAssignNode(w io.Writer) {
-	emitNodeAssemblerMethodAssignNode_scalar(w, g.AdjCfg, g)
+func (g float64BuilderGenerator) EmitNodeAssemblerMethodConvertFrom(w io.Writer) {
+	emitNodeAssemblerMethodConvertFrom_scalar(w, g.AdjCfg, g)
 }
 func (g float64BuilderGenerator) EmitNodeAssemblerOtherBits(w io.Writer) {
 	// Nothing needed here for float64 kinds.

--- a/schema/gen/go/genFloatReprFloat.go
+++ b/schema/gen/go/genFloatReprFloat.go
@@ -103,6 +103,6 @@ func (float64ReprFloatReprBuilderGenerator) EmitNodeAssemblerMethodAssignFloat(i
 func (float64ReprFloatReprBuilderGenerator) EmitNodeAssemblerMethodAssignString(io.Writer) {}
 func (float64ReprFloatReprBuilderGenerator) EmitNodeAssemblerMethodAssignBytes(io.Writer)  {}
 func (float64ReprFloatReprBuilderGenerator) EmitNodeAssemblerMethodAssignLink(io.Writer)   {}
-func (float64ReprFloatReprBuilderGenerator) EmitNodeAssemblerMethodAssignNode(io.Writer)   {}
+func (float64ReprFloatReprBuilderGenerator) EmitNodeAssemblerMethodConvertFrom(io.Writer)   {}
 func (float64ReprFloatReprBuilderGenerator) EmitNodeAssemblerMethodPrototype(io.Writer)    {}
 func (float64ReprFloatReprBuilderGenerator) EmitNodeAssemblerOtherBits(io.Writer)          {}

--- a/schema/gen/go/genInt.go
+++ b/schema/gen/go/genInt.go
@@ -111,8 +111,8 @@ func (g intBuilderGenerator) EmitNodeAssemblerMethodAssignNull(w io.Writer) {
 func (g intBuilderGenerator) EmitNodeAssemblerMethodAssignInt(w io.Writer) {
 	emitNodeAssemblerMethodAssignKind_scalar(w, g.AdjCfg, g)
 }
-func (g intBuilderGenerator) EmitNodeAssemblerMethodAssignNode(w io.Writer) {
-	emitNodeAssemblerMethodAssignNode_scalar(w, g.AdjCfg, g)
+func (g intBuilderGenerator) EmitNodeAssemblerMethodConvertFrom(w io.Writer) {
+	emitNodeAssemblerMethodConvertFrom_scalar(w, g.AdjCfg, g)
 }
 func (g intBuilderGenerator) EmitNodeAssemblerOtherBits(w io.Writer) {
 	// Nothing needed here for int kinds.

--- a/schema/gen/go/genIntReprInt.go
+++ b/schema/gen/go/genIntReprInt.go
@@ -103,6 +103,6 @@ func (intReprIntReprBuilderGenerator) EmitNodeAssemblerMethodAssignFloat(io.Writ
 func (intReprIntReprBuilderGenerator) EmitNodeAssemblerMethodAssignString(io.Writer) {}
 func (intReprIntReprBuilderGenerator) EmitNodeAssemblerMethodAssignBytes(io.Writer)  {}
 func (intReprIntReprBuilderGenerator) EmitNodeAssemblerMethodAssignLink(io.Writer)   {}
-func (intReprIntReprBuilderGenerator) EmitNodeAssemblerMethodAssignNode(io.Writer)   {}
+func (intReprIntReprBuilderGenerator) EmitNodeAssemblerMethodConvertFrom(io.Writer)   {}
 func (intReprIntReprBuilderGenerator) EmitNodeAssemblerMethodPrototype(io.Writer)    {}
 func (intReprIntReprBuilderGenerator) EmitNodeAssemblerOtherBits(io.Writer)          {}

--- a/schema/gen/go/genLink.go
+++ b/schema/gen/go/genLink.go
@@ -120,8 +120,8 @@ func (g linkBuilderGenerator) EmitNodeAssemblerMethodAssignNull(w io.Writer) {
 func (g linkBuilderGenerator) EmitNodeAssemblerMethodAssignLink(w io.Writer) {
 	emitNodeAssemblerMethodAssignKind_scalar(w, g.AdjCfg, g)
 }
-func (g linkBuilderGenerator) EmitNodeAssemblerMethodAssignNode(w io.Writer) {
-	emitNodeAssemblerMethodAssignNode_scalar(w, g.AdjCfg, g)
+func (g linkBuilderGenerator) EmitNodeAssemblerMethodConvertFrom(w io.Writer) {
+	emitNodeAssemblerMethodConvertFrom_scalar(w, g.AdjCfg, g)
 }
 func (g linkBuilderGenerator) EmitNodeAssemblerOtherBits(w io.Writer) {
 	// Nothing needed here for link kinds.

--- a/schema/gen/go/genLinkReprLink.go
+++ b/schema/gen/go/genLinkReprLink.go
@@ -103,6 +103,6 @@ func (linkReprLinkReprBuilderGenerator) EmitNodeAssemblerMethodAssignFloat(io.Wr
 func (linkReprLinkReprBuilderGenerator) EmitNodeAssemblerMethodAssignString(io.Writer) {}
 func (linkReprLinkReprBuilderGenerator) EmitNodeAssemblerMethodAssignBytes(io.Writer)  {}
 func (linkReprLinkReprBuilderGenerator) EmitNodeAssemblerMethodAssignLink(io.Writer)   {}
-func (linkReprLinkReprBuilderGenerator) EmitNodeAssemblerMethodAssignNode(io.Writer)   {}
+func (linkReprLinkReprBuilderGenerator) EmitNodeAssemblerMethodConvertFrom(io.Writer)   {}
 func (linkReprLinkReprBuilderGenerator) EmitNodeAssemblerMethodPrototype(io.Writer)    {}
 func (linkReprLinkReprBuilderGenerator) EmitNodeAssemblerOtherBits(io.Writer)          {}

--- a/schema/gen/go/genList.go
+++ b/schema/gen/go/genList.go
@@ -288,8 +288,8 @@ func (g listBuilderGenerator) EmitNodeAssemblerMethodBeginList(w io.Writer) {
 func (g listBuilderGenerator) EmitNodeAssemblerMethodAssignNull(w io.Writer) {
 	emitNodeAssemblerMethodAssignNull_recursive(w, g.AdjCfg, g)
 }
-func (g listBuilderGenerator) EmitNodeAssemblerMethodAssignNode(w io.Writer) {
-	emitNodeAssemblerMethodAssignNode_listoid(w, g.AdjCfg, g)
+func (g listBuilderGenerator) EmitNodeAssemblerMethodConvertFrom(w io.Writer) {
+	emitNodeAssemblerMethodConvertFrom_listoid(w, g.AdjCfg, g)
 }
 func (g listBuilderGenerator) EmitNodeAssemblerOtherBits(w io.Writer) {
 	emitNodeAssemblerHelper_listoid_tidyHelper(w, g.AdjCfg, g)

--- a/schema/gen/go/genListReprList.go
+++ b/schema/gen/go/genListReprList.go
@@ -197,8 +197,8 @@ func (g listReprListReprBuilderGenerator) EmitNodeAssemblerMethodBeginList(w io.
 func (g listReprListReprBuilderGenerator) EmitNodeAssemblerMethodAssignNull(w io.Writer) {
 	emitNodeAssemblerMethodAssignNull_recursive(w, g.AdjCfg, g)
 }
-func (g listReprListReprBuilderGenerator) EmitNodeAssemblerMethodAssignNode(w io.Writer) {
-	emitNodeAssemblerMethodAssignNode_listoid(w, g.AdjCfg, g)
+func (g listReprListReprBuilderGenerator) EmitNodeAssemblerMethodConvertFrom(w io.Writer) {
+	emitNodeAssemblerMethodConvertFrom_listoid(w, g.AdjCfg, g)
 }
 func (g listReprListReprBuilderGenerator) EmitNodeAssemblerOtherBits(w io.Writer) {
 	emitNodeAssemblerHelper_listoid_tidyHelper(w, g.AdjCfg, g)

--- a/schema/gen/go/genMap.go
+++ b/schema/gen/go/genMap.go
@@ -339,8 +339,8 @@ func (g mapBuilderGenerator) EmitNodeAssemblerMethodBeginMap(w io.Writer) {
 func (g mapBuilderGenerator) EmitNodeAssemblerMethodAssignNull(w io.Writer) {
 	emitNodeAssemblerMethodAssignNull_recursive(w, g.AdjCfg, g)
 }
-func (g mapBuilderGenerator) EmitNodeAssemblerMethodAssignNode(w io.Writer) {
-	emitNodeAssemblerMethodAssignNode_mapoid(w, g.AdjCfg, g)
+func (g mapBuilderGenerator) EmitNodeAssemblerMethodConvertFrom(w io.Writer) {
+	emitNodeAssemblerMethodConvertFrom_mapoid(w, g.AdjCfg, g)
 }
 func (g mapBuilderGenerator) EmitNodeAssemblerOtherBits(w io.Writer) {
 	emitNodeAssemblerHelper_mapoid_keyTidyHelper(w, g.AdjCfg, g)

--- a/schema/gen/go/genMapReprMap.go
+++ b/schema/gen/go/genMapReprMap.go
@@ -196,8 +196,8 @@ func (g mapReprMapReprBuilderGenerator) EmitNodeAssemblerMethodBeginMap(w io.Wri
 func (g mapReprMapReprBuilderGenerator) EmitNodeAssemblerMethodAssignNull(w io.Writer) {
 	emitNodeAssemblerMethodAssignNull_recursive(w, g.AdjCfg, g)
 }
-func (g mapReprMapReprBuilderGenerator) EmitNodeAssemblerMethodAssignNode(w io.Writer) {
-	emitNodeAssemblerMethodAssignNode_mapoid(w, g.AdjCfg, g)
+func (g mapReprMapReprBuilderGenerator) EmitNodeAssemblerMethodConvertFrom(w io.Writer) {
+	emitNodeAssemblerMethodConvertFrom_mapoid(w, g.AdjCfg, g)
 }
 func (g mapReprMapReprBuilderGenerator) EmitNodeAssemblerOtherBits(w io.Writer) {
 	emitNodeAssemblerHelper_mapoid_keyTidyHelper(w, g.AdjCfg, g)

--- a/schema/gen/go/genString.go
+++ b/schema/gen/go/genString.go
@@ -127,8 +127,8 @@ func (g stringBuilderGenerator) EmitNodeAssemblerMethodAssignNull(w io.Writer) {
 func (g stringBuilderGenerator) EmitNodeAssemblerMethodAssignString(w io.Writer) {
 	emitNodeAssemblerMethodAssignKind_scalar(w, g.AdjCfg, g)
 }
-func (g stringBuilderGenerator) EmitNodeAssemblerMethodAssignNode(w io.Writer) {
-	emitNodeAssemblerMethodAssignNode_scalar(w, g.AdjCfg, g)
+func (g stringBuilderGenerator) EmitNodeAssemblerMethodConvertFrom(w io.Writer) {
+	emitNodeAssemblerMethodConvertFrom_scalar(w, g.AdjCfg, g)
 }
 func (g stringBuilderGenerator) EmitNodeAssemblerOtherBits(w io.Writer) {
 	// Nothing needed here for string kinds.

--- a/schema/gen/go/genStringReprString.go
+++ b/schema/gen/go/genStringReprString.go
@@ -103,6 +103,6 @@ func (stringReprStringReprBuilderGenerator) EmitNodeAssemblerMethodAssignFloat(i
 func (stringReprStringReprBuilderGenerator) EmitNodeAssemblerMethodAssignString(io.Writer) {}
 func (stringReprStringReprBuilderGenerator) EmitNodeAssemblerMethodAssignBytes(io.Writer)  {}
 func (stringReprStringReprBuilderGenerator) EmitNodeAssemblerMethodAssignLink(io.Writer)   {}
-func (stringReprStringReprBuilderGenerator) EmitNodeAssemblerMethodAssignNode(io.Writer)   {}
+func (stringReprStringReprBuilderGenerator) EmitNodeAssemblerMethodConvertFrom(io.Writer)   {}
 func (stringReprStringReprBuilderGenerator) EmitNodeAssemblerMethodPrototype(io.Writer)    {}
 func (stringReprStringReprBuilderGenerator) EmitNodeAssemblerOtherBits(io.Writer)          {}

--- a/schema/gen/go/genStruct.go
+++ b/schema/gen/go/genStruct.go
@@ -280,15 +280,15 @@ func (g structBuilderGenerator) EmitNodeAssemblerMethodBeginMap(w io.Writer) {
 func (g structBuilderGenerator) EmitNodeAssemblerMethodAssignNull(w io.Writer) {
 	emitNodeAssemblerMethodAssignNull_recursive(w, g.AdjCfg, g)
 }
-func (g structBuilderGenerator) EmitNodeAssemblerMethodAssignNode(w io.Writer) {
-	// AssignNode goes through three phases:
+func (g structBuilderGenerator) EmitNodeAssemblerMethodConvertFrom(w io.Writer) {
+	// ConvertFrom goes through three phases:
 	// 1. is it null?  Jump over to AssignNull (which may or may not reject it).
 	// 2. is it our own type?  Handle specially -- we might be able to do efficient things.
 	// 3. is it the right kind to morph into us?  Do so.
 	//
 	// We do not set m=midvalue in phase 3 -- it shouldn't matter unless you're trying to pull off concurrent access, which is wrong and unsafe regardless.
 	doTemplate(`
-		func (na *_{{ .Type | TypeSymbol }}__Assembler) AssignNode(v ipld.Node) error {
+		func (na *_{{ .Type | TypeSymbol }}__Assembler) ConvertFrom(v ipld.Node) error {
 			if v.IsNull() {
 				return na.AssignNull()
 			}
@@ -311,7 +311,7 @@ func (g structBuilderGenerator) EmitNodeAssemblerMethodAssignNode(w io.Writer) {
 				return nil
 			}
 			if v.ReprKind() != ipld.ReprKind_Map {
-				return ipld.ErrWrongKind{TypeName: "{{ .PkgName }}.{{ .Type.Name }}", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+				return ipld.ErrWrongKind{TypeName: "{{ .PkgName }}.{{ .Type.Name }}", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 			}
 			itr := v.MapIterator()
 			for !itr.Done() {
@@ -319,10 +319,10 @@ func (g structBuilderGenerator) EmitNodeAssemblerMethodAssignNode(w io.Writer) {
 				if err != nil {
 					return err
 				}
-				if err := na.AssembleKey().AssignNode(k); err != nil {
+				if err := na.AssembleKey().ConvertFrom(k); err != nil {
 					return err
 				}
-				if err := na.AssembleValue().AssignNode(v); err != nil {
+				if err := na.AssembleValue().ConvertFrom(v); err != nil {
 					return err
 				}
 			}
@@ -575,7 +575,7 @@ func (g structBuilderGenerator) emitKeyAssembler(w io.Writer) {
 	stubs.EmitNodeAssemblerMethodAssignBytes(w)
 	stubs.EmitNodeAssemblerMethodAssignLink(w)
 	doTemplate(`
-		func (ka *_{{ .Type | TypeSymbol }}__KeyAssembler) AssignNode(v ipld.Node) error {
+		func (ka *_{{ .Type | TypeSymbol }}__KeyAssembler) ConvertFrom(v ipld.Node) error {
 			if v2, err := v.AsString(); err != nil {
 				return err
 			} else {

--- a/schema/gen/go/genStructReprStringjoin.go
+++ b/schema/gen/go/genStructReprStringjoin.go
@@ -214,13 +214,13 @@ func (g structReprStringjoinReprBuilderGenerator) EmitNodeAssemblerMethodAssignS
 	`, w, g.AdjCfg, g)
 }
 
-func (g structReprStringjoinReprBuilderGenerator) EmitNodeAssemblerMethodAssignNode(w io.Writer) {
-	// AssignNode goes through three phases:
+func (g structReprStringjoinReprBuilderGenerator) EmitNodeAssemblerMethodConvertFrom(w io.Writer) {
+	// ConvertFrom goes through three phases:
 	// 1. is it null?  Jump over to AssignNull (which may or may not reject it).
 	// 2. is it our own type?  Handle specially -- we might be able to do efficient things.
 	// 3. is it the right kind to morph into us?  Do so.
 	doTemplate(`
-		func (na *_{{ .Type | TypeSymbol }}__ReprAssembler) AssignNode(v ipld.Node) error {
+		func (na *_{{ .Type | TypeSymbol }}__ReprAssembler) ConvertFrom(v ipld.Node) error {
 			if v.IsNull() {
 				return na.AssignNull()
 			}

--- a/schema/gen/go/genStructReprTuple.go
+++ b/schema/gen/go/genStructReprTuple.go
@@ -332,8 +332,8 @@ func (g structReprTupleReprBuilderGenerator) EmitNodeAssemblerMethodBeginList(w 
 func (g structReprTupleReprBuilderGenerator) EmitNodeAssemblerMethodAssignNull(w io.Writer) {
 	emitNodeAssemblerMethodAssignNull_recursive(w, g.AdjCfg, g)
 }
-func (g structReprTupleReprBuilderGenerator) EmitNodeAssemblerMethodAssignNode(w io.Writer) {
-	emitNodeAssemblerMethodAssignNode_listoid(w, g.AdjCfg, g)
+func (g structReprTupleReprBuilderGenerator) EmitNodeAssemblerMethodConvertFrom(w io.Writer) {
+	emitNodeAssemblerMethodConvertFrom_listoid(w, g.AdjCfg, g)
 }
 func (g structReprTupleReprBuilderGenerator) EmitNodeAssemblerOtherBits(w io.Writer) {
 	g.emitListAssemblerChildTidyHelper(w)

--- a/schema/gen/go/genUnion.go
+++ b/schema/gen/go/genUnion.go
@@ -339,8 +339,8 @@ func (g unionBuilderGenerator) EmitNodeAssemblerMethodAssignNull(w io.Writer) {
 	//  but it's functionally accurate: the generated method should include a branch for the 'midvalue' state.
 	emitNodeAssemblerMethodAssignNull_recursive(w, g.AdjCfg, g)
 }
-func (g unionBuilderGenerator) EmitNodeAssemblerMethodAssignNode(w io.Writer) {
-	// AssignNode goes through three phases:
+func (g unionBuilderGenerator) EmitNodeAssemblerMethodConvertFrom(w io.Writer) {
+	// ConvertFrom goes through three phases:
 	// 1. is it null?  Jump over to AssignNull (which may or may not reject it).
 	// 2. is it our own type?  Handle specially -- we might be able to do efficient things.
 	// 3. is it the right kind to morph into us?  Do so.
@@ -349,7 +349,7 @@ func (g unionBuilderGenerator) EmitNodeAssemblerMethodAssignNode(w io.Writer) {
 	//
 	// DRY: this turns out to be textually identical to the method for structs!  (At least, for now.  It could/should probably be optimized to get to the point faster in phase 3.)
 	doTemplate(`
-		func (na *_{{ .Type | TypeSymbol }}__Assembler) AssignNode(v ipld.Node) error {
+		func (na *_{{ .Type | TypeSymbol }}__Assembler) ConvertFrom(v ipld.Node) error {
 			if v.IsNull() {
 				return na.AssignNull()
 			}
@@ -372,7 +372,7 @@ func (g unionBuilderGenerator) EmitNodeAssemblerMethodAssignNode(w io.Writer) {
 				return nil
 			}
 			if v.ReprKind() != ipld.ReprKind_Map {
-				return ipld.ErrWrongKind{TypeName: "{{ .PkgName }}.{{ .Type.Name }}", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+				return ipld.ErrWrongKind{TypeName: "{{ .PkgName }}.{{ .Type.Name }}", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 			}
 			itr := v.MapIterator()
 			for !itr.Done() {
@@ -380,10 +380,10 @@ func (g unionBuilderGenerator) EmitNodeAssemblerMethodAssignNode(w io.Writer) {
 				if err != nil {
 					return err
 				}
-				if err := na.AssembleKey().AssignNode(k); err != nil {
+				if err := na.AssembleKey().ConvertFrom(k); err != nil {
 					return err
 				}
-				if err := na.AssembleValue().AssignNode(v); err != nil {
+				if err := na.AssembleValue().ConvertFrom(v); err != nil {
 					return err
 				}
 			}
@@ -641,7 +641,7 @@ func (g unionBuilderGenerator) emitKeyAssembler(w io.Writer) {
 	stubs.EmitNodeAssemblerMethodAssignBytes(w)
 	stubs.EmitNodeAssemblerMethodAssignLink(w)
 	doTemplate(`
-		func (ka *_{{ .Type | TypeSymbol }}__KeyAssembler) AssignNode(v ipld.Node) error {
+		func (ka *_{{ .Type | TypeSymbol }}__KeyAssembler) ConvertFrom(v ipld.Node) error {
 			if v2, err := v.AsString(); err != nil {
 				return err
 			} else {

--- a/schema/gen/go/genUnionReprKeyed.go
+++ b/schema/gen/go/genUnionReprKeyed.go
@@ -248,10 +248,10 @@ func (g unionReprKeyedReprBuilderGenerator) EmitNodeAssemblerMethodAssignNull(w 
 	//  but it's functionally accurate: the generated method should include a branch for the 'midvalue' state.
 	emitNodeAssemblerMethodAssignNull_recursive(w, g.AdjCfg, g)
 }
-func (g unionReprKeyedReprBuilderGenerator) EmitNodeAssemblerMethodAssignNode(w io.Writer) {
+func (g unionReprKeyedReprBuilderGenerator) EmitNodeAssemblerMethodConvertFrom(w io.Writer) {
 	// DRY: this is once again not-coincidentally very nearly equal to the type-level method.  Would be good to dedup them... after we do the get-to-the-point-in-phase-3 improvement.
 	doTemplate(`
-		func (na *_{{ .Type | TypeSymbol }}__ReprAssembler) AssignNode(v ipld.Node) error {
+		func (na *_{{ .Type | TypeSymbol }}__ReprAssembler) ConvertFrom(v ipld.Node) error {
 			if v.IsNull() {
 				return na.AssignNull()
 			}
@@ -274,7 +274,7 @@ func (g unionReprKeyedReprBuilderGenerator) EmitNodeAssemblerMethodAssignNode(w 
 				return nil
 			}
 			if v.ReprKind() != ipld.ReprKind_Map {
-				return ipld.ErrWrongKind{TypeName: "{{ .PkgName }}.{{ .Type.Name }}.Repr", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+				return ipld.ErrWrongKind{TypeName: "{{ .PkgName }}.{{ .Type.Name }}.Repr", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 			}
 			itr := v.MapIterator()
 			for !itr.Done() {
@@ -282,10 +282,10 @@ func (g unionReprKeyedReprBuilderGenerator) EmitNodeAssemblerMethodAssignNode(w 
 				if err != nil {
 					return err
 				}
-				if err := na.AssembleKey().AssignNode(k); err != nil {
+				if err := na.AssembleKey().ConvertFrom(k); err != nil {
 					return err
 				}
-				if err := na.AssembleValue().AssignNode(v); err != nil {
+				if err := na.AssembleValue().ConvertFrom(v); err != nil {
 					return err
 				}
 			}
@@ -509,7 +509,7 @@ func (g unionReprKeyedReprBuilderGenerator) emitKeyAssembler(w io.Writer) {
 	stubs.EmitNodeAssemblerMethodAssignBytes(w)
 	stubs.EmitNodeAssemblerMethodAssignLink(w)
 	doTemplate(`
-		func (ka *_{{ .Type | TypeSymbol }}__ReprKeyAssembler) AssignNode(v ipld.Node) error {
+		func (ka *_{{ .Type | TypeSymbol }}__ReprKeyAssembler) ConvertFrom(v ipld.Node) error {
 			if v2, err := v.AsString(); err != nil {
 				return err
 			} else {

--- a/schema/gen/go/genUnionReprKinded.go
+++ b/schema/gen/go/genUnionReprKinded.go
@@ -542,8 +542,8 @@ func (g unionReprKindedReprBuilderGenerator) EmitNodeAssemblerMethodAssignLink(w
 		false,
 	), w, g.AdjCfg, g)
 }
-func (g unionReprKindedReprBuilderGenerator) EmitNodeAssemblerMethodAssignNode(w io.Writer) {
-	// This is a very mundane AssignNode: it just calls out to the other methods on this type.
+func (g unionReprKindedReprBuilderGenerator) EmitNodeAssemblerMethodConvertFrom(w io.Writer) {
+	// This is a very mundane ConvertFrom: it just calls out to the other methods on this type.
 	//  However, even that is a little more exciting than usual: because we can't *necessarily* reject any kind of arg,
 	//   we have the whole barrage of switch cases here.  We then leave any particular rejections to those methods.
 	//  Several cases could be statically replaced with errors and it would be an improvement.
@@ -551,7 +551,7 @@ func (g unionReprKindedReprBuilderGenerator) EmitNodeAssemblerMethodAssignNode(w
 	// Errors are problematic again, same as is noted in kindedUnionNodeAssemblerMethodTemplateMunge.
 	//  We also end up returning errors with other method names due to how we delegate; unfortunate.
 	doTemplate(`
-		func (na *_{{ .Type | TypeSymbol }}__ReprAssembler) AssignNode(v ipld.Node) error {
+		func (na *_{{ .Type | TypeSymbol }}__ReprAssembler) ConvertFrom(v ipld.Node) error {
 			if v.IsNull() {
 				return na.AssignNull()
 			}
@@ -600,10 +600,10 @@ func (g unionReprKindedReprBuilderGenerator) EmitNodeAssemblerMethodAssignNode(w
 					if err != nil {
 						return err
 					}
-					if err := na.AssembleKey().AssignNode(k); err != nil {
+					if err := na.AssembleKey().ConvertFrom(k); err != nil {
 						return err
 					}
-					if err := na.AssembleValue().AssignNode(v); err != nil {
+					if err := na.AssembleValue().ConvertFrom(v); err != nil {
 						return err
 					}
 				}
@@ -619,7 +619,7 @@ func (g unionReprKindedReprBuilderGenerator) EmitNodeAssemblerMethodAssignNode(w
 					if err != nil {
 						return err
 					}
-					if err := na.AssembleValue().AssignNode(v); err != nil {
+					if err := na.AssembleValue().ConvertFrom(v); err != nil {
 						return err
 					}
 				}

--- a/schema/gen/go/generators.go
+++ b/schema/gen/go/generators.go
@@ -72,7 +72,7 @@ type NodeBuilderGenerator interface {
 	EmitNodeAssemblerMethodAssignString(io.Writer)
 	EmitNodeAssemblerMethodAssignBytes(io.Writer)
 	EmitNodeAssemblerMethodAssignLink(io.Writer)
-	EmitNodeAssemblerMethodAssignNode(io.Writer)
+	EmitNodeAssemblerMethodConvertFrom(io.Writer)
 	EmitNodeAssemblerMethodPrototype(io.Writer)
 	EmitNodeAssemblerOtherBits(io.Writer) // key and value child assemblers are done here.
 }
@@ -150,7 +150,7 @@ func EmitNode(ng NodeGenerator, w io.Writer) {
 	nbg.EmitNodeAssemblerMethodAssignString(w)
 	nbg.EmitNodeAssemblerMethodAssignBytes(w)
 	nbg.EmitNodeAssemblerMethodAssignLink(w)
-	nbg.EmitNodeAssemblerMethodAssignNode(w)
+	nbg.EmitNodeAssemblerMethodConvertFrom(w)
 	nbg.EmitNodeAssemblerMethodPrototype(w)
 	nbg.EmitNodeAssemblerOtherBits(w)
 }

--- a/schema/gen/go/genpartsCommon.go
+++ b/schema/gen/go/genpartsCommon.go
@@ -252,13 +252,13 @@ func emitNodeAssemblerMethodAssignKind_scalar(w io.Writer, adjCfg *AdjunctCfg, d
 
 // leans heavily on the fact all the AsFoo and AssignFoo methods follow a very consistent textual pattern.
 // FUTURE: may be able to get this to work for recursives, too -- but maps and lists each have very unique bottom thirds of this function.
-func emitNodeAssemblerMethodAssignNode_scalar(w io.Writer, adjCfg *AdjunctCfg, data interface{}) {
-	// AssignNode goes through three phases:
+func emitNodeAssemblerMethodConvertFrom_scalar(w io.Writer, adjCfg *AdjunctCfg, data interface{}) {
+	// ConvertFrom goes through three phases:
 	// 1. is it null?  Jump over to AssignNull (which may or may not reject it).
 	// 2. is it our own type?  Handle specially -- we might be able to do efficient things.
 	// 3. is it the right kind to morph into us?  Do so.
 	doTemplate(`
-		func (na *_{{ .Type | TypeSymbol }}__Assembler) AssignNode(v ipld.Node) error {
+		func (na *_{{ .Type | TypeSymbol }}__Assembler) ConvertFrom(v ipld.Node) error {
 			if v.IsNull() {
 				return na.AssignNull()
 			}

--- a/schema/gen/go/genpartsList.go
+++ b/schema/gen/go/genpartsList.go
@@ -5,7 +5,7 @@ import (
 )
 
 // FIXME docs: these methods all say "-oid" but I think that was overoptimistic and not actually that applicable, really.
-//  AssignNode?  Okay, that one's fine.
+//  ConvertFrom?  Okay, that one's fine.
 //  The rest?  They're all *very* emphatic about knowing either:
 //   - that na.w.x is a slice; or,
 //   - that there's only one 'va' (one type; and that it's reused).
@@ -49,8 +49,8 @@ func emitNodeAssemblerMethodBeginList_listoid(w io.Writer, adjCfg *AdjunctCfg, d
 	`, w, adjCfg, data)
 }
 
-func emitNodeAssemblerMethodAssignNode_listoid(w io.Writer, adjCfg *AdjunctCfg, data interface{}) {
-	// AssignNode goes through three phases:
+func emitNodeAssemblerMethodConvertFrom_listoid(w io.Writer, adjCfg *AdjunctCfg, data interface{}) {
+	// ConvertFrom goes through three phases:
 	// 1. is it null?  Jump over to AssignNull (which may or may not reject it).
 	// 2. is it our own type?  Handle specially -- we might be able to do efficient things.
 	// 3. is it the right kind to morph into us?  Do so.
@@ -60,7 +60,7 @@ func emitNodeAssemblerMethodAssignNode_listoid(w io.Writer, adjCfg *AdjunctCfg, 
 	// This works easily for both type-level and representational nodes because
 	//  any divergences that have to do with the child value are nicely hidden behind `AssembleValue`.
 	doTemplate(`
-		func (na *_{{ .Type | TypeSymbol }}__{{ if .IsRepr }}Repr{{end}}Assembler) AssignNode(v ipld.Node) error {
+		func (na *_{{ .Type | TypeSymbol }}__{{ if .IsRepr }}Repr{{end}}Assembler) ConvertFrom(v ipld.Node) error {
 			if v.IsNull() {
 				return na.AssignNull()
 			}
@@ -83,7 +83,7 @@ func emitNodeAssemblerMethodAssignNode_listoid(w io.Writer, adjCfg *AdjunctCfg, 
 				return nil
 			}
 			if v.ReprKind() != ipld.ReprKind_List {
-				return ipld.ErrWrongKind{TypeName: "{{ .PkgName }}.{{ .Type.Name }}{{ if .IsRepr }}.Repr{{end}}", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: v.ReprKind()}
+				return ipld.ErrWrongKind{TypeName: "{{ .PkgName }}.{{ .Type.Name }}{{ if .IsRepr }}.Repr{{end}}", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: v.ReprKind()}
 			}
 			itr := v.ListIterator()
 			for !itr.Done() {
@@ -91,7 +91,7 @@ func emitNodeAssemblerMethodAssignNode_listoid(w io.Writer, adjCfg *AdjunctCfg, 
 				if err != nil {
 					return err
 				}
-				if err := na.AssembleValue().AssignNode(v); err != nil {
+				if err := na.AssembleValue().ConvertFrom(v); err != nil {
 					return err
 				}
 			}

--- a/schema/gen/go/genpartsMap.go
+++ b/schema/gen/go/genpartsMap.go
@@ -5,7 +5,7 @@ import (
 )
 
 // FIXME docs: these methods all say "-oid" but I think that was overoptimistic and not actually that applicable, really.
-//  AssignNode?  Okay, that one's fine.
+//  ConvertFrom?  Okay, that one's fine.
 //  The rest?  They're all *very* emphatic about knowing either:
 //   - that na.w.t and na.w.m are fields; or,
 //   - that there's only one 'ka' and 'va' (one type each; and that it's reused).
@@ -39,8 +39,8 @@ func emitNodeAssemblerMethodBeginMap_mapoid(w io.Writer, adjCfg *AdjunctCfg, dat
 	`, w, adjCfg, data)
 }
 
-func emitNodeAssemblerMethodAssignNode_mapoid(w io.Writer, adjCfg *AdjunctCfg, data interface{}) {
-	// AssignNode goes through three phases:
+func emitNodeAssemblerMethodConvertFrom_mapoid(w io.Writer, adjCfg *AdjunctCfg, data interface{}) {
+	// ConvertFrom goes through three phases:
 	// 1. is it null?  Jump over to AssignNull (which may or may not reject it).
 	// 2. is it our own type?  Handle specially -- we might be able to do efficient things.
 	// 3. is it the right kind to morph into us?  Do so.
@@ -50,7 +50,7 @@ func emitNodeAssemblerMethodAssignNode_mapoid(w io.Writer, adjCfg *AdjunctCfg, d
 	// This works easily for both type-level and representational nodes because
 	//  any divergences that have to do with the child value are nicely hidden behind  `AssembleKey` and `AssembleValue`.
 	doTemplate(`
-		func (na *_{{ .Type | TypeSymbol }}__{{ if .IsRepr }}Repr{{end}}Assembler) AssignNode(v ipld.Node) error {
+		func (na *_{{ .Type | TypeSymbol }}__{{ if .IsRepr }}Repr{{end}}Assembler) ConvertFrom(v ipld.Node) error {
 			if v.IsNull() {
 				return na.AssignNull()
 			}
@@ -73,7 +73,7 @@ func emitNodeAssemblerMethodAssignNode_mapoid(w io.Writer, adjCfg *AdjunctCfg, d
 				return nil
 			}
 			if v.ReprKind() != ipld.ReprKind_Map {
-				return ipld.ErrWrongKind{TypeName: "{{ .PkgName }}.{{ .Type.Name }}{{ if .IsRepr }}.Repr{{end}}", MethodName: "AssignNode", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
+				return ipld.ErrWrongKind{TypeName: "{{ .PkgName }}.{{ .Type.Name }}{{ if .IsRepr }}.Repr{{end}}", MethodName: "ConvertFrom", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: v.ReprKind()}
 			}
 			itr := v.MapIterator()
 			for !itr.Done() {
@@ -81,10 +81,10 @@ func emitNodeAssemblerMethodAssignNode_mapoid(w io.Writer, adjCfg *AdjunctCfg, d
 				if err != nil {
 					return err
 				}
-				if err := na.AssembleKey().AssignNode(k); err != nil {
+				if err := na.AssembleKey().ConvertFrom(k); err != nil {
 					return err
 				}
-				if err := na.AssembleValue().AssignNode(v); err != nil {
+				if err := na.AssembleValue().ConvertFrom(v); err != nil {
 					return err
 				}
 			}

--- a/schema/gen/go/genpartsMinima.go
+++ b/schema/gen/go/genpartsMinima.go
@@ -80,7 +80,7 @@ func EmitInternalEnums(packageName string, w io.Writer) {
 		func (ea _ErrorThunkAssembler) AssignString(string) error { return ea.e }
 		func (ea _ErrorThunkAssembler) AssignBytes([]byte) error { return ea.e }
 		func (ea _ErrorThunkAssembler) AssignLink(ipld.Link) error { return ea.e }
-		func (ea _ErrorThunkAssembler) AssignNode(ipld.Node) error { return ea.e }
+		func (ea _ErrorThunkAssembler) ConvertFrom(ipld.Node) error { return ea.e }
 		func (ea _ErrorThunkAssembler) Prototype() ipld.NodePrototype {
 			panic(fmt.Errorf("cannot get prototype from error-carrying assembler: already derailed with error: %w", ea.e))
 		}

--- a/schema/gen/go/mixins/kindTraits.go
+++ b/schema/gen/go/mixins/kindTraits.go
@@ -306,7 +306,7 @@ func (g kindAssemblerTraitsGenerator) emitNodeAssemblerMethodAssignLink(w io.Wri
 	`, w, g)
 }
 
-// bailed on extracting a common emitNodeAssemblerMethodAssignNode: way too many variations.
+// bailed on extracting a common emitNodeAssemblerMethodConvertFrom: way too many variations.
 
 func (g kindAssemblerTraitsGenerator) emitNodeAssemblerMethodPrototype(w io.Writer) {
 	doTemplate(`

--- a/traversal/selector/builder/builder.go
+++ b/traversal/selector/builder/builder.go
@@ -88,7 +88,7 @@ func (ssb *selectorSpecBuilder) ExploreRecursive(limit selector.RecursionLimit, 
 						panic("Unsupported recursion limit type")
 					}
 				})
-				na.AssembleEntry(selector.SelectorKey_Sequence).AssignNode(sequence.Node())
+				na.AssembleEntry(selector.SelectorKey_Sequence).ConvertFrom(sequence.Node())
 			})
 		}),
 	}
@@ -98,7 +98,7 @@ func (ssb *selectorSpecBuilder) ExploreAll(next SelectorSpec) SelectorSpec {
 	return selectorSpec{
 		fluent.MustBuildMap(ssb.np, 1, func(na fluent.MapAssembler) {
 			na.AssembleEntry(selector.SelectorKey_ExploreAll).CreateMap(1, func(na fluent.MapAssembler) {
-				na.AssembleEntry(selector.SelectorKey_Next).AssignNode(next.Node())
+				na.AssembleEntry(selector.SelectorKey_Next).ConvertFrom(next.Node())
 			})
 		}),
 	}
@@ -108,7 +108,7 @@ func (ssb *selectorSpecBuilder) ExploreIndex(index int64, next SelectorSpec) Sel
 		fluent.MustBuildMap(ssb.np, 1, func(na fluent.MapAssembler) {
 			na.AssembleEntry(selector.SelectorKey_ExploreIndex).CreateMap(2, func(na fluent.MapAssembler) {
 				na.AssembleEntry(selector.SelectorKey_Index).AssignInt(index)
-				na.AssembleEntry(selector.SelectorKey_Next).AssignNode(next.Node())
+				na.AssembleEntry(selector.SelectorKey_Next).ConvertFrom(next.Node())
 			})
 		}),
 	}
@@ -120,7 +120,7 @@ func (ssb *selectorSpecBuilder) ExploreRange(start, end int64, next SelectorSpec
 			na.AssembleEntry(selector.SelectorKey_ExploreRange).CreateMap(3, func(na fluent.MapAssembler) {
 				na.AssembleEntry(selector.SelectorKey_Start).AssignInt(start)
 				na.AssembleEntry(selector.SelectorKey_End).AssignInt(end)
-				na.AssembleEntry(selector.SelectorKey_Next).AssignNode(next.Node())
+				na.AssembleEntry(selector.SelectorKey_Next).ConvertFrom(next.Node())
 			})
 		}),
 	}
@@ -131,7 +131,7 @@ func (ssb *selectorSpecBuilder) ExploreUnion(members ...SelectorSpec) SelectorSp
 		fluent.MustBuildMap(ssb.np, 1, func(na fluent.MapAssembler) {
 			na.AssembleEntry(selector.SelectorKey_ExploreUnion).CreateList(int64(len(members)), func(na fluent.ListAssembler) {
 				for _, member := range members {
-					na.AssembleValue().AssignNode(member.Node())
+					na.AssembleValue().ConvertFrom(member.Node())
 				}
 			})
 		}),
@@ -163,5 +163,5 @@ type exploreFieldsSpecBuilder struct {
 }
 
 func (efsb exploreFieldsSpecBuilder) Insert(field string, s SelectorSpec) {
-	efsb.na.AssembleEntry(field).AssignNode(s.Node())
+	efsb.na.AssembleEntry(field).ConvertFrom(s.Node())
 }


### PR DESCRIPTION
This should be more intuitive to Go programmers, since assignments are
generally trivial operations, but conversions imply that extra work
might be needed to adapt the value to fit in the recipient.

The entire change is just:

	sed -ri 's/AssignNode/ConvertFrom/g' **/*.go

Downstream users can very likely use the same line to fix their function
declarations and calls.

Fixes #95.