### PR TITLE
traversal: implement monotonically decrementing budgets.

### DIFF
--- a/traversal/fns.go
+++ b/traversal/fns.go
@@ -2,6 +2,7 @@ package traversal
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/ipld/go-ipld-prime/datamodel"
 	"github.com/ipld/go-ipld-prime/linking"
@@ -79,4 +80,18 @@ type SkipMe struct{}
 
 func (SkipMe) Error() string {
 	return "skip"
+}
+
+type ErrBudgetExceeded struct {
+	BudgetKind string // "node"|"link"
+	Path       datamodel.Path
+	Link       datamodel.Link // only present if BudgetKind=="link"
+}
+
+func (e *ErrBudgetExceeded) Error() string {
+	msg := fmt.Sprintf("traversal budget exceeded: budget for %ss reached zero as we reached path %q", e.BudgetKind, e.Path)
+	if e.Link != nil {
+		msg += fmt.Sprintf(" (link: %q)", e.Link)
+	}
+	return msg
 }

--- a/traversal/fns.go
+++ b/traversal/fns.go
@@ -89,7 +89,7 @@ type ErrBudgetExceeded struct {
 }
 
 func (e *ErrBudgetExceeded) Error() string {
-	msg := fmt.Sprintf("traversal budget exceeded: budget for %ss reached zero as we reached path %q", e.BudgetKind, e.Path)
+	msg := fmt.Sprintf("traversal budget exceeded: budget for %ss reached zero while on path %q", e.BudgetKind, e.Path)
 	if e.Link != nil {
 		msg += fmt.Sprintf(" (link: %q)", e.Link)
 	}

--- a/traversal/walk_test.go
+++ b/traversal/walk_test.go
@@ -284,7 +284,7 @@ func TestWalkBudgets(t *testing.T) {
 		})
 		qt.Check(t, order, qt.Equals, 1) // because it should've stopped early
 		qt.Assert(t, err, qt.Not(qt.Equals), nil)
-		qt.Check(t, err.Error(), qt.Equals, `traversal budget exceeded: budget for nodes reached zero as we reached path "bar"`)
+		qt.Check(t, err.Error(), qt.Equals, `traversal budget exceeded: budget for nodes reached zero while on path "bar"`)
 	})
 	t.Run("link-budget-halts", func(t *testing.T) {
 		ss := ssb.ExploreAll(ssb.Matcher())
@@ -319,6 +319,6 @@ func TestWalkBudgets(t *testing.T) {
 		})
 		qt.Check(t, order, qt.Equals, 3)
 		qt.Assert(t, err, qt.Not(qt.Equals), nil)
-		qt.Check(t, err.Error(), qt.Equals, `traversal budget exceeded: budget for links reached zero as we reached path "3" (link: "baguqeeyexkjwnfy")`)
+		qt.Check(t, err.Error(), qt.Equals, `traversal budget exceeded: budget for links reached zero while on path "3" (link: "baguqeeyexkjwnfy")`)
 	})
 }


### PR DESCRIPTION
This patch adds budgets to traversals.  Setting a budget allows you to make a traversal halt and return within a fixed number of steps.

It's optional, and currently not on by default, but easy to set.

Budgets can be set in terms of either number of nodes visited, or number of links loaded.

A few other minor target-of-opportunity improvements to internal documentation are included, while I was passing through.