### PR TITLE
bindnode: fix for stringjoin struct emission when first field is the empty string

### DIFF
--- a/node/bindnode/repr.go
+++ b/node/bindnode/repr.go
@@ -364,6 +364,7 @@ func (w *_nodeRepr) AsString() (string, error) {
 	case schema.StructRepresentation_Stringjoin:
 		var b strings.Builder
 		itr := (*_node)(w).MapIterator()
+		first := true
 		for !itr.Done() {
 			_, v, err := itr.Next()
 			if err != nil {
@@ -373,7 +374,9 @@ func (w *_nodeRepr) AsString() (string, error) {
 			if err != nil {
 				return "", err
 			}
-			if b.Len() > 0 {
+			if first {
+				first = false
+			} else {
 				b.WriteString(stg.GetDelim())
 			}
 			b.WriteString(s)


### PR DESCRIPTION
In the case of an empty string as the first field, the buffer length
is not a valid proxy for whether we're on the first field or not.

This means if we have some type like:
`type Foo struct {a String; b String} representation stringjoin(":")`,
and the value of it is `{"", "b"}`, then the string of that
should still be ":b".

Before this fix, it would incorrectly be emitted as "b" (no joiner),
which would not round-trip.