### PR TITLE
Allow parsing of single Null tokens from refmt

### DIFF
--- a/codec/dagcbor/unmarshal.go
+++ b/codec/dagcbor/unmarshal.go
@@ -47,7 +47,7 @@ func unmarshal1(na ipld.NodeAssembler, tokSrc shared.TokenSource, gas *int, opti
 	if err != nil {
 		return err
 	}
-	if done && !tk.Type.IsValue() {
+	if done && !tk.Type.IsValue() && tk.Type != tok.TNull {
 		return fmt.Errorf("unexpected eof")
 	}
 	return unmarshal2(na, tokSrc, &tk, gas, options)

--- a/codec/dagjson/unmarshal.go
+++ b/codec/dagjson/unmarshal.go
@@ -37,7 +37,7 @@ func Unmarshal(na ipld.NodeAssembler, tokSrc shared.TokenSource, options Unmarsh
 	if err != nil {
 		return err
 	}
-	if done && !st.tk[0].Type.IsValue() {
+	if done && !st.tk[0].Type.IsValue() && st.tk[0].Type != tok.TNull {
 		return fmt.Errorf("unexpected eof")
 	}
 	return st.unmarshal(na, tokSrc)


### PR DESCRIPTION
For blocks that are simply "null":
 * dag-cbor: `0xf6`
 * dag-json: `null`