### PR TITLE
Printer feature

### DIFF
--- a/printer/doc.go
+++ b/printer/doc.go
@@ -1,0 +1,94 @@
+/*
+Printer provides features for printing out IPLD nodes and their contained data in a human-readable diagnostic format.
+
+Outputs should look like...
+
+	map{
+		"foo": "bar"
+		"zot": struct<Foobar>{
+			someFieldName: list{
+				0: "this"
+				1: "is untyped"
+				2: int{400}
+				3: bool{true}
+			}
+			otherField: list<ANamedListType>{
+				0: "mind you: 'ANamedListType' is the name of the *list type*."
+				1: "it is not the name of the value types.  those are not actually shown here."
+				2: "you'd have to look at the schema for that information."
+			}
+			moreField: list<[nullable String]>{
+				0: "this is a typed list"
+				1: "but anonymous"
+				2: null
+			}
+		}
+		"frog": map<{String:String}>{
+			"as you have probably imagined": "this is a typed (but anonymous type) map"
+		}
+		"numbers": int{1}
+		"binary": bytes{ABCDEF0123456789}
+		"typed numbers": int<MyNamedTypeInt>{9000}
+		"typed string": string<MyNamedTypeString>{"okay, this one needed some marker prefixes."}
+		"map with typed keys": map<{MyNamedTypeString:MyNamedTypeString}>{
+			"despite being typed": string<MyNamedTypeString>{"map keys still never need prefixes; there's no ambiguity"}
+			"but for the values": string<MyNamedTypeString>{"we still use them"}
+			"well, maybe": string<MyNamedTypeString>{"this might actually be worth debating; it doesn't seem necessary (unless the map value is a variant type, but that's then already addressed by another case)"}
+		}
+		"structs": struct<FooBar>{
+			foo: "do not need to have quoted field names"
+			bar: "because (unlike map keys) their character range is already restricted"
+		}
+		"unit types": unit<TheTypeName>
+		"notice unit types": "have no braces at all, because they have literally no further details.  they're all type info."
+		"variants": variant<TheUnionName>{string<TheInhabitant>{
+			"that was wild, wasn't it.  Check out these double closing braces, coming up, too!  also the string got forced to a new line, even though it usually would've clung closer to its type and kind marker."
+		}}
+		"enums": enum<TheEnumName>{"inhabitant name"}
+		"typed bools": bool<TheBoolName>{true}
+		"map with struct keys": map<{FooBar:String}>{
+			struct<FooBar>{foo:"foo", bar:"bar"}: "that one probably surprised you, didn't it?"
+			struct<FooBar>{foo:"hmmm", bar:"maybe"}: "we might be able to get away without the kind+type marker, actually.  but we need the one-liner struct content printing, at least, for sure."
+		}
+		"map with really wicked keys": map<{WickedNestedUnion:String}>{
+			variant<WickedNestedUnion>{variant<AnotherUnion>{string<TheInhabitant>{"wow"}}}: "yeah, that happens sometimes"
+		}
+	}
+
+
+Notice that strings can be emitted without a kind indicator.
+This is optional, and configurable, but a default, because strings are so common
+(and also, that the quotation marks already make them sufficiently clear)
+that it's neither necessary nor desirable to burden every string with a kind indicator.
+Everything else *does* have an explicit leading indicator that names the data's kind.
+Maps and lists already need enough syntactic weight that adding another few characters isn't a significant weight.
+For the various number kinds... well, it seems better to be clear, with those.  (Number parsers are otherwise often an annoying lookahead problem.)
+For bytes, the need is obvious.  (Among other things, the hexidecimal up until the first letter could be confused with an integer, if we didn't label both of them.)
+Anything that's typed also gets a leading indicator section again, even if its kind is something we'd otherwise elide, like string.
+
+Notice that struct fields aren't quoted.  (It's not necessary, because field names are already constrained.)
+But map keys are.  (They need quoting because they can be any string.)
+
+Note that the output of printer is NOT INTENDED TO BE PARSABLE.
+It is NOT an IPLD codec!
+It is a diagnostic format only.
+Much of the information included (especially about schema type information)
+is _more_ information than the IPLD data model holds alone,
+so trying to re-parse the printer output would be a strange choice.
+
+The diagnostic format emitted by printer is not formally specified,
+and is not necessarily language-agnostic.
+It may not even remain stable across releases of this library.
+It is intended to be used for diagnostics only.
+
+*/
+package printer
+
+/*
+How to print ADLs is not yet clear.
+
+Perhaps something like `<!TheADLName>` will do;
+this would also stack reasonably clearly with types as `<TheTypeName!TheADLName>`;
+this style would have the downside of making ADLs look *very* different than other mere representation strategies,
+which may be totally reasonable or mildly questionable depending on how purist you feel about that.
+*/

--- a/printer/printer.go
+++ b/printer/printer.go
@@ -1,0 +1,234 @@
+package printer
+
+import (
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/ipld/go-ipld-prime/datamodel"
+	"github.com/ipld/go-ipld-prime/schema"
+)
+
+// Print emits a textual description of the node tree straight to stdout.
+// All printer configuration will be the default;
+// links will be printed, and will not be traversed.
+func Print(n datamodel.Node) {
+	Fprint(os.Stdout, n)
+}
+
+// Sprint returns a textual description of the node tree.
+// All printer configuration will be the default;
+// links will be printed, and will not be traversed.
+func Sprint(n datamodel.Node) string {
+	var buf strings.Builder
+	Fprint(&buf, n)
+	return buf.String()
+}
+
+// Fprint accepts an io.Writer to which a textual description of the node tree will be written.
+// All printer configuration will be the default;
+// links will be printed, and will not be traversed.
+func Fprint(w io.Writer, n datamodel.Node) {
+	Config{}.Fprint(w, n)
+}
+
+// Fprint accepts an io.Writer to which a textual description of the node tree will be written.
+// The configuration structure this method is attached to can be used to specified details
+// for how the printout will be formatted.
+func (cfg Config) Fprint(w io.Writer, n datamodel.Node) {
+	pr := printBuf{w, cfg}
+	pr.Config.init()
+	pr.doString(0, printState_normal, n)
+}
+
+type Config struct {
+	// If true, long strings and long byte sequences will truncated, and will include ellipses instead.
+	//
+	// Not yet supported.
+	Abbreviate bool
+
+	// If set, the indentation to use.
+	// If nil, it will be treated as a default "\t".
+	Indentation []byte
+
+	// Probably does exactly what you think it does.
+	StartingIndent []byte
+
+	// Set to true if you like verbosity, I guess.
+	// If false, strings will only have kind+type markings if they're typed.
+	//
+	// Not yet supported.
+	AlwaysMarkStrings bool
+}
+
+func (cfg *Config) init() {
+	if cfg.Indentation == nil {
+		cfg.Indentation = []byte{'\t'}
+	}
+}
+
+// oneline decides if a value should be flatted into printing on a single,
+// or if it's allowed to spread out over multiple lines.
+// Note that this will not be asked if something outside of a value has already declared it's
+// doing a oneline rendering; that railroads everything within it into that mode too.
+func (cfg Config) oneline(typ schema.Type, isInKey bool) bool {
+	return isInKey // Future: this could become customizable, with some kind of Always|OnlyInKeys|Never option enum per type.
+}
+
+// useRepr decides if a value should be printed using its representation.
+// Sometimes configuring this to be true for structs or unions with stringy representations
+// will cause map printouts using them as keys to become drastically more readable
+// (if with some loss of informativeness, or at least loss of explicitness).
+func (cfg Config) useRepr(typ schema.Type, isInKey bool) bool {
+	return false
+}
+
+// FUTURE: one could imagine putting an optional LinkSystem param into the Config, too, and some recursion control.
+// It's definitely going to be the default to do zero recursion across links, though,
+// as doing that requires creating graph visualizations, and that is both possible, yet to do well becomes rather nontrivial.
+// Also, often a single node's tree visualization has been enough to get started debugging whatever I need to debug so far.
+
+type printBuf struct {
+	wr io.Writer
+
+	Config
+}
+
+func (z *printBuf) writeString(s string) {
+	z.wr.Write([]byte(s))
+}
+
+func (z *printBuf) doIndent(indentLevel int) {
+	z.wr.Write(z.Config.StartingIndent)
+	for i := 0; i < indentLevel; i++ {
+		z.wr.Write(z.Config.Indentation)
+	}
+}
+
+const (
+	printState_normal  = iota
+	printState_isKey   // may sometimes entersen or stringify things harder.
+	printState_isValue // signals that we're continuing a line that started with a key (so, don't emit indent).
+)
+
+func (z *printBuf) doString(indentLevel int, printState uint8, n datamodel.Node) {
+	// First: indent.
+	switch printState {
+	case printState_normal, printState_isKey:
+		z.doIndent(indentLevel)
+	}
+	// Second: the typekind and type name; or, just the kind, if there's no type.
+	if tn, ok := n.(schema.TypedNode); ok {
+		z.writeString(tn.Type().TypeKind().String())
+		z.writeString("<")
+		z.writeString(string(tn.Type().Name()))
+		z.writeString(">")
+		switch tn.Type().TypeKind() {
+		case schema.TypeKind_Invalid:
+			z.writeString("{?!}")
+		case schema.TypeKind_Map:
+			// continue -- the data-model driven behavior is sufficient to handle the content.
+		case schema.TypeKind_List:
+			// continue -- the data-model driven behavior is sufficient to handle the content.
+		case schema.TypeKind_Unit:
+			return // that's it!  there's no content data for a unit type.
+		case schema.TypeKind_Bool:
+			// continue -- the data-model driven behavior is sufficient to handle the content.
+		case schema.TypeKind_Int:
+			// continue -- the data-model driven behavior is sufficient to handle the content.
+		case schema.TypeKind_Float:
+			// continue -- the data-model driven behavior is sufficient to handle the content.
+		case schema.TypeKind_String:
+			// continue -- the data-model driven behavior is sufficient to handle the content.
+		case schema.TypeKind_Bytes:
+			// continue -- the data-model driven behavior is sufficient to handle the content.
+		case schema.TypeKind_Link:
+			// continue -- the data-model driven behavior is sufficient to handle the content.
+		case schema.TypeKind_Struct:
+			panic("TODO")
+		case schema.TypeKind_Union:
+			panic("TODO")
+		case schema.TypeKind_Enum:
+			panic("TODO")
+		default:
+			panic("unreachable")
+		}
+	} else {
+		z.writeString(n.Kind().String())
+	}
+	// Third: all the actual content.
+	// FUTURE: this is probably gonna become... somewhat more conditional, and may end up being a sub-function to be reasonably wieldy.
+	switch n.Kind() {
+	case datamodel.Kind_Map:
+		z.writeString("{\n")
+		for itr := n.MapIterator(); !itr.Done(); {
+			k, v, err := itr.Next()
+			if err != nil {
+				z.doIndent(indentLevel + 1)
+				z.writeString("!! map iteration step yielded error: ")
+				z.writeString(err.Error())
+				z.writeString("\n")
+				break
+			}
+			z.doString(indentLevel+1, printState_isKey, k)
+			z.writeString(": ")
+			z.doString(indentLevel+1, printState_isValue, v)
+			z.writeString("\n")
+		}
+		z.doIndent(indentLevel)
+		z.writeString("}")
+	case datamodel.Kind_List:
+		z.writeString("{\n")
+		for itr := n.ListIterator(); !itr.Done(); {
+			idx, v, err := itr.Next()
+			if err != nil {
+				z.doIndent(indentLevel + 1)
+				z.writeString("!! list iteration step yielded error: ")
+				z.writeString(err.Error())
+				z.writeString("\n")
+				break
+			}
+			z.doIndent(indentLevel + 1)
+			z.writeString(strconv.FormatInt(idx, 10))
+			z.writeString(": ")
+			z.doString(indentLevel+1, printState_isValue, v)
+			z.writeString("\n")
+		}
+		z.doIndent(indentLevel)
+		z.writeString("}")
+	case datamodel.Kind_Null:
+		if n.IsAbsent() {
+			z.writeString("absent\n")
+		} else {
+			z.writeString("null\n")
+		}
+	case datamodel.Kind_Bool:
+		z.writeString("{")
+		if b, _ := n.AsBool(); b {
+			z.writeString("true\n")
+		} else {
+			z.writeString("false\n")
+		}
+		z.writeString("}")
+	case datamodel.Kind_Int:
+		x, _ := n.AsInt()
+		z.writeString("{")
+		z.writeString(strconv.FormatInt(x, 10))
+		z.writeString("}")
+	case datamodel.Kind_Float:
+		x, _ := n.AsFloat()
+		z.writeString("{")
+		strconv.FormatFloat(x, 'f', -1, 64)
+		z.writeString("}")
+	case datamodel.Kind_String:
+		x, _ := n.AsString()
+		z.writeString("{")
+		z.writeString(strconv.QuoteToGraphic(x))
+		z.writeString("}")
+	case datamodel.Kind_Bytes:
+		panic("TODO")
+	case datamodel.Kind_Link:
+		panic("TODO")
+	}
+}

--- a/printer/printer.go
+++ b/printer/printer.go
@@ -72,9 +72,24 @@ type Config struct {
 	// Not yet supported.
 	AlwaysMarkStrings bool
 
-	AlwaysUseMapComplexStyle bool
+	// Set to true if you want type info to be skipped for any type that's in the Prelude
+	// (e.g. instead of `string<String>{` seeing only `string{` is preferred, etc).
+	//
+	// Not yet supported.
+	ElidePreludeTypeInfo bool
 
-	SpecificMapComplexStyle map[schema.TypeName]bool
+	// Set to true if you want maps to use "complex"-style printouts:
+	// meaning they will print their keys on separate lines than their values,
+	// and keys may spread across mutiple lines if appropriate.
+	//
+	// If not set, a heuristic will be used based on if the map is known to
+	// have keys that are complex enough that rendering them as oneline seems likely to overload.
+	// See Config.useCmplxKeys for exactly how that's deteremined.
+	UseMapComplexStyleAlways bool
+
+	// For maps to use "complex"-style printouts (or not) per type.
+	// See docs on UseMapComplexStyleAlways for the overview of what "complex"-style means.
+	UseMapComplexStyleOnType map[schema.TypeName]bool
 }
 
 func (cfg *Config) init() {
@@ -101,14 +116,14 @@ func (cfg Config) useRepr(typ schema.Type, isInKey bool) bool {
 
 // useCmplxKeys decides if a map should print itself using a multi-line and extra-indented style for keys.
 func (cfg Config) useCmplxKeys(mapn datamodel.Node) bool {
-	if cfg.AlwaysUseMapComplexStyle {
+	if cfg.UseMapComplexStyleAlways {
 		return true
 	}
 	tn, ok := mapn.(schema.TypedNode)
 	if !ok {
 		return false
 	}
-	force, ok := cfg.SpecificMapComplexStyle[tn.Type().Name()]
+	force, ok := cfg.UseMapComplexStyleOnType[tn.Type().Name()]
 	if ok {
 		return force
 	}

--- a/printer/printer.go
+++ b/printer/printer.go
@@ -234,6 +234,10 @@ func (z *printBuf) doString(indentLevel int, printState uint8, n datamodel.Node)
 			panic("unreachable")
 		}
 	} else {
+		if n.IsAbsent() {
+			z.writeString("absent")
+			return
+		}
 		z.writeString(n.Kind().String())
 	}
 	// Third: all the actual content.
@@ -287,17 +291,13 @@ func (z *printBuf) doString(indentLevel int, printState uint8, n datamodel.Node)
 		z.doIndent(indentLevel)
 		z.writeString("}")
 	case datamodel.Kind_Null:
-		if n.IsAbsent() {
-			z.writeString("absent\n")
-		} else {
-			z.writeString("null\n")
-		}
+		// nothing: we already wrote the word "null" when we wrote the kind info prefix.
 	case datamodel.Kind_Bool:
 		z.writeString("{")
 		if b, _ := n.AsBool(); b {
-			z.writeString("true\n")
+			z.writeString("true")
 		} else {
-			z.writeString("false\n")
+			z.writeString("false")
 		}
 		z.writeString("}")
 	case datamodel.Kind_Int:

--- a/printer/printer.go
+++ b/printer/printer.go
@@ -227,7 +227,14 @@ func (z *printBuf) doString(indentLevel int, printState uint8, n datamodel.Node)
 			z.writeString("}")
 			return
 		case schema.TypeKind_Union:
-			panic("TODO")
+			// There will only be one thing in it, but we still have to use an iterator
+			//  to figure out what that is if we're doing this generically.
+			//  We can ignore the key and just look at the value type again though (even though those are the same in practice).
+			_, v, _ := n.MapIterator().Next()
+			z.writeString("{")
+			z.doString(indentLevel, printState_isValue, v)
+			z.writeString("}")
+			return
 		case schema.TypeKind_Enum:
 			panic("TODO")
 		default:

--- a/printer/printer_test.go
+++ b/printer/printer_test.go
@@ -128,7 +128,7 @@ func TestTypedData(t *testing.T) {
 		}, ts.TypeByName("WowMap"))
 		t.Run("complex-keys-in-effect", func(t *testing.T) {
 			cfg := Config{
-				AlwaysUseMapComplexStyle: true,
+				UseMapComplexStyleAlways: true,
 			}
 			qt.Check(t, cfg.Sprint(n), qt.CmpEquals(), wish.Dedent(`
 				map<WowMap>{
@@ -159,7 +159,7 @@ func TestTypedData(t *testing.T) {
 		})
 		t.Run("complex-keys-in-disabled", func(t *testing.T) {
 			cfg := Config{
-				SpecificMapComplexStyle: map[schema.TypeName]bool{
+				UseMapComplexStyleOnType: map[schema.TypeName]bool{
 					"WowMap": false,
 				},
 			}

--- a/printer/printer_test.go
+++ b/printer/printer_test.go
@@ -26,7 +26,7 @@ func TestSimpleData(t *testing.T) {
 			qp.ListEntry(la, qp.Int(2))
 		}))
 	})
-	qt.Check(t, Sprint(n), qt.Equals, wish.Dedent(`
+	qt.Check(t, Sprint(n), qt.CmpEquals(), wish.Dedent(`
 		map{
 			string{"some key"}: string{"some value"}
 			string{"another key"}: string{"another value"}
@@ -56,7 +56,7 @@ func TestTypedData(t *testing.T) {
 			}, nil),
 		)
 		n := bindnode.Wrap(&FooBar{"x", "y"}, ts.TypeByName("FooBar"))
-		qt.Check(t, Sprint(n), qt.Equals, wish.Dedent(`
+		qt.Check(t, Sprint(n), qt.CmpEquals(), wish.Dedent(`
 			struct<FooBar>{
 				foo: string<String>{"x"}
 				bar: string<String>{"y"}
@@ -87,7 +87,7 @@ func TestTypedData(t *testing.T) {
 				{"z", "z"}: "b",
 			},
 		}, ts.TypeByName("WowMap"))
-		qt.Check(t, Sprint(n), qt.Equals, wish.Dedent(`
+		qt.Check(t, Sprint(n), qt.CmpEquals(), wish.Dedent(`
 			map<WowMap>{
 				struct<FooBar>{foo: string<String>{"x"}, bar: string<String>{"y"}}: string<String>{"a"}
 				struct<FooBar>{foo: string<String>{"z"}, bar: string<String>{"z"}}: string<String>{"b"}
@@ -130,7 +130,7 @@ func TestTypedData(t *testing.T) {
 			cfg := Config{
 				AlwaysUseMapComplexStyle: true,
 			}
-			qt.Check(t, cfg.Sprint(n), qt.Equals, wish.Dedent(`
+			qt.Check(t, cfg.Sprint(n), qt.CmpEquals(), wish.Dedent(`
 				map<WowMap>{
 					struct<FooBar>{
 							foo: string<String>{"x"}
@@ -163,7 +163,7 @@ func TestTypedData(t *testing.T) {
 					"WowMap": false,
 				},
 			}
-			qt.Check(t, cfg.Sprint(n), qt.Equals, wish.Dedent(`
+			qt.Check(t, cfg.Sprint(n), qt.CmpEquals(), wish.Dedent(`
 				map<WowMap>{
 					struct<FooBar>{foo: string<String>{"x"}, bar: struct<Baz>{baz: string<String>{"y"}}, baz: struct<Baz>{baz: string<String>{"y"}}}: struct<Baz>{
 						baz: string<String>{"a"}

--- a/printer/printer_test.go
+++ b/printer/printer_test.go
@@ -1,0 +1,38 @@
+package printer
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/ipld/go-ipld-prime/datamodel"
+	"github.com/ipld/go-ipld-prime/fluent/qp"
+	"github.com/ipld/go-ipld-prime/node/basicnode"
+)
+
+func TestSimpleData(t *testing.T) {
+	n, _ := qp.BuildMap(basicnode.Prototype.Any, -1, func(ma datamodel.MapAssembler) {
+		qp.MapEntry(ma, "some key", qp.String("some value"))
+		qp.MapEntry(ma, "another key", qp.String("another value"))
+		qp.MapEntry(ma, "nested map", qp.Map(2, func(ma datamodel.MapAssembler) {
+			qp.MapEntry(ma, "deeper entries", qp.String("deeper values"))
+			qp.MapEntry(ma, "more deeper entries", qp.String("more deeper values"))
+		}))
+		qp.MapEntry(ma, "nested list", qp.List(2, func(la datamodel.ListAssembler) {
+			qp.ListEntry(la, qp.Int(1))
+			qp.ListEntry(la, qp.Int(2))
+		}))
+	})
+	qt.Check(t, Sprint(n), qt.Equals, `map{
+	string{"some key"}: string{"some value"}
+	string{"another key"}: string{"another value"}
+	string{"nested map"}: map{
+		string{"deeper entries"}: string{"deeper values"}
+		string{"more deeper entries"}: string{"more deeper values"}
+	}
+	string{"nested list"}: list{
+		0: int{1}
+		1: int{2}
+	}
+}`)
+}

--- a/printer/printer_test.go
+++ b/printer/printer_test.go
@@ -87,17 +87,10 @@ func TestTypedData(t *testing.T) {
 				{"z", "z"}: "b",
 			},
 		}, ts.TypeByName("WowMap"))
-		// This is fairly nasty on the eye, but certainly accurate.
 		qt.Check(t, Sprint(n), qt.Equals, wish.Dedent(`
 			map<WowMap>{
-				struct<FooBar>{
-					foo: string<String>{"x"}
-					bar: string<String>{"y"}
-				}: string<String>{"a"}
-				struct<FooBar>{
-					foo: string<String>{"z"}
-					bar: string<String>{"z"}
-				}: string<String>{"b"}
+				struct<FooBar>{foo: string<String>{"x"}, bar: string<String>{"y"}}: string<String>{"a"}
+				struct<FooBar>{foo: string<String>{"z"}, bar: string<String>{"z"}}: string<String>{"b"}
 			}`,
 		))
 	})


### PR DESCRIPTION
I've started developing a `printer` feature, which provides a human-readable debugging output describing a tree of nodes.

This is an answer to https://github.com/ipld/go-ipld-prime/issues/88 .

- :heavy_check_mark: It's reasonably human readable, and rich in information.
- :heavy_check_mark: It can describe typed or untyped data, or a mixture of it.
- :heavy_check_mark: Everything works generically over the `datamodel.Node` interface, and feature-detects `schema.TypedNode` as appropriate.
- :heavy_check_mark: No additional methods are needed from nodes.
- :heavy_check_mark: There are a number of configuration options already (and probably more are desired).
- :non-potable_water: Nongoal: it's not a codec.  It's not intended to be parsable!  (This is important: I want this to provide _more_ information than data model alone, which means it's definitionally _not_ a codec.)
- :shrug: Does not currently log anything about the node implementation type (e.g. bindnode vs basicnode vs custom/codegen'd).  We could add this in the future if it seems useful?
- :shrug: It's not standardized.  (I don't see any reason to aggressively push this to be a cross-language thing.  If it evolves well and seems desirable?  Okay, sure.  But we don't need to start there.)  On the plus side: that also means it's not frozen to this format.

The syntax is somewhat impulsively chosen.  Roughly, it's `kindname{"value"}` (so: `string{"foo"}` and `int{12}` and `bool{true}` etc), or for typed information, `typekindname<TheTypeName>{"value"}`.  You can check out the tests for a few more examples of how it looks.  We could bikeshed this syntax, I suppose, but so far, I'm finding it tolerably readable.

I've started using this in debugging myself already as I work using go-ipld-prime as a downstream user in other projects, and it's saving me tons of time, and also starting to show up in my docs there to explain features to people.  I'm pretty happy about it.  (Also: it means I'm already relatively attached to some of these commit hashes and will try to roll forward and resist a need to rebase if possible.)

In the future, I'd like to add some functions to the root `ipld` package which call these printer features, for rapid easy use and for discoverability, but that's not included in this PR yet.

Review welcome.  This seems like the sort of thing I'd rather merge relatively quickly, and continue iterating on master, though.