### PR TITLE
Implement traversal.FocusedTransform.

### DIFF
--- a/path.go
+++ b/path.go
@@ -147,11 +147,19 @@ func (p Path) String() string {
 	return sb.String()
 }
 
-// Segements returns a slice of the path segment strings.
+// Segments returns a slice of the path segment strings.
 //
 // It is not lawful to mutate nor append the returned slice.
 func (p Path) Segments() []PathSegment {
 	return p.segments
+}
+
+// Len returns the number of segments in this path.
+//
+// Zero segments means the path refers to "the current node".
+// One segment means it refers to a child of the current node; etc.
+func (p Path) Len() int {
+	return len(p.segments)
 }
 
 // Join creates a new path composed of the concatenation of this and the given path's segments.
@@ -190,4 +198,21 @@ func (p Path) Parent() Path {
 // Truncate returns a path with only as many segments remaining as requested.
 func (p Path) Truncate(i int) Path {
 	return Path{p.segments[0:i]}
+}
+
+// Last returns the trailing segment of the path.
+func (p Path) Last() PathSegment {
+	if len(p.segments) < 1 {
+		return PathSegment{}
+	}
+	return p.segments[len(p.segments)-1]
+}
+
+// Shift returns the first segment of the path together with the remaining path after that first segment.
+// If applied to a zero-length path, it returns an empty segment and the same zero-length path.
+func (p Path) Shift() (PathSegment, Path) {
+	if len(p.segments) < 1 {
+		return PathSegment{}, Path{}
+	}
+	return p.segments[0], Path{p.segments[1:]}
 }

--- a/traversal/common.go
+++ b/traversal/common.go
@@ -45,3 +45,24 @@ func (prog *Progress) init() {
 	}
 	prog.Cfg.init()
 }
+
+// asPathSegment figures out how to coerce a node into a PathSegment.
+// If it's a typed node: we take its representation.  (Could be a struct with some string representation.)
+// If it's a string or an int, that's it.
+// Any other case will panic.  (If you're using this one keys returned by a MapIterator, though, you can ignore this possibility;
+// any compliant map implementation should've already rejected that data long ago, and should not be able to yield it to you from an iterator.)
+func asPathSegment(n ipld.Node) ipld.PathSegment {
+	if n2, ok := n.(schema.TypedNode); ok {
+		n = n2.Representation()
+	}
+	switch n.Kind() {
+	case ipld.Kind_String:
+		s, _ := n.AsString()
+		return ipld.PathSegmentOfString(s)
+	case ipld.Kind_Int:
+		i, _ := n.AsInt()
+		return ipld.PathSegmentOfInt(i)
+	default:
+		panic(fmt.Errorf("cannot get pathsegment from a %s", n.Kind()))
+	}
+}


### PR DESCRIPTION
`traversal.FocusedTransform` is now available.  It takes a starting Node, a Path, and a TransformFn (which is essentially just a function from Node to Node), and uses those instructions to build a new Node tree with the transform applied at the given path.

Like all the other `traversal.*` functions, it carries a `traversal.Progress` object around, which you can use in the TransformFn to see where you are, or to do continued traversals or transformations at deeper levels of the data while keeping a coherent track of overall position, etc.

This works even if the Path happens to cross links!  If you've configured enough Loader and Storer functions in the `traversal.Config`, any links crossed will be automatically loaded, the transform will continue inside, and when the transform is complete, the data beyond the link will be reserialized in the same style as the original link (e.g. in the case of CIDs, that means: same multicodec will be used, same multihash will be used, etc etc), and the link will be replaced with a link to the new data, which will also have been stored.

This patch also includes a few new accessors for Path that are helpful and reasonable.