### PR TITLE
Addtional examples of bindnode usage.

### DIFF
--- a/node/bindnode/example_test.go
+++ b/node/bindnode/example_test.go
@@ -1,6 +1,8 @@
 package bindnode_test
 
 import (
+	"bytes"
+	"fmt"
 	"os"
 
 	ipld "github.com/ipld/go-ipld-prime"
@@ -79,4 +81,105 @@ func ExamplePrototype_onlySchema() {
 
 	// Output:
 	// {"Friends":["Sarah","Alex"],"Name":"Michael"}
+}
+
+func ExampleWrap_withSchemaUsingStringjoinStruct() {
+	ts := schema.TypeSystem{}
+	ts.Init()
+	ts.Accumulate(schema.SpawnString("String"))
+	ts.Accumulate(schema.SpawnStruct("FooBarBaz",
+		[]schema.StructField{
+			schema.SpawnStructField("foo", "String", false, false),
+			schema.SpawnStructField("bar", "String", false, false),
+			schema.SpawnStructField("baz", "String", false, false),
+		},
+		schema.SpawnStructRepresentationStringjoin(":"),
+	))
+	schemaType := ts.TypeByName("FooBarBaz")
+
+	type FooBarBaz struct {
+		Foo string
+		Bar string
+		Baz string
+	}
+	fbb := &FooBarBaz{
+		Foo: "x",
+		Bar: "y",
+		Baz: "z",
+	}
+	node := bindnode.Wrap(fbb, schemaType)
+
+	// Take the representation of the node, and serialize it.
+	nodeRepr := node.Representation()
+	var buf bytes.Buffer
+	dagjson.Encode(nodeRepr, &buf)
+
+	// Output how this was serialized, for the example.
+	fmt.Fprintf(os.Stdout, "json: %s\n", buf.Bytes())
+
+	// Now unmarshal that again and print that too, to show it working both ways.
+	np := bindnode.Prototype(&FooBarBaz{}, schemaType)
+	nb := np.Representation().NewBuilder()
+	err := dagjson.Decode(nb, &buf)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("golang: %#v\n", bindnode.Unwrap(nb.Build()))
+
+	// Output:
+	// json: "x:y:z"
+	// golang: &bindnode_test.FooBarBaz{Foo:"x", Bar:"y", Baz:"z"}
+}
+
+func ExampleWrap_withSchemaUsingStringprefixUnion() {
+	ts := schema.TypeSystem{}
+	ts.Init()
+	ts.Accumulate(schema.SpawnString("Foo"))
+	ts.Accumulate(schema.SpawnString("Bar"))
+	ts.Accumulate(schema.SpawnUnion("FooOrBar",
+		[]schema.TypeName{
+			"Foo",
+			"Bar",
+		},
+		schema.SpawnUnionRepresentationStringprefix(
+			":", // n.b. this API will change soon; a schema-schema iteration has removed the distinct joiner string.
+			map[string]schema.TypeName{
+				"foo": "Foo",
+				"bar": "Bar",
+			},
+		),
+	))
+	schemaType := ts.TypeByName("FooOrBar")
+
+	// The golang structures for unions don't look as simple as one might like.  Golang has no native sum types, so we do something interesting here.
+	type FooOrBar struct {
+		Index int
+		Value interface{}
+	}
+	fob := &FooOrBar{
+		Index: 1,
+		Value: "oi",
+	}
+	node := bindnode.Wrap(fob, schemaType)
+
+	// Take the representation of the node, and serialize it.
+	nodeRepr := node.Representation()
+	var buf bytes.Buffer
+	dagjson.Encode(nodeRepr, &buf)
+
+	// Output how this was serialized, for the example.
+	fmt.Fprintf(os.Stdout, "json: %s\n", buf.Bytes())
+
+	// Now unmarshal that again and print that too, to show it working both ways.
+	np := bindnode.Prototype((*FooOrBar)(nil), schemaType)
+	nb := np.Representation().NewBuilder()
+	err := dagjson.Decode(nb, &buf)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("golang: %#v\n", bindnode.Unwrap(nb.Build()))
+
+	// Output:
+	// json: "bar:oi"
+	// golang: &bindnode_test.FooOrBar{Index:1, Value:"oi"}
 }


### PR DESCRIPTION
I added a few more examples of bindnode usage while poking around to make sure I knew for myself what it can do :)

Including exercise of:

- stringjoin representations of structs

- stringprefix representations of unions

- schema field names that do not directly equal go struct field names

- deserialization!

I'm not sure if they're ideal documentation; they're just what I ended up plonking out for myself to see.