### PR TITLE
Introduce 'quip' data building helpers.

### DIFF
--- a/fluent/quip/operations.go
+++ b/fluent/quip/operations.go
@@ -1,0 +1,32 @@
+package quip
+
+import (
+	"github.com/ipld/go-ipld-prime"
+)
+
+func CopyRange(e *error, la ipld.ListAssembler, src ipld.Node, start, end int64) {
+	if *e != nil {
+		return
+	}
+	if start >= src.Length() {
+		return
+	}
+	if end < 0 {
+		end = src.Length()
+	}
+	if end < start {
+		return
+	}
+	for i := start; i < end; i++ {
+		n, err := src.LookupByIndex(i)
+		if err != nil {
+			*e = err
+			return
+		}
+		if err := la.AssembleValue().AssignNode(n); err != nil {
+			*e = err
+			return
+		}
+	}
+	return
+}

--- a/fluent/quip/quip.go
+++ b/fluent/quip/quip.go
@@ -1,0 +1,146 @@
+// quip is a package of quick ipld patterns.
+//
+// Most quip functions take a pointer to an error as their first argument.
+// This has two purposes: if there's an error there, the quip function will do nothing;
+// and if the quip function does something and creates an error, it puts it there.
+// The effect of this is that most logic can be written very linearly.
+//
+// quip functions can be used to increase brevity without worrying about performance costs.
+// None of the quip functions cause additional allocations in the course of their work.
+// Benchmarks indicate no measurable speed penalties versus longhand manual error checking.
+//
+// This package is currently considered experimental, and may change.
+// Feel free to use it, but be advised that code using it may require frequent
+// updating until things settle; naming conventions in this package may be
+// revised with relatively little warning.
+package quip
+
+import (
+	"github.com/ipld/go-ipld-prime"
+)
+
+// TODO:REVIEW: a few things about this outline and its symbol naming:
+//  - consistency/nomenclature check:
+//    - fluent package uses "BuildMap" at package scope.  And then "CreateMap" on its NB facade (which takes a callback param).  It's calling "NodeBuilder.BeginMap" internally, of course.  (is fluent's current choice odd and deserving of revising?)
+//      - the "Build" vs "Create" prefixes here indicate methods that start with a builder or prototype and return a full node, vs methods that work on assemblers.  (the fluent package doesn't have any methods that *don't* take callbacks, so there's no name component to talk about that.)
+//    - here currently we've used "BeginMap" for something that returns a MapAssembler (consistent with ipld.NB), and "BuildMap" takes a callback.
+//  - ditto the above bullet tree for List instead of Map.
+//  - many of these methods could have varying parameter types: ipld.Node forms, interface{} and dtrt forms, and callback-taking-assembler forms.  They all need unique names.
+//    - this is the case for values, and similarly for keys (though for keys the most important ones are probably string | ipld.Node | pathSegment).  The crossproduct there is sizable.
+//    - do we want to fill out this matrix completely?
+//    - what naming convention can we use to make this consistent?
+//  - do we actually want the non-callback/returns-MapAssembler BeginMap style to be something this package bothers to export?
+//    - hard to imagine actually wanting to use these.
+//    - since it turns out that the callbacks *do* get optimized quite reasonably by the compiler in common cases, there's no reason to avoid them.
+
+// TODO: a few notable gaps in what's provided, which should improve terseness even more:
+//  - we don't have top-level functions for doing a full Build returning a Node (and saving you the np.NewBuilder preamble and nb.Build postamble).  see naming issues discussion.
+//  - we don't have great shorthand for scalar assignment at the leaves.  current best is a composition like `quip.AbsorbError(&err, na.AssignString(x))`.
+//    - do we want to make an `quip.Assign{Kind}(*error, *ipld.NodeAssembler, {kindPrimitive})` for each kind?  seems like a lot of symbols.
+//    - there's also generally a whole `quip.MapEntry(... {...})` or `ListEntry` clause around *that*, with the single Absorb+Assign line in the middle.  that's boilerplate that needs trimming as well.
+//      - so... twice as many Assign helpers, because it's kinda necessary to specialize them to map and list assemblers too?  uff.
+
+func AbsorbError(e *error, err error) {
+	if *e != nil {
+		return
+	}
+	if err != nil {
+		*e = err
+	}
+}
+
+func BeginMap(e *error, na ipld.NodeAssembler, sizeHint int64) ipld.MapAssembler {
+	if *e != nil {
+		return nil
+	}
+	ma, err := na.BeginMap(sizeHint)
+	if err != nil {
+		*e = err
+		return nil
+	}
+	return ma
+}
+
+func BuildMap(e *error, na ipld.NodeAssembler, sizeHint int64, fn func(ma ipld.MapAssembler)) {
+	if *e != nil {
+		return
+	}
+	ma, err := na.BeginMap(sizeHint)
+	if err != nil {
+		*e = err
+		return
+	}
+	fn(ma)
+	*e = ma.Finish()
+}
+
+func MapEntry(e *error, ma ipld.MapAssembler, k string, fn func(va ipld.NodeAssembler)) {
+	if *e != nil {
+		return
+	}
+	va, err := ma.AssembleEntry(k)
+	if err != nil {
+		*e = err
+		return
+	}
+	fn(va)
+}
+
+func BeginList(e *error, na ipld.NodeAssembler, sizeHint int64) ipld.ListAssembler {
+	if *e != nil {
+		return nil
+	}
+	la, err := na.BeginList(sizeHint)
+	if err != nil {
+		*e = err
+		return nil
+	}
+	return la
+}
+
+func BuildList(e *error, na ipld.NodeAssembler, sizeHint int64, fn func(la ipld.ListAssembler)) {
+	if *e != nil {
+		return
+	}
+	la, err := na.BeginList(sizeHint)
+	if err != nil {
+		*e = err
+		return
+	}
+	fn(la)
+	*e = la.Finish()
+}
+
+func ListEntry(e *error, la ipld.ListAssembler, fn func(va ipld.NodeAssembler)) {
+	if *e != nil {
+		return
+	}
+	fn(la.AssembleValue())
+}
+
+func CopyRange(e *error, la ipld.ListAssembler, src ipld.Node, start, end int64) {
+	if *e != nil {
+		return
+	}
+	if start >= src.Length() {
+		return
+	}
+	if end < 0 {
+		end = src.Length()
+	}
+	if end < start {
+		return
+	}
+	for i := start; i < end; i++ {
+		n, err := src.LookupByIndex(i)
+		if err != nil {
+			*e = err
+			return
+		}
+		if err := la.AssembleValue().AssignNode(n); err != nil {
+			*e = err
+			return
+		}
+	}
+	return
+}

--- a/fluent/quip/quip.go
+++ b/fluent/quip/quip.go
@@ -9,36 +9,44 @@
 // None of the quip functions cause additional allocations in the course of their work.
 // Benchmarks indicate no measurable speed penalties versus longhand manual error checking.
 //
-// This package is currently considered experimental, and may change.
-// Feel free to use it, but be advised that code using it may require frequent
-// updating until things settle; naming conventions in this package may be
-// revised with relatively little warning.
+// Several functions perform comparable operations but with different arguments,
+// and so these function names follow a pattern:
+//
+//   - `Build*` functions take a NodePrototype and return a Node.
+//   - `Assemble*` functions take a NodeAssembler and feed data into it.
+//   - There is no analog of `NodeAssembler.Begin*` functions
+//     (we simply always use callbacks for structuring, because this is reasonably optimal).
+//   - `Assign*` functions handle values of the scalar kinds
+//     (these of course also never need callbacks, since there's no possible recursion).
+//
+// The `Assemble*` functions are used recursively.
+// The `Build*` functions can be used instead of `Assemble*` at the top of a tree
+// in order to save on writing a few additional lines of NodeBuilder setup and usage.
+// (The `Assemble*` functions can also be used at the top of a tree if you
+// wish to control the NodeBuilder yourself.  This may be desirable for being
+// able to reset and reuse the NodeBuilder when performance is critical, for example.)
+//
+// The usual IPLD NodeAssembler, MapAssembler, and ListAssembler interfaces are still
+// available while using quip functions, should you wish to interact with them directly,
+// or compose the use of quip functions with other styles of data manipulation.
+//
 package quip
 
 import (
 	"github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/fluent"
 )
 
-// TODO:REVIEW: a few things about this outline and its symbol naming:
-//  - consistency/nomenclature check:
-//    - fluent package uses "BuildMap" at package scope.  And then "CreateMap" on its NB facade (which takes a callback param).  It's calling "NodeBuilder.BeginMap" internally, of course.  (is fluent's current choice odd and deserving of revising?)
-//      - the "Build" vs "Create" prefixes here indicate methods that start with a builder or prototype and return a full node, vs methods that work on assemblers.  (the fluent package doesn't have any methods that *don't* take callbacks, so there's no name component to talk about that.)
-//    - here currently we've used "BeginMap" for something that returns a MapAssembler (consistent with ipld.NB), and "BuildMap" takes a callback.
-//  - ditto the above bullet tree for List instead of Map.
-//  - many of these methods could have varying parameter types: ipld.Node forms, interface{} and dtrt forms, and callback-taking-assembler forms.  They all need unique names.
-//    - this is the case for values, and similarly for keys (though for keys the most important ones are probably string | ipld.Node | pathSegment).  The crossproduct there is sizable.
-//    - do we want to fill out this matrix completely?
-//    - what naming convention can we use to make this consistent?
-//  - do we actually want the non-callback/returns-MapAssembler BeginMap style to be something this package bothers to export?
-//    - hard to imagine actually wanting to use these.
-//    - since it turns out that the callbacks *do* get optimized quite reasonably by the compiler in common cases, there's no reason to avoid them.
-
-// TODO: a few notable gaps in what's provided, which should improve terseness even more:
-//  - we don't have top-level functions for doing a full Build returning a Node (and saving you the np.NewBuilder preamble and nb.Build postamble).  see naming issues discussion.
-//  - we don't have great shorthand for scalar assignment at the leaves.  current best is a composition like `quip.AbsorbError(&err, na.AssignString(x))`.
-//    - do we want to make an `quip.Assign{Kind}(*error, *ipld.NodeAssembler, {kindPrimitive})` for each kind?  seems like a lot of symbols.
-//    - there's also generally a whole `quip.MapEntry(... {...})` or `ListEntry` clause around *that*, with the single Absorb+Assign line in the middle.  that's boilerplate that needs trimming as well.
-//      - so... twice as many Assign helpers, because it's kinda necessary to specialize them to map and list assemblers too?  uff.
+// - removed the "Begin*" functions; no need to expose that kind of raw operation when the callback forms are zero-cost.
+// - renamed functions for consistent "Build" vs "Assemble".
+// - added "Assign*" functions for all scalar kinds, which reduces the usage of "AbsorbError" (but also, left AbsorbError in).
+// - renamed the ListEntry/MapEntry functions to also have "Assemble*" forms (still callback style).
+// - while also adding Assign{Map|List}Entry{Kind} functions (lets you get rid of another callback whenever the value is a scalar).
+// - added Assign{|MapEntry|ListEntry} functions, which shell out to fluent.Reflect for even more convenience (at the cost of performance).
+// - moved higher level functions like CopyRange to a separate file.
+//
+// Varations on map key arguments (which could be PathSegment or even Node, in addition to string) still aren't made available this.
+// Perhaps that's just okay.  If you're really up some sort of creek where you need that, you can still just use the MapAssembler.AssembleKey system directly.
 
 func AbsorbError(e *error, err error) {
 	if *e != nil {
@@ -49,19 +57,28 @@ func AbsorbError(e *error, err error) {
 	}
 }
 
-func BeginMap(e *error, na ipld.NodeAssembler, sizeHint int64) ipld.MapAssembler {
+func BuildMap(e *error, np ipld.NodePrototype, sizeHint int64, fn func(ma ipld.MapAssembler)) ipld.Node {
 	if *e != nil {
 		return nil
 	}
-	ma, err := na.BeginMap(sizeHint)
+	nb := np.NewBuilder()
+	ma, err := nb.BeginMap(sizeHint)
 	if err != nil {
 		*e = err
 		return nil
 	}
-	return ma
+	fn(ma)
+	if *e != nil {
+		return nil
+	}
+	*e = ma.Finish()
+	if *e != nil {
+		return nil
+	}
+	return nb.Build()
 }
 
-func BuildMap(e *error, na ipld.NodeAssembler, sizeHint int64, fn func(ma ipld.MapAssembler)) {
+func AssembleMap(e *error, na ipld.NodeAssembler, sizeHint int64, fn func(ma ipld.MapAssembler)) {
 	if *e != nil {
 		return
 	}
@@ -77,7 +94,7 @@ func BuildMap(e *error, na ipld.NodeAssembler, sizeHint int64, fn func(ma ipld.M
 	*e = ma.Finish()
 }
 
-func MapEntry(e *error, ma ipld.MapAssembler, k string, fn func(va ipld.NodeAssembler)) {
+func AssembleMapEntry(e *error, ma ipld.MapAssembler, k string, fn func(va ipld.NodeAssembler)) {
 	if *e != nil {
 		return
 	}
@@ -89,19 +106,28 @@ func MapEntry(e *error, ma ipld.MapAssembler, k string, fn func(va ipld.NodeAsse
 	fn(va)
 }
 
-func BeginList(e *error, na ipld.NodeAssembler, sizeHint int64) ipld.ListAssembler {
+func BuildList(e *error, np ipld.NodePrototype, sizeHint int64, fn func(la ipld.ListAssembler)) ipld.Node {
 	if *e != nil {
 		return nil
 	}
-	la, err := na.BeginList(sizeHint)
+	nb := np.NewBuilder()
+	la, err := nb.BeginList(sizeHint)
 	if err != nil {
 		*e = err
 		return nil
 	}
-	return la
+	fn(la)
+	if *e != nil {
+		return nil
+	}
+	*e = la.Finish()
+	if *e != nil {
+		return nil
+	}
+	return nb.Build()
 }
 
-func BuildList(e *error, na ipld.NodeAssembler, sizeHint int64, fn func(la ipld.ListAssembler)) {
+func AssembleList(e *error, na ipld.NodeAssembler, sizeHint int64, fn func(la ipld.ListAssembler)) {
 	if *e != nil {
 		return
 	}
@@ -117,36 +143,231 @@ func BuildList(e *error, na ipld.NodeAssembler, sizeHint int64, fn func(la ipld.
 	*e = la.Finish()
 }
 
-func ListEntry(e *error, la ipld.ListAssembler, fn func(va ipld.NodeAssembler)) {
+func AssembleListEntry(e *error, la ipld.ListAssembler, fn func(va ipld.NodeAssembler)) {
 	if *e != nil {
 		return
 	}
 	fn(la.AssembleValue())
 }
 
-func CopyRange(e *error, la ipld.ListAssembler, src ipld.Node, start, end int64) {
+func AssignNull(e *error, na ipld.NodeAssembler) {
 	if *e != nil {
 		return
 	}
-	if start >= src.Length() {
+	*e = na.AssignNull()
+}
+func AssignBool(e *error, na ipld.NodeAssembler, x bool) {
+	if *e != nil {
 		return
 	}
-	if end < 0 {
-		end = src.Length()
-	}
-	if end < start {
+	*e = na.AssignBool(x)
+}
+func AssignInt(e *error, na ipld.NodeAssembler, x int64) {
+	if *e != nil {
 		return
 	}
-	for i := start; i < end; i++ {
-		n, err := src.LookupByIndex(i)
-		if err != nil {
-			*e = err
-			return
-		}
-		if err := la.AssembleValue().AssignNode(n); err != nil {
-			*e = err
-			return
-		}
+	*e = na.AssignInt(x)
+}
+func AssignFloat(e *error, na ipld.NodeAssembler, x float64) {
+	if *e != nil {
+		return
 	}
-	return
+	*e = na.AssignFloat(x)
+}
+func AssignString(e *error, na ipld.NodeAssembler, x string) {
+	if *e != nil {
+		return
+	}
+	*e = na.AssignString(x)
+}
+func AssignBytes(e *error, na ipld.NodeAssembler, x []byte) {
+	if *e != nil {
+		return
+	}
+	*e = na.AssignBytes(x)
+}
+func AssignLink(e *error, na ipld.NodeAssembler, x ipld.Link) {
+	if *e != nil {
+		return
+	}
+	*e = na.AssignLink(x)
+}
+func AssignNode(e *error, na ipld.NodeAssembler, x ipld.Node) {
+	if *e != nil {
+		return
+	}
+	*e = na.AssignNode(x)
+}
+
+// Assign takes any value and attempts to turn it into something we can reparse as Node-like,
+// using the same logic as fluent.Reflect.
+// It's not particularly performant, so use it only when convenience matters more than performance.
+func Assign(e *error, na ipld.NodeAssembler, x interface{}) {
+	if *e != nil {
+		return
+	}
+	*e = fluent.ReflectIntoAssembler(na, x)
+}
+
+func AssignMapEntryNull(e *error, ma ipld.MapAssembler, k string) {
+	if *e != nil {
+		return
+	}
+	va, err := ma.AssembleEntry(k)
+	if err != nil {
+		*e = err
+		return
+	}
+	*e = va.AssignNull()
+}
+func AssignMapEntryBool(e *error, ma ipld.MapAssembler, k string, v bool) {
+	if *e != nil {
+		return
+	}
+	va, err := ma.AssembleEntry(k)
+	if err != nil {
+		*e = err
+		return
+	}
+	*e = va.AssignBool(v)
+}
+func AssignMapEntryInt(e *error, ma ipld.MapAssembler, k string, v int64) {
+	if *e != nil {
+		return
+	}
+	va, err := ma.AssembleEntry(k)
+	if err != nil {
+		*e = err
+		return
+	}
+	*e = va.AssignInt(v)
+}
+func AssignMapEntryFloat(e *error, ma ipld.MapAssembler, k string, v float64) {
+	if *e != nil {
+		return
+	}
+	va, err := ma.AssembleEntry(k)
+	if err != nil {
+		*e = err
+		return
+	}
+	*e = va.AssignFloat(v)
+}
+func AssignMapEntryString(e *error, ma ipld.MapAssembler, k string, v string) {
+	if *e != nil {
+		return
+	}
+	va, err := ma.AssembleEntry(k)
+	if err != nil {
+		*e = err
+		return
+	}
+	*e = va.AssignString(v)
+}
+func AssignMapEntryBytes(e *error, ma ipld.MapAssembler, k string, v []byte) {
+	if *e != nil {
+		return
+	}
+	va, err := ma.AssembleEntry(k)
+	if err != nil {
+		*e = err
+		return
+	}
+	*e = va.AssignBytes(v)
+}
+func AssignMapEntryLink(e *error, ma ipld.MapAssembler, k string, v ipld.Link) {
+	if *e != nil {
+		return
+	}
+	va, err := ma.AssembleEntry(k)
+	if err != nil {
+		*e = err
+		return
+	}
+	*e = va.AssignLink(v)
+}
+func AssignMapEntryNode(e *error, ma ipld.MapAssembler, k string, v ipld.Node) {
+	if *e != nil {
+		return
+	}
+	va, err := ma.AssembleEntry(k)
+	if err != nil {
+		*e = err
+		return
+	}
+	*e = va.AssignNode(v)
+}
+
+// AssignMapEntry takes any value and attempts to turn it into something we can reparse as Node-like,
+// using the same logic as fluent.Reflect.
+// It's not particularly performant, so use it only when convenience matters more than performance.
+func AssignMapEntry(e *error, ma ipld.MapAssembler, k string, x interface{}) {
+	if *e != nil {
+		return
+	}
+	va, err := ma.AssembleEntry(k)
+	if err != nil {
+		*e = err
+		return
+	}
+	*e = fluent.ReflectIntoAssembler(va, x)
+}
+
+func AssignListEntryNull(e *error, la ipld.ListAssembler) {
+	if *e != nil {
+		return
+	}
+	*e = la.AssembleValue().AssignNull()
+}
+func AssignListEntryBool(e *error, la ipld.ListAssembler, v bool) {
+	if *e != nil {
+		return
+	}
+	*e = la.AssembleValue().AssignBool(v)
+}
+func AssignListEntryInt(e *error, la ipld.ListAssembler, v int64) {
+	if *e != nil {
+		return
+	}
+	*e = la.AssembleValue().AssignInt(v)
+}
+func AssignListEntryFloat(e *error, la ipld.ListAssembler, v float64) {
+	if *e != nil {
+		return
+	}
+	*e = la.AssembleValue().AssignFloat(v)
+}
+func AssignListEntryString(e *error, la ipld.ListAssembler, v string) {
+	if *e != nil {
+		return
+	}
+	*e = la.AssembleValue().AssignString(v)
+}
+func AssignListEntryBytes(e *error, la ipld.ListAssembler, v []byte) {
+	if *e != nil {
+		return
+	}
+	*e = la.AssembleValue().AssignBytes(v)
+}
+func AssignListEntryLink(e *error, la ipld.ListAssembler, v ipld.Link) {
+	if *e != nil {
+		return
+	}
+	*e = la.AssembleValue().AssignLink(v)
+}
+func AssignListEntryNode(e *error, la ipld.ListAssembler, v ipld.Node) {
+	if *e != nil {
+		return
+	}
+	*e = la.AssembleValue().AssignNode(v)
+}
+
+// AssignListEntry takes any value and attempts to turn it into something we can reparse as Node-like,
+// using the same logic as fluent.Reflect.
+// It's not particularly performant, so use it only when convenience matters more than performance.
+func AssignListEntry(e *error, la ipld.ListAssembler, x interface{}) {
+	if *e != nil {
+		return
+	}
+	*e = fluent.ReflectIntoAssembler(la.AssembleValue(), x)
 }

--- a/fluent/quip/quip.go
+++ b/fluent/quip/quip.go
@@ -71,6 +71,9 @@ func BuildMap(e *error, na ipld.NodeAssembler, sizeHint int64, fn func(ma ipld.M
 		return
 	}
 	fn(ma)
+	if *e != nil {
+		return
+	}
 	*e = ma.Finish()
 }
 
@@ -108,6 +111,9 @@ func BuildList(e *error, na ipld.NodeAssembler, sizeHint int64, fn func(la ipld.
 		return
 	}
 	fn(la)
+	if *e != nil {
+		return
+	}
 	*e = la.Finish()
 }
 

--- a/fluent/quip/quip_bench_test.go
+++ b/fluent/quip/quip_bench_test.go
@@ -1,0 +1,245 @@
+package quip_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/codec/dagjson"
+	"github.com/ipld/go-ipld-prime/fluent"
+	"github.com/ipld/go-ipld-prime/fluent/quip"
+	basicnode "github.com/ipld/go-ipld-prime/node/basic"
+)
+
+func BenchmarkQuip(b *testing.B) {
+	var n ipld.Node
+	var err error
+	for i := 0; i < b.N; i++ {
+		n, err = f1()
+	}
+	_ = n
+	if err != nil {
+		b.Fatal(err)
+	}
+}
+
+func BenchmarkUnmarshal(b *testing.B) {
+	var n ipld.Node
+	var err error
+	serial := `[{
+		"destination": "/",
+		"type": "overlay",
+		"source": "none",
+		"options": [
+			"lowerdir=/",
+			"upperdir=/tmp/overlay-root/upper",
+			"workdir=/tmp/overlay-root/work"
+		]
+	}]`
+	r := strings.NewReader(serial)
+	for i := 0; i < b.N; i++ {
+		nb := basicnode.Prototype.Any.NewBuilder()
+		err = dagjson.Decoder(nb, r)
+		n = nb.Build()
+		r.Reset(serial)
+	}
+	_ = n
+	if err != nil {
+		b.Fatal(err)
+	}
+}
+
+func BenchmarkFluent(b *testing.B) {
+	var n ipld.Node
+	var err error
+	for i := 0; i < b.N; i++ {
+		n, err = fluent.BuildList(basicnode.Prototype.Any, -1, func(la fluent.ListAssembler) {
+			la.AssembleValue().CreateMap(4, func(ma fluent.MapAssembler) {
+				ma.AssembleEntry("destination").AssignString("/")
+				ma.AssembleEntry("type").AssignString("overlay")
+				ma.AssembleEntry("source").AssignString("none")
+				ma.AssembleEntry("options").CreateList(-1, func(la fluent.ListAssembler) {
+					la.AssembleValue().AssignString("lowerdir=" + "/")
+					la.AssembleValue().AssignString("upperdir=" + "/tmp/overlay-root/upper")
+					la.AssembleValue().AssignString("workdir=" + "/tmp/overlay-root/work")
+				})
+			})
+		})
+	}
+	_ = n
+	if err != nil {
+		b.Fatal(err)
+	}
+}
+
+func BenchmarkReflect(b *testing.B) {
+	var n ipld.Node
+	var err error
+	val := []interface{}{
+		map[string]interface{}{
+			"destination": "/",
+			"type":        "overlay",
+			"source":      "none",
+			"options": []string{
+				"lowerdir=/",
+				"upperdir=/tmp/overlay-root/upper",
+				"workdir=/tmp/overlay-root/work",
+			},
+		},
+	}
+	for i := 0; i < b.N; i++ {
+		n, err = fluent.Reflect(basicnode.Prototype.Any, val)
+	}
+	_ = n
+	if err != nil {
+		b.Fatal(err)
+	}
+}
+
+func BenchmarkReflectIncludingInitialization(b *testing.B) {
+	var n ipld.Node
+	var err error
+	for i := 0; i < b.N; i++ {
+		n, err = fluent.Reflect(basicnode.Prototype.Any, []interface{}{
+			map[string]interface{}{
+				"destination": "/",
+				"type":        "overlay",
+				"source":      "none",
+				"options": []string{
+					"lowerdir=/",
+					"upperdir=/tmp/overlay-root/upper",
+					"workdir=/tmp/overlay-root/work",
+				},
+			},
+		})
+	}
+	_ = n
+	if err != nil {
+		b.Fatal(err)
+	}
+}
+
+func BenchmarkAgonizinglyBare(b *testing.B) {
+	var n ipld.Node
+	var err error
+	for i := 0; i < b.N; i++ {
+		n, err = fab()
+	}
+	_ = n
+	if err != nil {
+		b.Fatal(err)
+	}
+}
+
+func fab() (ipld.Node, error) {
+	nb := basicnode.Prototype.Any.NewBuilder()
+	la1, err := nb.BeginList(-1)
+	if err != nil {
+		return nil, err
+	}
+	ma, err := la1.AssembleValue().BeginMap(4)
+	if err != nil {
+		return nil, err
+	}
+	va, err := ma.AssembleEntry("destination")
+	if err != nil {
+		return nil, err
+	}
+	err = va.AssignString("/")
+	if err != nil {
+		return nil, err
+	}
+	va, err = ma.AssembleEntry("type")
+	if err != nil {
+		return nil, err
+	}
+	err = va.AssignString("overlay")
+	if err != nil {
+		return nil, err
+	}
+	va, err = ma.AssembleEntry("source")
+	if err != nil {
+		return nil, err
+	}
+	err = va.AssignString("none")
+	if err != nil {
+		return nil, err
+	}
+	va, err = ma.AssembleEntry("options")
+	if err != nil {
+		return nil, err
+	}
+	la2, err := va.BeginList(-4)
+	if err != nil {
+		return nil, err
+	}
+	err = la2.AssembleValue().AssignString("lowerdir=" + "/")
+	if err != nil {
+		return nil, err
+	}
+	err = la2.AssembleValue().AssignString("upperdir=" + "/tmp/overlay-root/upper")
+	if err != nil {
+		return nil, err
+	}
+	err = la2.AssembleValue().AssignString("workdir=" + "/tmp/overlay-root/work")
+	if err != nil {
+		return nil, err
+	}
+	err = la2.Finish()
+	if err != nil {
+		return nil, err
+	}
+	err = ma.Finish()
+	if err != nil {
+		return nil, err
+	}
+	err = la1.Finish()
+	if err != nil {
+		return nil, err
+	}
+	return nb.Build(), nil
+}
+
+func f1() (_ ipld.Node, err error) {
+	nb := basicnode.Prototype.Any.NewBuilder()
+	quip.BuildList(&err, nb, -1, func(la ipld.ListAssembler) {
+		f2(la.AssembleValue(),
+			"/",
+			"overlay",
+			"none",
+			[]string{
+				"lowerdir=" + "/",
+				"upperdir=" + "/tmp/overlay-root/upper",
+				"workdir=" + "/tmp/overlay-root/work",
+			},
+		)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return nb.Build(), nil
+}
+
+func f2(na ipld.NodeAssembler, a string, b string, c string, d []string) (err error) {
+	quip.BuildMap(&err, na, 4, func(ma ipld.MapAssembler) {
+		quip.MapEntry(&err, ma, "destination", func(va ipld.NodeAssembler) {
+			quip.AbsorbError(&err, va.AssignString(a))
+		})
+		quip.MapEntry(&err, ma, "type", func(va ipld.NodeAssembler) {
+			quip.AbsorbError(&err, va.AssignString(b))
+		})
+		quip.MapEntry(&err, ma, "source", func(va ipld.NodeAssembler) {
+			quip.AbsorbError(&err, va.AssignString(c))
+		})
+		quip.MapEntry(&err, ma, "options", func(va ipld.NodeAssembler) {
+			quip.BuildList(&err, va, int64(len(d)), func(la ipld.ListAssembler) {
+				for i := range d {
+					quip.ListEntry(&err, la, func(va ipld.NodeAssembler) {
+						quip.AbsorbError(&err, va.AssignString(d[i]))
+					})
+				}
+			})
+		})
+	})
+	return
+}

--- a/fluent/quip/quip_example_test.go
+++ b/fluent/quip/quip_example_test.go
@@ -1,0 +1,62 @@
+package quip_test
+
+import (
+	"os"
+
+	"github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/codec/dagjson"
+	"github.com/ipld/go-ipld-prime/fluent/quip"
+	basicnode "github.com/ipld/go-ipld-prime/node/basic"
+)
+
+func Example() {
+	nb := basicnode.Prototype.Any.NewBuilder()
+	var err error
+	quip.BuildMap(&err, nb, 4, func(ma ipld.MapAssembler) {
+		quip.MapEntry(&err, ma, "some key", func(va ipld.NodeAssembler) {
+			quip.AbsorbError(&err, va.AssignString("some value"))
+		})
+		quip.MapEntry(&err, ma, "another key", func(va ipld.NodeAssembler) {
+			quip.AbsorbError(&err, va.AssignString("another value"))
+		})
+		quip.MapEntry(&err, ma, "nested map", func(va ipld.NodeAssembler) {
+			quip.BuildMap(&err, va, 2, func(ma ipld.MapAssembler) {
+				quip.MapEntry(&err, ma, "deeper entries", func(va ipld.NodeAssembler) {
+					quip.AbsorbError(&err, va.AssignString("deeper values"))
+				})
+				quip.MapEntry(&err, ma, "more deeper entries", func(va ipld.NodeAssembler) {
+					quip.AbsorbError(&err, va.AssignString("more deeper values"))
+				})
+			})
+		})
+		quip.MapEntry(&err, ma, "nested list", func(va ipld.NodeAssembler) {
+			quip.BuildList(&err, va, 2, func(la ipld.ListAssembler) {
+				quip.ListEntry(&err, la, func(va ipld.NodeAssembler) {
+					quip.AbsorbError(&err, va.AssignInt(1))
+				})
+				quip.ListEntry(&err, la, func(va ipld.NodeAssembler) {
+					quip.AbsorbError(&err, va.AssignInt(2))
+				})
+			})
+		})
+	})
+	if err != nil {
+		panic(err)
+	}
+	n := nb.Build()
+	dagjson.Encoder(n, os.Stdout)
+
+	// Output:
+	// {
+	// 	"some key": "some value",
+	// 	"another key": "another value",
+	// 	"nested map": {
+	// 		"deeper entries": "deeper values",
+	// 		"more deeper entries": "more deeper values"
+	// 	},
+	// 	"nested list": [
+	// 		1,
+	// 		2
+	// 	]
+	// }
+}

--- a/fluent/quip/quip_example_test.go
+++ b/fluent/quip/quip_example_test.go
@@ -10,40 +10,26 @@ import (
 )
 
 func Example() {
-	nb := basicnode.Prototype.Any.NewBuilder()
 	var err error
-	quip.BuildMap(&err, nb, 4, func(ma ipld.MapAssembler) {
-		quip.MapEntry(&err, ma, "some key", func(va ipld.NodeAssembler) {
-			quip.AbsorbError(&err, va.AssignString("some value"))
-		})
-		quip.MapEntry(&err, ma, "another key", func(va ipld.NodeAssembler) {
-			quip.AbsorbError(&err, va.AssignString("another value"))
-		})
-		quip.MapEntry(&err, ma, "nested map", func(va ipld.NodeAssembler) {
-			quip.BuildMap(&err, va, 2, func(ma ipld.MapAssembler) {
-				quip.MapEntry(&err, ma, "deeper entries", func(va ipld.NodeAssembler) {
-					quip.AbsorbError(&err, va.AssignString("deeper values"))
-				})
-				quip.MapEntry(&err, ma, "more deeper entries", func(va ipld.NodeAssembler) {
-					quip.AbsorbError(&err, va.AssignString("more deeper values"))
-				})
+	n := quip.BuildMap(&err, basicnode.Prototype.Any, 4, func(ma ipld.MapAssembler) {
+		quip.AssignMapEntryString(&err, ma, "some key", "some value")
+		quip.AssignMapEntryString(&err, ma, "another key", "another value")
+		quip.AssembleMapEntry(&err, ma, "nested map", func(na ipld.NodeAssembler) {
+			quip.AssembleMap(&err, na, 2, func(ma ipld.MapAssembler) {
+				quip.AssignMapEntryString(&err, ma, "deeper entries", "deeper values")
+				quip.AssignMapEntryString(&err, ma, "more deeper entries", "more deeper values")
 			})
 		})
-		quip.MapEntry(&err, ma, "nested list", func(va ipld.NodeAssembler) {
-			quip.BuildList(&err, va, 2, func(la ipld.ListAssembler) {
-				quip.ListEntry(&err, la, func(va ipld.NodeAssembler) {
-					quip.AbsorbError(&err, va.AssignInt(1))
-				})
-				quip.ListEntry(&err, la, func(va ipld.NodeAssembler) {
-					quip.AbsorbError(&err, va.AssignInt(2))
-				})
+		quip.AssembleMapEntry(&err, ma, "nested list", func(na ipld.NodeAssembler) {
+			quip.AssembleList(&err, na, 2, func(la ipld.ListAssembler) {
+				quip.AssignListEntryInt(&err, la, 1)
+				quip.AssignListEntryInt(&err, la, 2)
 			})
 		})
 	})
 	if err != nil {
 		panic(err)
 	}
-	n := nb.Build()
 	dagjson.Encoder(n, os.Stdout)
 
 	// Output:


### PR DESCRIPTION
I developed a new pattern for building IPLD structures.  This started as a little experiment, but worked so dang well I instantly want to ship it.

The basic idea is that every function in the package takes an `*error` as its first parameter, and gathers any errors during the function's operation in there, instead of returning them.  If the `*error` is already non-nil, it just returns without doing anything.  This lets you write very linear code without a lot of fuss, and tends to "do the right thing" in over all flow control.

A function that's the equivalent of each of the methods on `NodeAssembler` exists.  (I've also sprinkled in a few other useful ones like "CopyRange" for lists.)  These generally take a `NodeAssembler` to work on as a parameter.  For those functions that work on recursive kinds, I've done callback arguments, which causes tree structures to syntactically indent like trees (and also saves you the calling and error checking of `Finish()` functions), which I tend to think is good.

Check out the example function around https://github.com/ipld/go-ipld-prime/pull/134/files#diff-46ca8eb0f742995be52debd745cb616db55f094a46c9182058da8b1d3b548ed9R15-R42 for a demonstration of how using these helpers looks.

Syntactically, this comes out a *lot* shorter than using the `NodeAssembler` manually and doing all the error checks in longhand.  It's not quite as short as some of our other syntaxes (yet?) either, but it's most of the way there, and there's still room for improvement.  Here's the linecounts summary, based on the examples that can be found in the benchmarks in this diff:

- Quip: ~ ~18 SLOC~ update: now down to ~12 SLOC
- Fluent Builders: ~12 SLOC
- Fluent Reflect: ~12 SLOC
- Unmarshal: ~12 SLOC
- (agonizingly) Bare: ~*66* SLOC

(~I think we can get this 18 down to the 12 of the others; there's some comments in the diff about avenues to explore.  And then 12 is about as far as I'd push it on this example, apparently (on this example data, any less implies you're collapsing more than one tree structure element into each line of source, which is of dubious desirability for readability).~  update: Indeed we did get it down to 12!)

("unmarshal" is arguably an odd thing to include in this comparison table, but I thought to myself: well, okay, what if we take that as an approximation for "how good could we get if we invented a whole DSL for this?".  It's just interesting to ponder.)

The really good news about all this?  It's also working with *zero overhead*.  And I mean *immeasurable*.  Here's a sample benchmark result:

```
BenchmarkQuip-12                               946 ns/op      880 B/op     17 allocs/op
BenchmarkUnmarshal-12                         6435 ns/op     2208 B/op     52 allocs/op
BenchmarkFluent-12                            1361 ns/op     1136 B/op     31 allocs/op
BenchmarkReflect-12                           1257 ns/op     1008 B/op     20 allocs/op
BenchmarkReflectIncludingInitialization-12    1558 ns/op     1440 B/op     25 allocs/op
BenchmarkAgonizinglyBare-12                    981 ns/op      944 B/op     19 allocs/op
```

Using the `quip` helpers is literally free.  In fact, evidently, it's so amenable to compiler inlining and other compile-time optimizations that it's actually *faster* than the longhand direct usage of `NodeAssembler`.  (Borderline hard to believe, I know, but, I think it's not even a sampling artifact, and the benchmark membench results also support this.  I suspect the extra nested functions in the `quip` style are letting the escape analyzer get quite clever and shift more things onto the stack, whereas my longhand function held onto more assemblers at once, in... ways that were harder to optimize.  I dunno.  Haven't looked that gift horse in the mouth too deeply, honestly.)

By comparison, our other previous attempts at helper functions for assembling IPLD data had a 30% cpu time tax, and something like a 50% garbage tax.  Those taxes meant you really couldn't have nice syntax and ideal performance at the same time... and that meant, in practice, a lot of code would get written twice: once the terse way, and a second time the fast way as soon as it showed up on an application level benchmark.  Having to decide which of two styles to use based on whether you estimated you could stomach the performance hit was just an awful choice to have to make.  With `quip`, that choice is gone: you can have nice syntax _and_ fast at the same time.

I've skimmed a little of the assembler output to see why its so fast.  It seems that quip functions are generally inlinable.  I suspect this means the "if err" branches can often be unrolled into one jump target per function in assembly.  Also importantly, the anonymous functions used to make the syntactic tree structures (and save us from needing to make `Finish()` calls) get compiled into anonymous functions *without* closure state -- which is important because: it means they're not dynamically dispatched; and they don't do a sneaky allocation to create an anonymous struct that holds closure state (which can be one of the sources of allocs that can be the most syntactically difficult to track down).  I suspect it's possible to write more complicated callbacks which would cause the closure alloc cost, but... if the most common usage doesn't, I'm happy enough with that.

Worth noting that of the remaining allocations shown in the benchmark... most of them are probably from the fact we're using `basicnode` nodes to hold this data.  `basicnode` implementations are decidedly allocation-happy since they don't know _anything_ about the structure of the data they're holding.  If we implemented another benchmark against a codegen'd node that does know about the structure of the data, I suspect the alloc count would be in the single digits.  Might even be able to get it down to ~one or~ two (which is about as low as I can imagine for a corpus like this one that involves two variable sized lists).

There's probably more work to do here:
- ~More helpers (especially around leaf values; see comments in diff) could make this even terser.~ update: There are now more helpers for scalar and leaf values.
- "Quip" is probably a working title for the package.
- We can always find more high-level helpers like `CopyRange` to keep adding, I'm sure!

... but I think this is a pretty solid foundation to build more on.