### PR TITLE
Add enumerate methods to the multicodec registries.

### DIFF
--- a/multicodec/defaultRegistry.go
+++ b/multicodec/defaultRegistry.go
@@ -53,6 +53,22 @@ func LookupEncoder(indicator uint64) (ipld.Encoder, error) {
 	return DefaultRegistry.LookupEncoder(indicator)
 }
 
+// ListEncoders returns a list of multicodec indicators for which an ipld.Encoder is registered.
+// The list is in no particular order.
+// It is a shortcut to the ListEncoders method on the global DefaultRegistry.
+//
+// Be judicious about trying to use this function outside of debugging.
+// Because the global default registry is global and easily modified,
+// and can be changed by any of the transitive dependencies of your program,
+// its contents are not particularly stable.
+// In particular, it is not recommended to make any behaviors of your program conditional
+// based on information returned by this function -- if your program needs conditional
+// behavior based on registred codecs, you may want to consider taking more explicit control
+// and using your own non-default registry.
+func ListEncoders() []uint64 {
+	return DefaultRegistry.ListEncoders()
+}
+
 // RegisterDecoder updates the global DefaultRegistry a map a multicodec indicator number to the given ipld.Decoder function.
 // The decoder functions registered can be subsequently looked up using LookupDecoder.
 // It is a shortcut to the RegisterDecoder method on the global DefaultRegistry.
@@ -82,4 +98,20 @@ func RegisterDecoder(indicator uint64, decodeFunc ipld.Decoder) {
 // for this indicator number by an earlier call to the RegisterDecoder function.
 func LookupDecoder(indicator uint64) (ipld.Decoder, error) {
 	return DefaultRegistry.LookupDecoder(indicator)
+}
+
+// ListDecoders returns a list of multicodec indicators for which an ipld.Decoder is registered.
+// The list is in no particular order.
+// It is a shortcut to the ListDecoders method on the global DefaultRegistry.
+//
+// Be judicious about trying to use this function outside of debugging.
+// Because the global default registry is global and easily modified,
+// and can be changed by any of the transitive dependencies of your program,
+// its contents are not particularly stable.
+// In particular, it is not recommended to make any behaviors of your program conditional
+// based on information returned by this function -- if your program needs conditional
+// behavior based on registred codecs, you may want to consider taking more explicit control
+// and using your own non-default registry.
+func ListDecoders() []uint64 {
+	return DefaultRegistry.ListDecoders()
 }

--- a/multicodec/registry.go
+++ b/multicodec/registry.go
@@ -60,6 +60,16 @@ func (r *Registry) LookupEncoder(indicator uint64) (ipld.Encoder, error) {
 	return encodeFunc, nil
 }
 
+// ListEncoders returns a list of multicodec indicators for which an ipld.Encoder is registered.
+// The list is in no particular order.
+func (r *Registry) ListEncoders() []uint64 {
+	encoders := make([]uint64, 0, len(r.encoders))
+	for e := range r.encoders {
+		encoders = append(encoders, e)
+	}
+	return encoders
+}
+
 // RegisterDecoder updates a simple map of multicodec indicator number to ipld.Decoder function.
 // The decoder functions registered can be subsequently looked up using LookupDecoder.
 func (r *Registry) RegisterDecoder(indicator uint64, decodeFunc ipld.Decoder) {
@@ -80,4 +90,14 @@ func (r *Registry) LookupDecoder(indicator uint64) (ipld.Decoder, error) {
 		return nil, fmt.Errorf("no decoder registered for multicodec code %d (0x%x)", indicator, indicator)
 	}
 	return decodeFunc, nil
+}
+
+// ListDecoders returns a list of multicodec indicators for which an ipld.Decoder is registered.
+// The list is in no particular order.
+func (r *Registry) ListDecoders() []uint64 {
+	decoders := make([]uint64, 0, len(r.decoders))
+	for d := range r.decoders {
+		decoders = append(decoders, d)
+	}
+	return decoders
 }


### PR DESCRIPTION
(This is a logical port of https://github.com/ipld/go-ipld-prime/pull/169 to follow https://github.com/ipld/go-ipld-prime/pull/172 .)

I've added more documentation -- particularly, cautionary notes on the package-scope functions which read the global shared state.