### PR TITLE
Sort map entries marshalling dag-json

### DIFF
--- a/codec/dagjson/marshal.go
+++ b/codec/dagjson/marshal.go
@@ -16,7 +16,21 @@ import (
 // except for the `case ipld.Kind_Link` block,
 // which is dag-json's special sauce for schemafree links.
 
-func Marshal(n ipld.Node, sink shared.TokenSink, allowLinks bool) error {
+type MarshalOptions struct {
+	// If true, will encode nodes with a Link kind using the DAG-JSON
+	// `{"/":"cid string"}` form.
+	EncodeLinks bool
+
+	// If true, will encode nodes with a Bytes kind using the DAG-JSON
+	// `{"/":{"bytes":"base64 bytes..."}}` form.
+	EncodeBytes bool
+
+	// If true, will sort map keys prior to encoding using plain bytewise
+	// comparison.
+	SortMapKeys bool
+}
+
+func Marshal(n ipld.Node, sink shared.TokenSink, options MarshalOptions) error {
 	var tk tok.Token
 	switch n.Kind() {
 	case ipld.Kind_Invalid:
@@ -32,33 +46,54 @@ func Marshal(n ipld.Node, sink shared.TokenSink, allowLinks bool) error {
 		if _, err := sink.Step(&tk); err != nil {
 			return err
 		}
-		// Collect map entries, then sort by key
-		type entry struct {
-			key   string
-			value ipld.Node
-		}
-		entries := []entry{}
-		for itr := n.MapIterator(); !itr.Done(); {
-			k, v, err := itr.Next()
-			if err != nil {
-				return err
+		if options.SortMapKeys {
+			// Collect map entries, then sort by key
+			type entry struct {
+				key   string
+				value ipld.Node
 			}
-			keyStr, err := k.AsString()
-			if err != nil {
-				return err
+			entries := []entry{}
+			for itr := n.MapIterator(); !itr.Done(); {
+				k, v, err := itr.Next()
+				if err != nil {
+					return err
+				}
+				keyStr, err := k.AsString()
+				if err != nil {
+					return err
+				}
+				entries = append(entries, entry{keyStr, v})
 			}
-			entries = append(entries, entry{keyStr, v})
-		}
-		sort.Slice(entries, func(i, j int) bool { return entries[i].key < entries[j].key })
-		// Emit map contents (and recurse).
-		for _, e := range entries {
-			tk.Type = tok.TString
-			tk.Str = e.key
-			if _, err := sink.Step(&tk); err != nil {
-				return err
+			sort.Slice(entries, func(i, j int) bool { return entries[i].key < entries[j].key })
+			// Emit map contents (and recurse).
+			for _, e := range entries {
+				tk.Type = tok.TString
+				tk.Str = e.key
+				if _, err := sink.Step(&tk); err != nil {
+					return err
+				}
+				if err := Marshal(e.value, sink, options); err != nil {
+					return err
+				}
 			}
-			if err := Marshal(e.value, sink, allowLinks); err != nil {
-				return err
+		} else {
+			// Don't sort map, emit map contents (and recurse).
+			for itr := n.MapIterator(); !itr.Done(); {
+				k, v, err := itr.Next()
+				if err != nil {
+					return err
+				}
+				tk.Type = tok.TString
+				tk.Str, err = k.AsString()
+				if err != nil {
+					return err
+				}
+				if _, err := sink.Step(&tk); err != nil {
+					return err
+				}
+				if err := Marshal(v, sink, options); err != nil {
+					return err
+				}
 			}
 		}
 		// Emit map close.
@@ -79,7 +114,7 @@ func Marshal(n ipld.Node, sink shared.TokenSink, allowLinks bool) error {
 			if err != nil {
 				return err
 			}
-			if err := Marshal(v, sink, allowLinks); err != nil {
+			if err := Marshal(v, sink, options); err != nil {
 				return err
 			}
 		}
@@ -128,7 +163,7 @@ func Marshal(n ipld.Node, sink shared.TokenSink, allowLinks bool) error {
 		if err != nil {
 			return err
 		}
-		if allowLinks {
+		if options.EncodeBytes {
 			// Precisely seven tokens to emit:
 			tk.Type = tok.TMapOpen
 			tk.Length = 1
@@ -170,7 +205,7 @@ func Marshal(n ipld.Node, sink shared.TokenSink, allowLinks bool) error {
 			return err
 		}
 	case ipld.Kind_Link:
-		if !allowLinks {
+		if !options.EncodeLinks {
 			return fmt.Errorf("cannot Marshal ipld links to JSON")
 		}
 		v, err := n.AsLink()

--- a/codec/dagjson/multicodec.go
+++ b/codec/dagjson/multicodec.go
@@ -21,7 +21,10 @@ func init() {
 }
 
 func Decode(na ipld.NodeAssembler, r io.Reader) error {
-	err := Unmarshal(na, json.NewDecoder(r), true)
+	err := Unmarshal(na, json.NewDecoder(r), UnmarshalOptions{
+		ParseLinks: true,
+		ParseBytes: true,
+	})
 	if err != nil {
 		return err
 	}
@@ -53,5 +56,10 @@ func Encode(n ipld.Node, w io.Writer) error {
 	// Shell out directly to generic inspection path.
 	//  (There's not really any fastpaths of note for json.)
 	// Write another function if you need to tune encoding options about whitespace.
-	return Marshal(n, json.NewEncoder(w, json.EncodeOptions{}), true)
+	return Marshal(n, json.NewEncoder(w, json.EncodeOptions{}),
+		MarshalOptions{
+			EncodeLinks: true,
+			EncodeBytes: true,
+			SortMapKeys: true,
+		})
 }

--- a/codec/dagjson/roundtripBytes_test.go
+++ b/codec/dagjson/roundtripBytes_test.go
@@ -15,7 +15,7 @@ var byteNode = fluent.MustBuildMap(basicnode.Prototype__Map{}, 4, func(na fluent
 	na.AssembleEntry("plain").AssignString("olde string")
 	na.AssembleEntry("bytes").AssignBytes([]byte("deadbeef"))
 })
-var byteSerial = `{"plain":"olde string","bytes":{"/":{"bytes":"ZGVhZGJlZWY="}}}`
+var byteSerial = `{"bytes":{"/":{"bytes":"ZGVhZGJlZWY="}},"plain":"olde string"}`
 
 func TestRoundtripBytes(t *testing.T) {
 	t.Run("encoding", func(t *testing.T) {

--- a/codec/dagjson/roundtripBytes_test.go
+++ b/codec/dagjson/roundtripBytes_test.go
@@ -15,6 +15,10 @@ var byteNode = fluent.MustBuildMap(basicnode.Prototype__Map{}, 4, func(na fluent
 	na.AssembleEntry("plain").AssignString("olde string")
 	na.AssembleEntry("bytes").AssignBytes([]byte("deadbeef"))
 })
+var byteNodeSorted = fluent.MustBuildMap(basicnode.Prototype__Map{}, 4, func(na fluent.MapAssembler) {
+	na.AssembleEntry("bytes").AssignBytes([]byte("deadbeef"))
+	na.AssembleEntry("plain").AssignString("olde string")
+})
 var byteSerial = `{"bytes":{"/":{"bytes":"ZGVhZGJlZWY="}},"plain":"olde string"}`
 
 func TestRoundtripBytes(t *testing.T) {
@@ -29,7 +33,7 @@ func TestRoundtripBytes(t *testing.T) {
 		nb := basicnode.Prototype__Map{}.NewBuilder()
 		err := Decode(nb, buf)
 		Require(t, err, ShouldEqual, nil)
-		Wish(t, nb.Build(), ShouldEqual, byteNode)
+		Wish(t, nb.Build(), ShouldEqual, byteNodeSorted)
 	})
 }
 

--- a/codec/dagjson/roundtripCidlink_test.go
+++ b/codec/dagjson/roundtripCidlink_test.go
@@ -36,7 +36,7 @@ func TestRoundtripCidlink(t *testing.T) {
 
 	n2, err := lsys.Load(ipld.LinkContext{}, lnk, basicnode.Prototype.Any)
 	Require(t, err, ShouldEqual, nil)
-	Wish(t, n2, ShouldEqual, n)
+	Wish(t, n2, ShouldEqual, nSorted)
 }
 
 // Make sure that a map that *almost* looks like a link is handled safely.

--- a/codec/dagjson/roundtrip_test.go
+++ b/codec/dagjson/roundtrip_test.go
@@ -27,7 +27,7 @@ var n = fluent.MustBuildMap(basicnode.Prototype__Map{}, 4, func(na fluent.MapAss
 		})
 	})
 })
-var serial = `{"plain":"olde string","map":{"one":1,"two":2},"list":["three","four"],"nested":{"deeper":["things"]}}`
+var serial = `{"list":["three","four"],"map":{"one":1,"two":2},"nested":{"deeper":["things"]},"plain":"olde string"}`
 
 func TestRoundtrip(t *testing.T) {
 	t.Run("encoding", func(t *testing.T) {

--- a/codec/dagjson/roundtrip_test.go
+++ b/codec/dagjson/roundtrip_test.go
@@ -27,6 +27,22 @@ var n = fluent.MustBuildMap(basicnode.Prototype__Map{}, 4, func(na fluent.MapAss
 		})
 	})
 })
+var nSorted = fluent.MustBuildMap(basicnode.Prototype__Map{}, 4, func(na fluent.MapAssembler) {
+	na.AssembleEntry("list").CreateList(2, func(na fluent.ListAssembler) {
+		na.AssembleValue().AssignString("three")
+		na.AssembleValue().AssignString("four")
+	})
+	na.AssembleEntry("map").CreateMap(2, func(na fluent.MapAssembler) {
+		na.AssembleEntry("one").AssignInt(1)
+		na.AssembleEntry("two").AssignInt(2)
+	})
+	na.AssembleEntry("nested").CreateMap(1, func(na fluent.MapAssembler) {
+		na.AssembleEntry("deeper").CreateList(1, func(na fluent.ListAssembler) {
+			na.AssembleValue().AssignString("things")
+		})
+	})
+	na.AssembleEntry("plain").AssignString("olde string")
+})
 var serial = `{"list":["three","four"],"map":{"one":1,"two":2},"nested":{"deeper":["things"]},"plain":"olde string"}`
 
 func TestRoundtrip(t *testing.T) {
@@ -41,7 +57,7 @@ func TestRoundtrip(t *testing.T) {
 		nb := basicnode.Prototype__Map{}.NewBuilder()
 		err := Decode(nb, buf)
 		Require(t, err, ShouldEqual, nil)
-		Wish(t, nb.Build(), ShouldEqual, n)
+		Wish(t, nb.Build(), ShouldEqual, nSorted)
 	})
 }
 

--- a/codec/json/multicodec.go
+++ b/codec/json/multicodec.go
@@ -24,7 +24,10 @@ func init() {
 func Decode(na ipld.NodeAssembler, r io.Reader) error {
 	// Shell out directly to generic builder path.
 	//  (There's not really any fastpaths of note for json.)
-	err := dagjson.Unmarshal(na, rfmtjson.NewDecoder(r), false)
+	err := dagjson.Unmarshal(na, rfmtjson.NewDecoder(r), dagjson.UnmarshalOptions{
+		ParseLinks: false,
+		ParseBytes: false,
+	})
 	if err != nil {
 		return err
 	}
@@ -59,5 +62,9 @@ func Encode(n ipld.Node, w io.Writer) error {
 	return dagjson.Marshal(n, rfmtjson.NewEncoder(w, rfmtjson.EncodeOptions{
 		Line:   []byte{'\n'},
 		Indent: []byte{'\t'},
-	}), false)
+	}), dagjson.MarshalOptions{
+		EncodeLinks: false,
+		EncodeBytes: false,
+		SortMapKeys: false,
+	})
 }

--- a/fluent/qp/example_test.go
+++ b/fluent/qp/example_test.go
@@ -30,5 +30,5 @@ func Example() {
 	dagjson.Encode(n, os.Stdout)
 
 	// Output:
-	// {"some key":"some value","another key":"another value","nested map":{"deeper entries":"deeper values","more deeper entries":"more deeper values"},"nested list":[1,2]}
+	// {"another key":"another value","nested list":[1,2],"nested map":{"deeper entries":"deeper values","more deeper entries":"more deeper values"},"some key":"some value"}
 }

--- a/node/bindnode/example_test.go
+++ b/node/bindnode/example_test.go
@@ -42,7 +42,7 @@ func ExampleWrap_withSchema() {
 	dagjson.Encode(nodeRepr, os.Stdout)
 
 	// Output:
-	// {"Name":"Michael","Friends":["Sarah","Alex"]}
+	// {"Friends":["Sarah","Alex"],"Name":"Michael"}
 }
 
 func ExamplePrototype_onlySchema() {
@@ -78,5 +78,5 @@ func ExamplePrototype_onlySchema() {
 	dagjson.Encode(nodeRepr, os.Stdout)
 
 	// Output:
-	// {"Name":"Michael","Friends":["Sarah","Alex"]}
+	// {"Friends":["Sarah","Alex"],"Name":"Michael"}
 }

--- a/node/tests/schemaStructsContainingMaybe.go
+++ b/node/tests/schemaStructsContainingMaybe.go
@@ -47,7 +47,7 @@ func SchemaTestStructsContainingMaybe(t *testing.T, engine Engine) {
 		{
 			name:     "vvvvv-AllFieldsSet",
 			typeJson: `{"f1":"a","f2":"b","f3":"c","f4":"d","f5":"e"}`,
-			reprJson: `{"r1":"a","r2":"b","r3":"c","r4":"d","f5":"e"}`,
+			reprJson: `{"f5":"e","r1":"a","r2":"b","r3":"c","r4":"d"}`,
 			typePoints: []testcasePoint{
 				{"", ipld.Kind_Map},
 				{"f1", "a"},
@@ -68,7 +68,7 @@ func SchemaTestStructsContainingMaybe(t *testing.T, engine Engine) {
 		{
 			name:     "vvnnv-Nulls",
 			typeJson: `{"f1":"a","f2":"b","f3":null,"f4":null,"f5":"e"}`,
-			reprJson: `{"r1":"a","r2":"b","r3":null,"r4":null,"f5":"e"}`,
+			reprJson: `{"f5":"e","r1":"a","r2":"b","r3":null,"r4":null}`,
 			typePoints: []testcasePoint{
 				{"", ipld.Kind_Map},
 				{"f1", "a"},
@@ -89,7 +89,7 @@ func SchemaTestStructsContainingMaybe(t *testing.T, engine Engine) {
 		{
 			name:     "vzvzv-AbsentOptionals",
 			typeJson: `{"f1":"a","f3":"c","f5":"e"}`,
-			reprJson: `{"r1":"a","r3":"c","f5":"e"}`,
+			reprJson: `{"f5":"e","r1":"a","r3":"c"}`,
 			typePoints: []testcasePoint{
 				{"", ipld.Kind_Map},
 				{"f1", "a"},

--- a/node/tests/testcase.go
+++ b/node/tests/testcase.go
@@ -210,7 +210,11 @@ func testMarshal(t *testing.T, n ipld.Node, data string) {
 	// We'll marshal with "pretty" linebreaks and indents (and re-format the fixture to the same) for better diffing.
 	prettyprint := json.EncodeOptions{Line: []byte{'\n'}, Indent: []byte{'\t'}}
 	var buf bytes.Buffer
-	err := dagjson.Marshal(n, json.NewEncoder(&buf, prettyprint), true)
+	err := dagjson.Marshal(n, json.NewEncoder(&buf, prettyprint), dagjson.MarshalOptions{
+		EncodeLinks: true,
+		EncodeBytes: true,
+		SortMapKeys: true,
+	})
 	if err != nil {
 		t.Errorf("marshal failed: %s", err)
 	}

--- a/traversal/focus_test.go
+++ b/traversal/focus_test.go
@@ -318,7 +318,7 @@ func TestFocusedTransformWithLinks(t *testing.T) {
 			Wish(t, progress.Path.String(), ShouldEqual, "linkedMap/nested/nonlink")
 			Wish(t, must.String(prev), ShouldEqual, "zoo")
 			Wish(t, progress.LastBlock.Path.String(), ShouldEqual, "linkedMap")
-			Wish(t, progress.LastBlock.Link.String(), ShouldEqual, "baguqeeye2opztzy")
+			Wish(t, progress.LastBlock.Link.String(), ShouldEqual, "baguqeeyezhlahvq")
 			nb := prev.Prototype().NewBuilder()
 			nb.AssignString("new string!")
 			return nb.Build(), nil


### PR DESCRIPTION
Let me count the ways that you're going to hate this @warpfork ... but this is what everyone else has agreed the spec should do, it's what go-ipfs is doing with its existing encoding/json usage so existing test fixtures all make this assumption, and this opens the way to get some cross-impl test fixtures in place.

As for my impl, yeah .. that might take some finessing.

Builds on #202 so whitespace removal is in here already.