### PR TITLE
fluent: add qp, a different spin on quip

### DIFF
--- a/fluent/qp/example_test.go
+++ b/fluent/qp/example_test.go
@@ -1,0 +1,45 @@
+package qp_test
+
+import (
+	"os"
+
+	"github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/codec/dagjson"
+	"github.com/ipld/go-ipld-prime/fluent/qp"
+	basicnode "github.com/ipld/go-ipld-prime/node/basic"
+)
+
+// TODO: can we make ListEntry/MapEntry less verbose?
+
+func Example() {
+	n, err := qp.BuildMap(basicnode.Prototype.Any, 4, func(ma ipld.MapAssembler) {
+		qp.MapEntry(ma, "some key", qp.String("some value"))
+		qp.MapEntry(ma, "another key", qp.String("another value"))
+		qp.MapEntry(ma, "nested map", qp.Map(2, func(ma ipld.MapAssembler) {
+			qp.MapEntry(ma, "deeper entries", qp.String("deeper values"))
+			qp.MapEntry(ma, "more deeper entries", qp.String("more deeper values"))
+		}))
+		qp.MapEntry(ma, "nested list", qp.List(2, func(la ipld.ListAssembler) {
+			qp.ListEntry(la, qp.Int(1))
+			qp.ListEntry(la, qp.Int(2))
+		}))
+	})
+	if err != nil {
+		panic(err)
+	}
+	dagjson.Encoder(n, os.Stdout)
+
+	// Output:
+	// {
+	// 	"some key": "some value",
+	// 	"another key": "another value",
+	// 	"nested map": {
+	// 		"deeper entries": "deeper values",
+	// 		"more deeper entries": "more deeper values"
+	// 	},
+	// 	"nested list": [
+	// 		1,
+	// 		2
+	// 	]
+	// }
+}

--- a/fluent/qp/qp.go
+++ b/fluent/qp/qp.go
@@ -1,0 +1,106 @@
+// qp is similar to fluent/quip, but with a bit more magic.
+package qp
+
+import (
+	"github.com/ipld/go-ipld-prime"
+)
+
+type Assemble = func(ipld.NodeAssembler)
+
+func BuildMap(np ipld.NodePrototype, sizeHint int64, fn func(ipld.MapAssembler)) (_ ipld.Node, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = r.(error)
+		}
+	}()
+	nb := np.NewBuilder()
+	Map(sizeHint, fn)(nb)
+	return nb.Build(), nil
+}
+
+type mapParams struct {
+	sizeHint int64
+	fn       func(ipld.MapAssembler)
+}
+
+func (mp mapParams) Assemble(na ipld.NodeAssembler) {
+	ma, err := na.BeginMap(mp.sizeHint)
+	if err != nil {
+		panic(err)
+	}
+	mp.fn(ma)
+	if err := ma.Finish(); err != nil {
+		panic(err)
+	}
+}
+
+func Map(sizeHint int64, fn func(ipld.MapAssembler)) Assemble {
+	return mapParams{sizeHint, fn}.Assemble
+}
+
+func MapEntry(ma ipld.MapAssembler, k string, fn Assemble) {
+	na, err := ma.AssembleEntry(k)
+	if err != nil {
+		panic(err)
+	}
+	fn(na)
+}
+
+func BuildList(np ipld.NodePrototype, sizeHint int64, fn func(ipld.ListAssembler)) (_ ipld.Node, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = r.(error)
+		}
+	}()
+	nb := np.NewBuilder()
+	List(sizeHint, fn)(nb)
+	return nb.Build(), nil
+}
+
+type listParams struct {
+	sizeHint int64
+	fn       func(ipld.ListAssembler)
+}
+
+func (lp listParams) Assemble(na ipld.NodeAssembler) {
+	la, err := na.BeginList(lp.sizeHint)
+	if err != nil {
+		panic(err)
+	}
+	lp.fn(la)
+	if err := la.Finish(); err != nil {
+		panic(err)
+	}
+}
+
+func List(sizeHint int64, fn func(ipld.ListAssembler)) Assemble {
+	return listParams{sizeHint, fn}.Assemble
+}
+
+func ListEntry(la ipld.ListAssembler, fn Assemble) {
+	fn(la.AssembleValue())
+}
+
+type stringParam string
+
+func (s stringParam) Assemble(na ipld.NodeAssembler) {
+	if err := na.AssignString(string(s)); err != nil {
+		panic(err)
+	}
+}
+
+func String(s string) Assemble {
+	return stringParam(s).Assemble
+}
+
+type intParam int64
+
+func (i intParam) Assemble(na ipld.NodeAssembler) {
+	if err := na.AssignInt(int64(i)); err != nil {
+		panic(err)
+	}
+}
+
+func Int(i int64) Assemble {
+	return intParam(i).Assemble
+}


### PR DESCRIPTION
This is what I came up with, building on top of Eric's quip. I don't
want to waste too much time naming this, and I like two-letter package
names in place of dot-imports, so "qp" seems good enough for now. They
are the "strong" consonants when one says "Quick iPld".

First, move the benchmarks comparing all fluent packages to the root
fluent package, to keep things a bit more tidy.

Second, make all the benchmarks report their allocation stats, without
having to always remember to use the -benchmem flag.

Third, add a qp benchmark.

Fourth, notice a couple of potential bugs in the quip benchmarks, and
add TODOs for them.

Finally, add the qp API. It differs from quip in a few external ways:

1) No error pointers. Instead, it uses panics which are recovered at the
   top-level API layer. This reduces verbosity, removes the "forgot to
   handle an error" type of mistake, and does not affect performance
   thanks to the defers being statically allocated in the stack.

2) Supposed better composition. For example, one can use MapEntry along
   with Map to have a map inside another map. In contrast, quip requires
   either an extra layer of func literals, or extra API like
   AssignMapEntryString.

3) Thanks to the points above, the API is significantly smaller. Note
   that some helper APIs like Bool are missing, but even when added, qp
   should expose about half the API funcs taht quip does.

This is the first proof of concept. I'll probably finish adding the rest
of the API helpers when I find the first use case for qp.

Benchmark numbers, with perflock and benchstat on my i5-8350u laptop:

	name                              time/op
	Quip-8                            1.39µs ± 1%
	QuipWithoutScalarFuncs-8          1.42µs ± 2%
	Qp-8                              1.46µs ± 2%

	name                              alloc/op
	Quip-8                              912B ± 0%
	QuipWithoutScalarFuncs-8            912B ± 0%
	Qp-8                                912B ± 0%

	name                              allocs/op
	Quip-8                              18.0 ± 0%
	QuipWithoutScalarFuncs-8            18.0 ± 0%
	Qp-8                                18.0 ± 0%