### PR TITLE
storage: add 'RWStorage' grouping interface.

### DIFF
--- a/storage/api.go
+++ b/storage/api.go
@@ -15,6 +15,25 @@ type WritableStorage interface {
 	Put(ctx context.Context, key string, content []byte) error
 }
 
+// RWStorage is a type that can be used to advertise support for
+// both ReadableStorage and WritableStorage at the same time.
+//
+// Typically, this interface is seen in the return type of constructor functions
+// for storage systems that can be used both readable and writably,
+// but where the constructor function doesn't want to return a concrete type.
+// It is not often seen otherwise.
+//
+// APIs that take storage systems as a parameter should typically use
+// either ReadableStorage or WritableStorage explicitly,
+// and accept parameters for both, rather than using this interface.
+// (This two-parameter approach allows the user to provide
+// a pointer to the same storage for both, or provide different pointers,
+// or provide only a read pointer with no write pointer, etc, at their option.)
+type RWStorage interface {
+	ReadableStorage
+	WritableStorage
+}
+
 // --- streaming --->
 
 type StreamingReadableStorage interface {


### PR DESCRIPTION
Feedback requested.  I'm dubious about this one.

I've sometimes felt the desire to make a constructor function that -- like the doc in the diff describes -- returns an interface, not a concrete type, and happens to implement both the reading and the writing features at the same time.  Then, one wants that type to also be immediately ready to pass to any of the other functions that expect `ReadableStorage` or `WritableStorage`.  This combined interface would allow that.

On the other hand: this feels weird, because I spent >50% of the docs text saying when one _shouldn't_ use this interface.  Maybe we shouldn't introduce this interface, and instead should provide documentation recommending a pattern of `func MyRWConstructor(...your params here...) (ReadableStorage, WritableStorage, error)` that uses multiple returns in a way that's symmetric to how we pass them around separately elsewhere.

Thoughts?