### PR TITLE
schema/gen/go: cache genned code in os.TempDir

### DIFF
--- a/schema/gen/go/testEngine_disabled_test.go
+++ b/schema/gen/go/testEngine_disabled_test.go
@@ -17,14 +17,20 @@ func buildGennedCode(t *testing.T, prefix string, pkgName string) {
 	//    so 'pkgName' in practice is almost always "main").
 	//  I dunno, friend.  I didn't write the rules.
 	if pkgName == "main" {
-		withFile("./_test/"+prefix+"/main.go", func(w io.Writer) {
+		withFile(filepath.Join(tmpGenBuildDir, prefix, "main.go"), func(w io.Writer) {
 			fmt.Fprintf(w, "package %s\n\n", pkgName)
 			fmt.Fprintf(w, "func main() {}\n")
 		})
 	}
 
 	// Invoke 'go build' -- nothing fancy.
-	cmd := exec.Command("go", "build", "./_test/"+prefix)
+	files, err := filepath.Glob(filepath.Join(tmpGenBuildDir, prefix, "*.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	args := []string{"build"}
+	args = append(args, files...)
+	cmd := exec.Command("go", args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	err := cmd.Run()

--- a/schema/gen/go/testEngine_nocgo_test.go
+++ b/schema/gen/go/testEngine_nocgo_test.go
@@ -32,14 +32,20 @@ func buildGennedCode(t *testing.T, prefix string, pkgName string) {
 	//    so 'pkgName' in practice is almost always "main").
 	//  I dunno, friend.  I didn't write the rules.
 	if pkgName == "main" {
-		withFile("./_test/"+prefix+"/main.go", func(w io.Writer) {
+		withFile(filepath.Join(tmpGenBuildDir, prefix, "main.go"), func(w io.Writer) {
 			fmt.Fprintf(w, "package %s\n\n", pkgName)
 			fmt.Fprintf(w, "func main() {}\n")
 		})
 	}
 
 	// Invoke 'go build' -- nothing fancy.
-	cmd := exec.Command("go", "build", "./_test/"+prefix)
+	files, err := filepath.Glob(filepath.Join(tmpGenBuildDir, prefix, "*.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	args := []string{"build"}
+	args = append(args, files...)
+	cmd := exec.Command("go", args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	err := cmd.Run()

--- a/schema/gen/go/testEngine_plugin_test.go
+++ b/schema/gen/go/testEngine_plugin_test.go
@@ -5,26 +5,37 @@ package gengo
 import (
 	"os"
 	"os/exec"
+	"path/filepath"
 	"plugin"
 	"testing"
 
 	"github.com/ipld/go-ipld-prime"
 )
 
+func objPath(prefix string) string {
+	return filepath.Join(tmpGenBuildDir, prefix, "obj.so")
+}
+
 func buildGennedCode(t *testing.T, prefix string, _ string) {
 	// Invoke `go build` with flags to create a plugin -- we'll be able to
 	//  load into this plugin into this selfsame process momentarily.
-	cmd := exec.Command("go", "build", "-o=./_test/"+prefix+"/obj.so", "-buildmode=plugin", "./_test/"+prefix)
+	// Use globbing, because these are files outside our module.
+	files, err := filepath.Glob(filepath.Join(tmpGenBuildDir, prefix, "*.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	args := []string{"build", "-o=" + objPath(prefix), "-buildmode=plugin"}
+	args = append(args, files...)
+	cmd := exec.Command("go", args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	err := cmd.Run()
-	if err != nil {
+	if err := cmd.Run(); err != nil {
 		t.Fatalf("genned code failed to compile: %s", err)
 	}
 }
 
 func runBehavioralTests(t *testing.T, prefix string, testsFn behavioralTests) {
-	plg, err := plugin.Open("./_test/" + prefix + "/obj.so")
+	plg, err := plugin.Open(objPath(prefix))
 	if err != nil {
 		panic(err) // Panic because if this was going to flunk, we expected it to flunk earlier when we ran 'go build'.
 	}


### PR DESCRIPTION
This means we no longer clutter the repository with lots of files, even
if they are git-ignored. It's always a bit of a red flag when you run
"go test ./..." and the result is a bunch of leftover files.

We still want to keep the files around, for the sake of Go's build
cache. And we still want their paths to be static between "go test"
runs. So put them in a static dir under os.TempDir.

This does mean that concurrent runs of these tests will likely not work
well. I don't imagine that's going to be a problem anytime soon, though.
If it really becomes a problem in the future, we could figure something
out like grabbing a file lock for the directory.

The idea behind using os.TempDir is that it will likely remain in place
between a number of "go test" runs within a hacking session, but it will
be eventually cleaned up by the system, such as when rebooting.

Note that we need to use globbing since one can't build "proper
packages" located outside a module. The only exception is building an
ad-hoc set of explicit Go files. While at it, use filepath.Join, to be
nice.