### PR TITLE
schema,tests,gen/go: more tests, gen union fixes.

### DIFF
--- a/datamodel/equal.go
+++ b/datamodel/equal.go
@@ -25,6 +25,9 @@ package datamodel
 // so an error should only happen if a Node implementation breaks that contract.
 // It is generally not recommended to call DeepEqual on ADL nodes.
 func DeepEqual(x, y Node) bool {
+	if x == nil || y == nil {
+		return false
+	}
 	xk, yk := x.Kind(), y.Kind()
 	if xk != yk {
 		return false

--- a/datamodel/equal.go
+++ b/datamodel/equal.go
@@ -26,7 +26,7 @@ package datamodel
 // It is generally not recommended to call DeepEqual on ADL nodes.
 func DeepEqual(x, y Node) bool {
 	if x == nil || y == nil {
-		return false
+		return x == y
 	}
 	xk, yk := x.Kind(), y.Kind()
 	if xk != yk {

--- a/datamodel/equal_test.go
+++ b/datamodel/equal_test.go
@@ -40,6 +40,8 @@ var deepEqualTests = []struct {
 	// Repeated basicnode.New invocations might return different pointers.
 	{"SameNodeDiffPointer", basic.NewString("same"), basic.NewString("same"), true},
 
+	{"NilVsNil", nil, nil, true},
+	{"NilVsNull", nil, datamodel.Null, false},
 	{"SameKindNull", datamodel.Null, datamodel.Null, true},
 	{"DiffKindNull", datamodel.Null, datamodel.Absent, false},
 	{"SameKindBool", basic.NewBool(true), basic.NewBool(true), true},

--- a/node/bindnode/node.go
+++ b/node/bindnode/node.go
@@ -754,11 +754,13 @@ func (w *_structAssembler) AssembleValue() datamodel.NodeAssembler {
 	name := w.curKey.val.String()
 	field := w.schemaType.Field(name)
 	if field == nil {
-		panic(fmt.Sprintf("TODO: missing field %s in %s", name, w.schemaType.Name()))
-		// return nil, datamodel.ErrInvalidKey{
+		// TODO: should've been raised when the key was submitted (we have room to return errors there, but can only panic at this point in the game).
+		// TODO: should make well-typed errors for this.
+		panic(fmt.Sprintf("TODO: invalid key: %q is not a field in type %s", name, w.schemaType.Name()))
+		// panic(schema.ErrInvalidKey{
 		// 	TypeName: w.schemaType.Name(),
 		// 	Key:      basicnode.NewString(name),
-		// }
+		// })
 	}
 	ftyp, ok := w.val.Type().FieldByName(fieldNameFromSchema(name))
 	if !ok {

--- a/node/bindnode/schema_test.go
+++ b/node/bindnode/schema_test.go
@@ -17,6 +17,9 @@ func forSchemaTest(name string) []tests.EngineSubtest {
 	if name == "Links" {
 		return nil // TODO(mvdan): add support for links
 	}
+	if name == "UnionKeyedComplexChildren" {
+		return nil // Specifically, 'InhabitantB/repr-create_with_AK+AV' borks, because it needs representation-level AssignNode to support more.
+	}
 	return []tests.EngineSubtest{{
 		Engine: &bindEngine{},
 	}}

--- a/schema/gen/go/genUnion.go
+++ b/schema/gen/go/genUnion.go
@@ -540,7 +540,7 @@ func (g unionBuilderGenerator) emitMapAssemblerMethods(w io.Writer) {
 			ma.state = maState_midValue
 			switch ma.ca {
 			{{- range $i, $member := .Type.Members }}
-			case {{ $i }}:
+			case {{ add $i 1 }}:
 				{{- if (eq (dot.AdjCfg.UnionMemlayout dot.Type) "embedAll") }}
 				ma.ca{{ add $i 1 }}.w = &ma.w.x{{ add $i 1 }}
 				ma.ca{{ add $i 1 }}.m = &ma.cm

--- a/schema/gen/go/genUnionReprKeyed.go
+++ b/schema/gen/go/genUnionReprKeyed.go
@@ -404,7 +404,7 @@ func (g unionReprKeyedReprBuilderGenerator) emitMapAssemblerMethods(w io.Writer)
 			ma.state = maState_midValue
 			switch ma.ca {
 			{{- range $i, $member := .Type.Members }}
-			case {{ $i }}:
+			case {{ add $i 1 }}:
 				{{- if (eq (dot.AdjCfg.UnionMemlayout dot.Type) "embedAll") }}
 				ma.ca{{ add $i 1 }}.w = &ma.w.x{{ add $i 1 }}
 				ma.ca{{ add $i 1 }}.m = &ma.cm


### PR DESCRIPTION
Increase the coverage produced by the schema test suites markedly, fixing a few old todos in the test system for typed nodes.

The additional exercise picks up some bugs in the codegen for unions.
(This was also reported by Adin, and I think possibly by Ian earlier,
though I only got around to reproducing it fully now.)  Those bugs --
off-by-ones; uuf -- are now fixed.

Some todos were encountered in bindnode by the new coverage too.
Only one thing.  But it's a bit more than I knew how to fix in one
sitting, so I've made that test skipped for now, hopefully to be
fixed soon.

Some error messages that confused me along the way are tweaked.

The datamodel.DeepEquals method is slightly less fragile on nils.