### PR TITLE
feat(linksystem): add reification to LinkSystem

### DIFF
--- a/linking.go
+++ b/linking.go
@@ -24,7 +24,11 @@ func (lsys *LinkSystem) Load(lnkCtx LinkContext, lnk Link, np NodePrototype) (No
 	if err := lsys.Fill(lnkCtx, lnk, nb); err != nil {
 		return nil, err
 	}
-	return nb.Build(), nil
+	nd := nb.Build()
+	if lsys.NodeReifier == nil {
+		return nd, nil
+	}
+	return lsys.NodeReifier(lnkCtx, nd, lsys)
 }
 
 func (lsys *LinkSystem) MustLoad(lnkCtx LinkContext, lnk Link, np NodePrototype) Node {

--- a/linksystem.go
+++ b/linksystem.go
@@ -33,6 +33,7 @@ type LinkSystem struct {
 	StorageWriteOpener BlockWriteOpener
 	StorageReadOpener  BlockReadOpener
 	TrustedStorage     bool
+	NodeReifier        NodeReifier
 }
 
 // The following two types define the two directions of transform that a codec can be expected to perform:
@@ -206,6 +207,21 @@ type (
 	// See the documentation of BlockWriteOpener for more description of this
 	// and an example of how this is likely to be reduced to practice.
 	BlockWriteCommitter func(Link) error
+
+	// NodeReifier defines the shape of a function that given a node with no schema
+	// or a basic schema, constructs Advanced Data Layout node
+	//
+	// The LinkSystem itself is passed to the NodeReifier along with a link context
+	// because Node interface methods on an ADL may actually traverse links to other
+	// pieces of context addressed data that need to be loaded with the Link system
+	//
+	// A NodeReifier return one of three things:
+	// - original node, no error = no reification occurred, just use original node
+	// - reified node, no error = the simple node was converted to an ADL
+	// - nil, error = the simple node should have been converted to an ADL but something
+	// went wrong when we tried to do so
+	//
+	NodeReifier func(LinkContext, Node, *LinkSystem) (Node, error)
 )
 
 // ErrLinkingSetup is returned by methods on LinkSystem when some part of the system is not set up correctly,


### PR DESCRIPTION
# Goals

Proposal for how to integrate ADL creation into the LinkSystem loading process

# Implementation

Add an optional reifier into the link system process to create ADLs. The reason to do this is to capture the link
system itself when reification happens, in case it needs to be put into the node, which is often not
accessible by the time you have a node. 

Another alternative would be to make this specific to
selector traversal, similar to LinkNodePrototypeChooser

# For Discussion

I actually left off Storage as a concern entirely. The simple version would be to just make a NodeSubstrater function with a shape like this:

```golang
type NodeSubstrater func(ipld.Node) (ipld.Node, error)
```

But in reality a Store operation on an ADL Node built with some kind of ADL builder (think HAMT) actually probably stores SEVERAL blocks. I'm not sure the absolute best way to do that. Technically, such a NodeBuilder could store its "sub blocks" on NodeBuilder.Build... but that also feels a bit odd since one does not expect that operation to store

Another option would be for NodeBuilder to assemble a bunch of nodes as needed in a temporary store, and then for the Store to move it to the actual blockstore? Hard to say.