### PR TITLE
Add link conditions for 'stop-at' expression in ExploreRecursive selector

### DIFF
--- a/traversal/selector/condition.go
+++ b/traversal/selector/condition.go
@@ -28,7 +28,7 @@ const (
 func (c *Condition) Match(n ipld.Node) bool {
 	switch c.mode {
 	case ConditionMode_Link:
-		if n.Kind() != ipld.Kind_Link || c.match.Kind() != ipld.Kind_Link {
+		if n.Kind() != ipld.Kind_Link {
 			return false
 		}
 		lnk, err := n.AsLink()

--- a/traversal/selector/condition.go
+++ b/traversal/selector/condition.go
@@ -1,0 +1,74 @@
+package selector
+
+import (
+	"fmt"
+
+	ipld "github.com/ipld/go-ipld-prime"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+)
+
+// Condition provides a mechanism for matching and limiting matching and
+// exploration of selectors.
+// Not all types of conditions which are imagined in the selector specification
+// are encoded at present, instead we currently only implement a subset that
+// is sufficient for initial pressing use cases.
+type Condition struct {
+	mode  ConditionMode
+	match ipld.Node
+}
+
+// A ConditionMode is the keyed representation for the union that is the condition
+type ConditionMode string
+
+const (
+	ConditionMode_Link ConditionMode = "/"
+)
+
+// Match decides if a given ipld.Node matches the condition.
+func (c *Condition) Match(n ipld.Node) bool {
+	switch c.mode {
+	case ConditionMode_Link:
+		if n.Kind() != ipld.Kind_Link || c.match.Kind() != ipld.Kind_Link {
+			return false
+		}
+		lnk, err := n.AsLink()
+		if err != nil {
+			return false
+		}
+		match, err := c.match.AsLink()
+		if err != nil {
+			return false
+		}
+		cidlnk, ok := lnk.(cidlink.Link)
+		cidmatch, ok2 := match.(cidlink.Link)
+		if ok && ok2 {
+			return cidmatch.Equals(cidlnk.Cid)
+		}
+		return match.String() == lnk.String()
+	default:
+		return false
+	}
+}
+
+// ParseCondition assembles a Condition from a condition selector node
+func (pc ParseContext) ParseCondition(n ipld.Node) (Condition, error) {
+	if n.Kind() != ipld.Kind_Map {
+		return Condition{}, fmt.Errorf("selector spec parse rejected: condition body must be a map")
+	}
+	if n.Length() != 1 {
+		return Condition{}, fmt.Errorf("selector spec parse rejected: condition is a keyed union and thus must be single-entry map")
+	}
+	kn, v, _ := n.MapIterator().Next()
+	kstr, _ := kn.AsString()
+	// Switch over the single key to determine which condition body comes next.
+	//  (This switch is where the keyed union discriminators concretely happen.)
+	switch ConditionMode(kstr) {
+	case ConditionMode_Link:
+		if _, err := v.AsLink(); err != nil {
+			return Condition{}, fmt.Errorf("selector spec parse rejected: condition_link must be a link")
+		}
+		return Condition{mode: ConditionMode_Link, match: v}, nil
+	default:
+		return Condition{}, fmt.Errorf("selector spec parse rejected: %q is not a known member of the condition union", kstr)
+	}
+}

--- a/traversal/selector/condition_test.go
+++ b/traversal/selector/condition_test.go
@@ -1,0 +1,44 @@
+package selector
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ipfs/go-cid"
+	. "github.com/warpfork/go-wish"
+
+	"github.com/ipld/go-ipld-prime/fluent"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	basicnode "github.com/ipld/go-ipld-prime/node/basic"
+)
+
+func TestParseCondition(t *testing.T) {
+	t.Run("parsing non map node should error", func(t *testing.T) {
+		sn := basicnode.NewInt(0)
+		_, err := ParseContext{}.ParseCondition(sn)
+		Wish(t, err, ShouldEqual, fmt.Errorf("selector spec parse rejected: condition body must be a map"))
+	})
+	t.Run("parsing map node without field should error", func(t *testing.T) {
+		sn := fluent.MustBuildMap(basicnode.Prototype__Map{}, 0, func(na fluent.MapAssembler) {})
+		_, err := ParseContext{}.ParseCondition(sn)
+		Wish(t, err, ShouldEqual, fmt.Errorf("selector spec parse rejected: condition is a keyed union and thus must be single-entry map"))
+	})
+
+	t.Run("parsing map node keyed to invalid type should error", func(t *testing.T) {
+		sn := fluent.MustBuildMap(basicnode.Prototype__Map{}, 1, func(na fluent.MapAssembler) {
+			na.AssembleEntry(string(ConditionMode_Link)).AssignInt(0)
+		})
+		_, err := ParseContext{}.ParseCondition(sn)
+		Wish(t, err, ShouldEqual, fmt.Errorf("selector spec parse rejected: condition_link must be a link"))
+	})
+	t.Run("parsing map node with condition field with valid selector node should parse", func(t *testing.T) {
+		lnk := cidlink.Link{Cid: cid.Undef}
+		sn := fluent.MustBuildMap(basicnode.Prototype__Map{}, 1, func(na fluent.MapAssembler) {
+			na.AssembleEntry(string(ConditionMode_Link)).AssignLink(lnk)
+		})
+		s, err := ParseContext{}.ParseCondition(sn)
+		Wish(t, err, ShouldEqual, nil)
+		lnkNode := basicnode.NewLink(lnk)
+		Wish(t, s, ShouldEqual, Condition{mode: ConditionMode_Link, match: lnkNode})
+	})
+}

--- a/traversal/selector/exploreRecursive.go
+++ b/traversal/selector/exploreRecursive.go
@@ -156,9 +156,6 @@ func (s ExploreRecursive) replaceRecursiveEdge(nextSelector Selector, replacemen
 
 // Decide if a node directly matches
 func (s ExploreRecursive) Decide(n ipld.Node) bool {
-	if s.stopAt != nil && s.stopAt.Match(n) {
-		return false
-	}
 	return s.current.Decide(n)
 }
 
@@ -203,7 +200,7 @@ func (pc ParseContext) ParseExploreRecursive(n ipld.Node) (Selector, error) {
 	var stopCondition *Condition
 	stop, err := n.LookupByString(SelectorKey_StopAt)
 	if err == nil {
-		condition, err := pc.PushParent(erc).ParseCondition(stop)
+		condition, err := pc.ParseCondition(stop)
 		if err != nil {
 			return nil, err
 		}

--- a/traversal/selector/exploreRecursive_test.go
+++ b/traversal/selector/exploreRecursive_test.go
@@ -130,7 +130,7 @@ func TestParseExploreRecursive(t *testing.T) {
 		})
 		s, err := ParseContext{}.ParseExploreRecursive(sn)
 		Wish(t, err, ShouldEqual, nil)
-		Wish(t, s, ShouldEqual, ExploreRecursive{ExploreAll{ExploreRecursiveEdge{}}, ExploreAll{ExploreRecursiveEdge{}}, RecursionLimit{RecursionLimit_Depth, 2}})
+		Wish(t, s, ShouldEqual, ExploreRecursive{ExploreAll{ExploreRecursiveEdge{}}, ExploreAll{ExploreRecursiveEdge{}}, RecursionLimit{RecursionLimit_Depth, 2}, nil})
 	})
 
 	t.Run("parsing map node with sequence field with valid selector node and limit type none should parse", func(t *testing.T) {
@@ -148,7 +148,7 @@ func TestParseExploreRecursive(t *testing.T) {
 		})
 		s, err := ParseContext{}.ParseExploreRecursive(sn)
 		Wish(t, err, ShouldEqual, nil)
-		Wish(t, s, ShouldEqual, ExploreRecursive{ExploreAll{ExploreRecursiveEdge{}}, ExploreAll{ExploreRecursiveEdge{}}, RecursionLimit{RecursionLimit_None, 0}})
+		Wish(t, s, ShouldEqual, ExploreRecursive{ExploreAll{ExploreRecursiveEdge{}}, ExploreAll{ExploreRecursiveEdge{}}, RecursionLimit{RecursionLimit_None, 0}, nil})
 	})
 
 }
@@ -181,7 +181,7 @@ func TestExploreRecursiveExplore(t *testing.T) {
 	t.Run("exploring should traverse until we get to maxDepth", func(t *testing.T) {
 		parentsSelector := ExploreAll{recursiveEdge}
 		subTree := ExploreFields{map[string]Selector{"Parents": parentsSelector}, []ipld.PathSegment{ipld.PathSegmentOfString("Parents")}}
-		rs = ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_Depth, maxDepth}}
+		rs = ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil}
 		nodeString := `{
 			"Parents": [
 				{
@@ -204,24 +204,24 @@ func TestExploreRecursiveExplore(t *testing.T) {
 		rn := nb.Build()
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupByString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfInt(0))
 		rn, err = rn.LookupByIndex(0)
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("Parents"))
 
 		rn, err = rn.LookupByString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfInt(0))
 		rn, err = rn.LookupByIndex(0)
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_Depth, maxDepth - 2}})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_Depth, maxDepth - 2}, nil})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupByString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 2}})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 2}, nil})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfInt(0))
 		rn, err = rn.LookupByIndex(0)
@@ -232,7 +232,7 @@ func TestExploreRecursiveExplore(t *testing.T) {
 	t.Run("exploring should traverse indefinitely if no depth specified", func(t *testing.T) {
 		parentsSelector := ExploreAll{recursiveEdge}
 		subTree := ExploreFields{map[string]Selector{"Parents": parentsSelector}, []ipld.PathSegment{ipld.PathSegmentOfString("Parents")}}
-		rs = ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_None, 0}}
+		rs = ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_None, 0}, nil}
 		nodeString := `{
 			"Parents": [
 				{
@@ -255,38 +255,38 @@ func TestExploreRecursiveExplore(t *testing.T) {
 		rn := nb.Build()
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupByString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_None, 0}})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_None, 0}, nil})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfInt(0))
 		rn, err = rn.LookupByIndex(0)
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_None, 0}})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_None, 0}, nil})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupByString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_None, 0}})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_None, 0}, nil})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfInt(0))
 		rn, err = rn.LookupByIndex(0)
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_None, 0}})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_None, 0}, nil})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupByString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_None, 0}})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_None, 0}, nil})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfInt(0))
 		rn, err = rn.LookupByIndex(0)
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_None, 0}})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_None, 0}, nil})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupByString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_None, 0}})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_None, 0}, nil})
 		Wish(t, err, ShouldEqual, nil)
 	})
 
 	t.Run("exploring should continue till we get to selector that returns nil on explore", func(t *testing.T) {
 		parentsSelector := ExploreIndex{recursiveEdge, [1]ipld.PathSegment{ipld.PathSegmentOfInt(1)}}
 		subTree := ExploreFields{map[string]Selector{"Parents": parentsSelector}, []ipld.PathSegment{ipld.PathSegmentOfString("Parents")}}
-		rs = ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_Depth, maxDepth}}
+		rs = ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil}
 		nodeString := `{
 			"Parents": {
 			}
@@ -298,7 +298,7 @@ func TestExploreRecursiveExplore(t *testing.T) {
 		rn := nb.Build()
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupByString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfInt(0))
 		Wish(t, rs, ShouldEqual, nil)
@@ -308,13 +308,13 @@ func TestExploreRecursiveExplore(t *testing.T) {
 		sideSelector := ExploreAll{recursiveEdge}
 		subTree := ExploreFields{map[string]Selector{
 			"Parents": parentsSelector,
-			"Side":    ExploreRecursive{sideSelector, sideSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}},
+			"Side":    ExploreRecursive{sideSelector, sideSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil},
 		}, []ipld.PathSegment{
 			ipld.PathSegmentOfString("Parents"),
 			ipld.PathSegmentOfString("Side"),
 		},
 		}
-		s := ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_Depth, maxDepth}}
+		s := ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil}
 		nodeString := `{
 			"Parents": [
 				{
@@ -347,15 +347,15 @@ func TestExploreRecursiveExplore(t *testing.T) {
 		rs = s
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupByString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfInt(0))
 		rn, err = rn.LookupByIndex(0)
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupByString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil})
 		Wish(t, err, ShouldEqual, nil)
 
 		// traverse down top level Side tree (nested recursion)
@@ -363,15 +363,15 @@ func TestExploreRecursiveExplore(t *testing.T) {
 		rs = s
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("Side"))
 		rn, err = rn.LookupByString("Side")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}}, RecursionLimit{RecursionLimit_Depth, maxDepth}})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil}, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("real"))
 		rn, err = rn.LookupByString("real")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}}, RecursionLimit{RecursionLimit_Depth, maxDepth}})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil}, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("apple"))
 		rn, err = rn.LookupByString("apple")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 2}}, RecursionLimit{RecursionLimit_Depth, maxDepth}})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 2}, nil}, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("sauce"))
 		rn, err = rn.LookupByString("sauce")
@@ -383,29 +383,29 @@ func TestExploreRecursiveExplore(t *testing.T) {
 		rs = s
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupByString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfInt(0))
 		rn, err = rn.LookupByIndex(0)
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("Side"))
 		rn, err = rn.LookupByString("Side")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}}, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil}, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("cheese"))
 		rn, err = rn.LookupByString("cheese")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}}, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil}, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("whiz"))
 		rn, err = rn.LookupByString("whiz")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 2}}, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 2}, nil}, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil})
 		Wish(t, err, ShouldEqual, nil)
 	})
 	t.Run("exploring should work with explore union and recursion", func(t *testing.T) {
 		parentsSelector := ExploreUnion{[]Selector{ExploreAll{Matcher{}}, ExploreIndex{recursiveEdge, [1]ipld.PathSegment{ipld.PathSegmentOfInt(0)}}}}
 		subTree := ExploreFields{map[string]Selector{"Parents": parentsSelector}, []ipld.PathSegment{ipld.PathSegmentOfString("Parents")}}
-		rs = ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_Depth, maxDepth}}
+		rs = ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil}
 		nodeString := `{
 			"Parents": [
 				{
@@ -428,20 +428,20 @@ func TestExploreRecursiveExplore(t *testing.T) {
 		rn := nb.Build()
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupByString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfInt(0))
 		rn, err = rn.LookupByIndex(0)
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreUnion{[]Selector{Matcher{}, subTree}}, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreUnion{[]Selector{Matcher{}, subTree}}, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfString("Parents"))
 
 		rn, err = rn.LookupByString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil})
 		Wish(t, err, ShouldEqual, nil)
 		rs = rs.Explore(rn, ipld.PathSegmentOfInt(0))
 		rn, err = rn.LookupByIndex(0)
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreUnion{[]Selector{Matcher{}, subTree}}, RecursionLimit{RecursionLimit_Depth, maxDepth - 2}})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreUnion{[]Selector{Matcher{}, subTree}}, RecursionLimit{RecursionLimit_Depth, maxDepth - 2}, nil})
 		Wish(t, err, ShouldEqual, nil)
 	})
 }


### PR DESCRIPTION
allows selectors of the form:
```json
{
		"R": {
			"l": {
				"none": 0
			},
			":>": {
				"a": {
					">": {
						"@": {}
					}
				}
			},
			"!": {
				"/": {
                                       "/":"bafyreifepiu23okq5zuyvyhsoiazv2icw2van3s7ko6d3ixl5jx2yj2yhu"
                                }
			}
		}
	}
```