### PR TITLE
Add bypass condition to ExploreRecursive selector

### DIFF
--- a/traversal/selector/condition_test.go
+++ b/traversal/selector/condition_test.go
@@ -30,8 +30,16 @@ func TestParseCondition(t *testing.T) {
 		})
 		_, err := ParseContext{}.ParseCondition(sn)
 		Wish(t, err, ShouldEqual, fmt.Errorf("selector spec parse rejected: condition_link must be a link"))
+
+		// Condition_HasField
+		sn = fluent.MustBuildMap(basicnode.Prototype.Map, 1, func(na fluent.MapAssembler) {
+			na.AssembleEntry(string(ConditionMode_HasField)).AssignInt(0)
+		})
+		_, err = ParseContext{}.ParseCondition(sn)
+		Wish(t, err, ShouldEqual, fmt.Errorf("selector spec parse rejected: condition_hasField must be a string"))
 	})
 	t.Run("parsing map node with condition field with valid selector node should parse", func(t *testing.T) {
+		//Condition_Link
 		lnk := cidlink.Link{Cid: cid.Undef}
 		sn := fluent.MustBuildMap(basicnode.Prototype.Map, 1, func(na fluent.MapAssembler) {
 			na.AssembleEntry(string(ConditionMode_Link)).AssignLink(lnk)
@@ -40,5 +48,14 @@ func TestParseCondition(t *testing.T) {
 		Wish(t, err, ShouldEqual, nil)
 		lnkNode := basicnode.NewLink(lnk)
 		Wish(t, s, ShouldEqual, Condition{mode: ConditionMode_Link, match: lnkNode})
+
+		//Condition_HasField
+		sn = fluent.MustBuildMap(basicnode.Prototype.Map, 1, func(na fluent.MapAssembler) {
+			na.AssembleEntry(string(ConditionMode_HasField)).AssignString("field")
+		})
+		s, err = ParseContext{}.ParseCondition(sn)
+		Wish(t, err, ShouldEqual, nil)
+		strNode := basicnode.NewString("field")
+		Wish(t, s, ShouldEqual, Condition{mode: ConditionMode_HasField, match: strNode})
 	})
 }

--- a/traversal/selector/exploreRecursive_test.go
+++ b/traversal/selector/exploreRecursive_test.go
@@ -130,7 +130,7 @@ func TestParseExploreRecursive(t *testing.T) {
 		})
 		s, err := ParseContext{}.ParseExploreRecursive(sn)
 		Wish(t, err, ShouldEqual, nil)
-		Wish(t, s, ShouldEqual, ExploreRecursive{ExploreAll{ExploreRecursiveEdge{}}, ExploreAll{ExploreRecursiveEdge{}}, RecursionLimit{RecursionLimit_Depth, 2}, nil})
+		Wish(t, s, ShouldEqual, ExploreRecursive{ExploreAll{ExploreRecursiveEdge{}}, ExploreAll{ExploreRecursiveEdge{}}, RecursionLimit{RecursionLimit_Depth, 2}, nil, nil})
 	})
 
 	t.Run("parsing map node with sequence field with valid selector node and limit type none should parse", func(t *testing.T) {
@@ -148,7 +148,7 @@ func TestParseExploreRecursive(t *testing.T) {
 		})
 		s, err := ParseContext{}.ParseExploreRecursive(sn)
 		Wish(t, err, ShouldEqual, nil)
-		Wish(t, s, ShouldEqual, ExploreRecursive{ExploreAll{ExploreRecursiveEdge{}}, ExploreAll{ExploreRecursiveEdge{}}, RecursionLimit{RecursionLimit_None, 0}, nil})
+		Wish(t, s, ShouldEqual, ExploreRecursive{ExploreAll{ExploreRecursiveEdge{}}, ExploreAll{ExploreRecursiveEdge{}}, RecursionLimit{RecursionLimit_None, 0}, nil, nil})
 	})
 
 }
@@ -181,7 +181,7 @@ func TestExploreRecursiveExplore(t *testing.T) {
 	t.Run("exploring should traverse until we get to maxDepth", func(t *testing.T) {
 		parentsSelector := ExploreAll{recursiveEdge}
 		subTree := ExploreFields{map[string]Selector{"Parents": parentsSelector}, []datamodel.PathSegment{datamodel.PathSegmentOfString("Parents")}}
-		rs = ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil}
+		rs = ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil, nil}
 		nodeString := `{
 			"Parents": [
 				{
@@ -204,24 +204,24 @@ func TestExploreRecursiveExplore(t *testing.T) {
 		rn := nb.Build()
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupByString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil, nil})
 		Wish(t, err, ShouldEqual, nil)
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfInt(0))
 		rn, err = rn.LookupByIndex(0)
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil, nil})
 		Wish(t, err, ShouldEqual, nil)
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfString("Parents"))
 
 		rn, err = rn.LookupByString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil, nil})
 		Wish(t, err, ShouldEqual, nil)
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfInt(0))
 		rn, err = rn.LookupByIndex(0)
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_Depth, maxDepth - 2}, nil})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_Depth, maxDepth - 2}, nil, nil})
 		Wish(t, err, ShouldEqual, nil)
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupByString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 2}, nil})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 2}, nil, nil})
 		Wish(t, err, ShouldEqual, nil)
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfInt(0))
 		rn, err = rn.LookupByIndex(0)
@@ -232,7 +232,7 @@ func TestExploreRecursiveExplore(t *testing.T) {
 	t.Run("exploring should traverse indefinitely if no depth specified", func(t *testing.T) {
 		parentsSelector := ExploreAll{recursiveEdge}
 		subTree := ExploreFields{map[string]Selector{"Parents": parentsSelector}, []datamodel.PathSegment{datamodel.PathSegmentOfString("Parents")}}
-		rs = ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_None, 0}, nil}
+		rs = ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_None, 0}, nil, nil}
 		nodeString := `{
 			"Parents": [
 				{
@@ -255,38 +255,38 @@ func TestExploreRecursiveExplore(t *testing.T) {
 		rn := nb.Build()
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupByString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_None, 0}, nil})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_None, 0}, nil, nil})
 		Wish(t, err, ShouldEqual, nil)
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfInt(0))
 		rn, err = rn.LookupByIndex(0)
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_None, 0}, nil})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_None, 0}, nil, nil})
 		Wish(t, err, ShouldEqual, nil)
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupByString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_None, 0}, nil})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_None, 0}, nil, nil})
 		Wish(t, err, ShouldEqual, nil)
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfInt(0))
 		rn, err = rn.LookupByIndex(0)
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_None, 0}, nil})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_None, 0}, nil, nil})
 		Wish(t, err, ShouldEqual, nil)
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupByString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_None, 0}, nil})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_None, 0}, nil, nil})
 		Wish(t, err, ShouldEqual, nil)
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfInt(0))
 		rn, err = rn.LookupByIndex(0)
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_None, 0}, nil})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_None, 0}, nil, nil})
 		Wish(t, err, ShouldEqual, nil)
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupByString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_None, 0}, nil})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_None, 0}, nil, nil})
 		Wish(t, err, ShouldEqual, nil)
 	})
 
 	t.Run("exploring should continue till we get to selector that returns nil on explore", func(t *testing.T) {
 		parentsSelector := ExploreIndex{recursiveEdge, [1]datamodel.PathSegment{datamodel.PathSegmentOfInt(1)}}
 		subTree := ExploreFields{map[string]Selector{"Parents": parentsSelector}, []datamodel.PathSegment{datamodel.PathSegmentOfString("Parents")}}
-		rs = ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil}
+		rs = ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil, nil}
 		nodeString := `{
 			"Parents": {
 			}
@@ -298,7 +298,7 @@ func TestExploreRecursiveExplore(t *testing.T) {
 		rn := nb.Build()
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupByString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil, nil})
 		Wish(t, err, ShouldEqual, nil)
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfInt(0))
 		Wish(t, rs, ShouldEqual, nil)
@@ -308,13 +308,13 @@ func TestExploreRecursiveExplore(t *testing.T) {
 		sideSelector := ExploreAll{recursiveEdge}
 		subTree := ExploreFields{map[string]Selector{
 			"Parents": parentsSelector,
-			"Side":    ExploreRecursive{sideSelector, sideSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil},
+			"Side":    ExploreRecursive{sideSelector, sideSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil, nil},
 		}, []datamodel.PathSegment{
 			datamodel.PathSegmentOfString("Parents"),
 			datamodel.PathSegmentOfString("Side"),
 		},
 		}
-		s := ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil}
+		s := ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil, nil}
 		nodeString := `{
 			"Parents": [
 				{
@@ -347,15 +347,15 @@ func TestExploreRecursiveExplore(t *testing.T) {
 		rs = s
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupByString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil, nil})
 		Wish(t, err, ShouldEqual, nil)
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfInt(0))
 		rn, err = rn.LookupByIndex(0)
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil, nil})
 		Wish(t, err, ShouldEqual, nil)
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupByString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil, nil})
 		Wish(t, err, ShouldEqual, nil)
 
 		// traverse down top level Side tree (nested recursion)
@@ -363,15 +363,15 @@ func TestExploreRecursiveExplore(t *testing.T) {
 		rs = s
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfString("Side"))
 		rn, err = rn.LookupByString("Side")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil}, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil, nil}, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil, nil})
 		Wish(t, err, ShouldEqual, nil)
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfString("real"))
 		rn, err = rn.LookupByString("real")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil}, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil, nil}, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil, nil})
 		Wish(t, err, ShouldEqual, nil)
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfString("apple"))
 		rn, err = rn.LookupByString("apple")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 2}, nil}, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 2}, nil, nil}, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil, nil})
 		Wish(t, err, ShouldEqual, nil)
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfString("sauce"))
 		rn, err = rn.LookupByString("sauce")
@@ -383,29 +383,29 @@ func TestExploreRecursiveExplore(t *testing.T) {
 		rs = s
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupByString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil, nil})
 		Wish(t, err, ShouldEqual, nil)
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfInt(0))
 		rn, err = rn.LookupByIndex(0)
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil, nil})
 		Wish(t, err, ShouldEqual, nil)
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfString("Side"))
 		rn, err = rn.LookupByString("Side")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil}, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil, nil}, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil, nil})
 		Wish(t, err, ShouldEqual, nil)
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfString("cheese"))
 		rn, err = rn.LookupByString("cheese")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil}, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil, nil}, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil, nil})
 		Wish(t, err, ShouldEqual, nil)
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfString("whiz"))
 		rn, err = rn.LookupByString("whiz")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 2}, nil}, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 2}, nil, nil}, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil, nil})
 		Wish(t, err, ShouldEqual, nil)
 	})
 	t.Run("exploring should work with explore union and recursion", func(t *testing.T) {
 		parentsSelector := ExploreUnion{[]Selector{ExploreAll{Matcher{}}, ExploreIndex{recursiveEdge, [1]datamodel.PathSegment{datamodel.PathSegmentOfInt(0)}}}}
 		subTree := ExploreFields{map[string]Selector{"Parents": parentsSelector}, []datamodel.PathSegment{datamodel.PathSegmentOfString("Parents")}}
-		rs = ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil}
+		rs = ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil, nil}
 		nodeString := `{
 			"Parents": [
 				{
@@ -428,20 +428,20 @@ func TestExploreRecursiveExplore(t *testing.T) {
 		rn := nb.Build()
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupByString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil, nil})
 		Wish(t, err, ShouldEqual, nil)
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfInt(0))
 		rn, err = rn.LookupByIndex(0)
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreUnion{[]Selector{Matcher{}, subTree}}, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreUnion{[]Selector{Matcher{}, subTree}}, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil, nil})
 		Wish(t, err, ShouldEqual, nil)
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfString("Parents"))
 
 		rn, err = rn.LookupByString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil, nil})
 		Wish(t, err, ShouldEqual, nil)
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfInt(0))
 		rn, err = rn.LookupByIndex(0)
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreUnion{[]Selector{Matcher{}, subTree}}, RecursionLimit{RecursionLimit_Depth, maxDepth - 2}, nil})
+		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreUnion{[]Selector{Matcher{}, subTree}}, RecursionLimit{RecursionLimit_Depth, maxDepth - 2}, nil, nil})
 		Wish(t, err, ShouldEqual, nil)
 	})
 }

--- a/traversal/selector/fieldKeys.go
+++ b/traversal/selector/fieldKeys.go
@@ -20,6 +20,7 @@ const (
 	SelectorKey_LimitDepth           = "depth"
 	SelectorKey_LimitNone            = "none"
 	SelectorKey_StopAt               = "!"
+	SelectorKey_Bypass               = ":x"
 	SelectorKey_Condition            = "&"
 	// not filling conditional keys since it's not complete
 )

--- a/traversal/walk_with_bypass_test.go
+++ b/traversal/walk_with_bypass_test.go
@@ -1,0 +1,201 @@
+package traversal_test
+
+import (
+	"testing"
+
+	. "github.com/warpfork/go-wish"
+
+	_ "github.com/ipld/go-ipld-prime/codec/dagjson"
+	"github.com/ipld/go-ipld-prime/datamodel"
+	"github.com/ipld/go-ipld-prime/fluent"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/ipld/go-ipld-prime/node/basicnode"
+	"github.com/ipld/go-ipld-prime/traversal"
+	"github.com/ipld/go-ipld-prime/traversal/selector"
+	"github.com/ipld/go-ipld-prime/traversal/selector/builder"
+)
+
+/* Remember, we've got the following fixtures in scope:
+var (
+	leafAlpha, leafAlphaLnk         = encode(basicnode.NewString("alpha"))
+	leafBeta, leafBetaLnk           = encode(basicnode.NewString("beta"))
+	middleMapNode, middleMapNodeLnk = encode(fluent.MustBuildMap(basicnode.Prototype__Map{}, 3, func(na fluent.MapAssembler) {
+		na.AssembleEntry("foo").AssignBool(true)
+		na.AssembleEntry("bar").AssignBool(false)
+		na.AssembleEntry("nested").CreateMap(2, func(na fluent.MapAssembler) {
+			na.AssembleEntry("alink").AssignLink(leafAlphaLnk)
+			na.AssembleEntry("nonlink").AssignString("zoo")
+		})
+	}))
+	middleListNode, middleListNodeLnk = encode(fluent.MustBuildList(basicnode.Prototype__List{}, 4, func(na fluent.ListAssembler) {
+		na.AssembleValue().AssignLink(leafAlphaLnk)
+		na.AssembleValue().AssignLink(leafAlphaLnk)
+		na.AssembleValue().AssignLink(leafBetaLnk)
+		na.AssembleValue().AssignLink(leafAlphaLnk)
+	}))
+	rootNode, rootNodeLnk = encode(fluent.MustBuildMap(basicnode.Prototype__Map{}, 4, func(na fluent.MapAssembler) {
+		na.AssembleEntry("plain").AssignString("olde string")
+		na.AssembleEntry("linkedString").AssignLink(leafAlphaLnk)
+		na.AssembleEntry("linkedMap").AssignLink(middleMapNodeLnk)
+		na.AssembleEntry("linkedList").AssignLink(middleListNodeLnk)
+	}))
+)
+*/
+
+// ExploreRecursiveWithStop builds a recursive selector node with a stop condition
+func ExploreRecursiveWithBypass(limit selector.RecursionLimit, sequence builder.SelectorSpec, stopField string) datamodel.Node {
+	np := basicnode.Prototype__Map{}
+	return fluent.MustBuildMap(np, 1, func(na fluent.MapAssembler) {
+		// RecursionLimit
+		na.AssembleEntry(selector.SelectorKey_ExploreRecursive).CreateMap(3, func(na fluent.MapAssembler) {
+			na.AssembleEntry(selector.SelectorKey_Limit).CreateMap(1, func(na fluent.MapAssembler) {
+				switch limit.Mode() {
+				case selector.RecursionLimit_Depth:
+					na.AssembleEntry(selector.SelectorKey_LimitDepth).AssignInt(limit.Depth())
+				case selector.RecursionLimit_None:
+					na.AssembleEntry(selector.SelectorKey_LimitNone).CreateMap(0, func(na fluent.MapAssembler) {})
+				default:
+					panic("Unsupported recursion limit type")
+				}
+			})
+			// Sequence
+			na.AssembleEntry(selector.SelectorKey_Sequence).CreateMap(1, func(na fluent.MapAssembler) {
+				na.AssembleEntry(selector.SelectorKey_ExploreUnion).CreateList(2, func(na fluent.ListAssembler) {
+					na.AssembleValue().AssignNode(fluent.MustBuildMap(np, 1, func(na fluent.MapAssembler) {
+						na.AssembleEntry(selector.SelectorKey_Matcher).CreateMap(0, func(na fluent.MapAssembler) {})
+					}))
+					na.AssembleValue().AssignNode(sequence.Node())
+				})
+			})
+
+			// Bypass condition
+			if stopField != "" {
+				cond := fluent.MustBuildMap(basicnode.Prototype__Map{}, 1, func(na fluent.MapAssembler) {
+					na.AssembleEntry(string(selector.ConditionMode_HasField)).AssignString(stopField)
+				})
+				na.AssembleEntry(selector.SelectorKey_Bypass).AssignNode(cond)
+			}
+		})
+	})
+
+}
+
+func TestBypass(t *testing.T) {
+	ssb := builder.NewSelectorSpecBuilder(basicnode.Prototype__Any{})
+	t.Run("test ExploreRecursive stopAt with simple node", func(t *testing.T) {
+		// Selector that passes through the map
+		s, err := selector.CompileSelector(ExploreRecursiveWithBypass(
+			selector.RecursionLimitNone(), ssb.ExploreAll(ssb.ExploreRecursiveEdge()),
+			"linkedMap"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		var order int
+		lsys := cidlink.DefaultLinkSystem()
+		lsys.StorageReadOpener = (&store).OpenRead
+		err = traversal.Progress{
+			Cfg: &traversal.Config{
+				LinkSystem:                     lsys,
+				LinkTargetNodePrototypeChooser: basicnode.Chooser,
+			},
+		}.WalkMatching(rootNode, s, func(prog traversal.Progress, n datamodel.Node) error {
+			// fmt.Println("Order", order, prog.Path.String())
+			switch order {
+			case 0:
+				// Root
+				Wish(t, prog.Path.String(), ShouldEqual, "")
+			case 1:
+				Wish(t, prog.Path.String(), ShouldEqual, "plain")
+				Wish(t, n, ShouldEqual, basicnode.NewString("olde string"))
+			case 2:
+				Wish(t, prog.Path.String(), ShouldEqual, "linkedString")
+			case 3:
+				Wish(t, prog.Path.String(), ShouldEqual, "linkedList")
+			// We are starting to traverse the linkedList, we passed through the map already
+			case 4:
+				Wish(t, prog.Path.String(), ShouldEqual, "linkedList/0")
+			}
+			order++
+			return nil
+		})
+		Wish(t, err, ShouldEqual, nil)
+		Wish(t, order, ShouldEqual, 8)
+	})
+}
+
+// mkChain creates a DAG that represent a chain of subDAGs.
+// The stopAt condition is extremely appealing for these use cases, as we can
+// partially sync a chain using ExploreRecursive without having to sync the
+// chain from scratch if we are already partially synced
+func mkGitLike() (datamodel.Node, []datamodel.Link) {
+	leafAlpha, leafAlphaLnk = encode(basicnode.NewString("alpha"))
+	leafBeta, leafBetaLnk = encode(basicnode.NewString("beta"))
+	_, mapLnk1 := encode(fluent.MustBuildMap(basicnode.Prototype__Map{}, 3, func(na fluent.MapAssembler) {
+		na.AssembleEntry("foo").AssignBool(true)
+		na.AssembleEntry("bar").AssignBool(false)
+		na.AssembleEntry("nested").CreateMap(2, func(na fluent.MapAssembler) {
+			na.AssembleEntry("alink").AssignLink(leafAlphaLnk)
+			na.AssembleEntry("nonlink").AssignString("zoo")
+		})
+	}))
+	_, mapLnk2 := encode(fluent.MustBuildMap(basicnode.Prototype__Map{}, 3, func(na fluent.MapAssembler) {
+		na.AssembleEntry("foo").AssignBool(true)
+		na.AssembleEntry("bar").AssignBool(false)
+		na.AssembleEntry("nested").CreateMap(2, func(na fluent.MapAssembler) {
+			na.AssembleEntry("alink").AssignLink(leafAlphaLnk)
+			na.AssembleEntry("nonlink").AssignString("zoo")
+		})
+	}))
+	_, mapLnk3 := encode(fluent.MustBuildMap(basicnode.Prototype__Map{}, 3, func(na fluent.MapAssembler) {
+		na.AssembleEntry("foo").AssignBool(true)
+		na.AssembleEntry("bar").AssignBool(false)
+		na.AssembleEntry("nested").CreateMap(2, func(na fluent.MapAssembler) {
+			na.AssembleEntry("alink").AssignLink(leafAlphaLnk)
+			na.AssembleEntry("nonlink").AssignString("zoo")
+		})
+	}))
+
+	_, ch1Lnk := encode(fluent.MustBuildMap(basicnode.Prototype__Map{}, 4, func(na fluent.MapAssembler) {
+		na.AssembleEntry("genesis").AssignLink(mapLnk1)
+	}))
+	_, ch2Lnk := encode(fluent.MustBuildMap(basicnode.Prototype__Map{}, 4, func(na fluent.MapAssembler) {
+		na.AssembleEntry("ch2").AssignLink(mapLnk2)
+		na.AssembleEntry("ch1").AssignLink(ch1Lnk)
+	}))
+	headNode, headLnk := encode(fluent.MustBuildMap(basicnode.Prototype__Map{}, 4, func(na fluent.MapAssembler) {
+		na.AssembleEntry("ch3").AssignLink(mapLnk3)
+		na.AssembleEntry("ch2").AssignLink(ch2Lnk)
+	}))
+
+	return headNode, []datamodel.Link{headLnk, ch2Lnk, ch1Lnk}
+}
+func TestBypassGitLike(t *testing.T) {
+	chainNode, _ := mkGitLike()
+	ssb := builder.NewSelectorSpecBuilder(basicnode.Prototype__Any{})
+	t.Run("test ExploreRecursive stopAt with simple node", func(t *testing.T) {
+		// Selector that passes through the map
+		s, err := selector.CompileSelector(ExploreRecursiveWithBypass(
+			selector.RecursionLimitNone(), ssb.ExploreAll(ssb.ExploreRecursiveEdge()),
+			"nested"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		var order int
+		lsys := cidlink.DefaultLinkSystem()
+		lsys.StorageReadOpener = (&store).OpenRead
+		err = traversal.Progress{
+			Cfg: &traversal.Config{
+				LinkSystem:                     lsys,
+				LinkTargetNodePrototypeChooser: basicnode.Chooser,
+			},
+		}.WalkMatching(chainNode, s, func(prog traversal.Progress, n datamodel.Node) error {
+			if prog.Path.String() == "alink" || prog.Path.String() == "nonlink" {
+				t.Fatal("we shouldn't have reecursed when seeing nested field")
+			}
+			order++
+			return nil
+		})
+		Wish(t, err, ShouldEqual, nil)
+		Wish(t, order, ShouldEqual, 12)
+	})
+}


### PR DESCRIPTION
This PR implements https://github.com/ipld/go-ipld-prime/issues/237

The idea is to have a `bypass` condition in `ExploreRecursive` selector to specify fields that shouldn't be recursed deeper (similar to the `RecursionLimit` condition but for specific fields).

Thus, the EploreRecursive selector turns into:
```js
type ExploreRecursive struct {
	sequence Selector (rename ":>")
	limit RecursionLimit (rename "l")
	stopAt optional Condition (rename "!") 
        bypass optional Condition (rename ":x")
}
```

And the representation would be like this:
```
{
                "R": {
                        "l": {
                                "none": 0
                        },
                        ":>": {
                                "a": {
                                        ">": {
                                                "@": {}
                                        }
                                }
                        },
                        "!": {
                                "/": {
                                       "/":"bafyreifepiu23okq5zuyvyhsoiazv2icw2van3s7ko6d3ixl5jx2yj2yhu"
                                }
                        },
                        ":x":  {
                               "hasField": "field_that_shouldn't_be_recursed",
                         }
                }
}
```
//cc @willscott 