### PR TITLE
all: fix "an" typos after the ipld->datamodel refactor

### DIFF
--- a/node/bindnode/api.go
+++ b/node/bindnode/api.go
@@ -1,4 +1,4 @@
-// Package bindnode provides an datamodel.Node implementation via Go reflection.
+// Package bindnode provides a datamodel.Node implementation via Go reflection.
 //
 // This package is EXPERIMENTAL; its behavior and API might change as it's still
 // in development.
@@ -12,7 +12,7 @@ import (
 )
 
 // Prototype implements a schema.TypedPrototype given a Go pointer type and an
-// IPLD schema type. Note that the result is also an datamodel.NodePrototype.
+// IPLD schema type. Note that the result is also a datamodel.NodePrototype.
 //
 // If both the Go type and schema type are supplied, it is assumed that they are
 // compatible with one another.
@@ -55,7 +55,7 @@ func Prototype(ptrType interface{}, schemaType schema.Type) schema.TypedPrototyp
 }
 
 // Wrap implements a schema.TypedNode given a non-nil pointer to a Go value and an
-// IPLD schema type. Note that the result is also an datamodel.Node.
+// IPLD schema type. Note that the result is also a datamodel.Node.
 //
 // Wrap is meant to be used when one already has a Go value with data.
 // As such, ptrVal must not be nil.
@@ -91,9 +91,9 @@ func Wrap(ptrVal interface{}, schemaType schema.Type) schema.TypedNode {
 // }
 //
 // Pros: API is easier to understand, harder to mix up with other datamodel.Nodes.
-// Cons: One usually only has an datamodel.Node, and type assertions can be weird.
+// Cons: One usually only has a datamodel.Node, and type assertions can be weird.
 
-// Unwrap takes an datamodel.Node implemented by Prototype or Wrap,
+// Unwrap takes a datamodel.Node implemented by Prototype or Wrap,
 // and returns a pointer to the inner Go value.
 //
 // Unwrap returns nil if the node isn't implemented by this package.

--- a/node/tests/testcase.go
+++ b/node/tests/testcase.go
@@ -286,9 +286,9 @@ func wishPoint(t *testing.T, n datamodel.Node, point testcasePoint) {
 //
 // If the expected value is a primitive string, it'll AsStrong on the Node; etc.
 //
-// Using an datamodel.Kind value is also possible, which will just check the kind and not the value contents.
+// Using a datamodel.Kind value is also possible, which will just check the kind and not the value contents.
 //
-// If an datamodel.Node is the expected value, a full deep ShouldEqual is used as normal.
+// If a datamodel.Node is the expected value, a full deep ShouldEqual is used as normal.
 func closeEnough(actual, expected interface{}) (string, bool) {
 	if expected == nil {
 		return ShouldEqual(actual, nil)

--- a/schema/typedNode.go
+++ b/schema/typedNode.go
@@ -41,7 +41,7 @@ type TypedNode interface {
 	// Type returns a reference to the reified schema.Type value.
 	Type() Type
 
-	// Representation returns an datamodel.Node which sees the data in this node
+	// Representation returns a datamodel.Node which sees the data in this node
 	// in its representation form.
 	//
 	// For example: if the `.Type().TypeKind()` of this node is "struct",
@@ -80,7 +80,7 @@ type TypedPrototype interface {
 	// Type returns a reference to the reified schema.Type value.
 	Type() Type
 
-	// Representation returns an datamodel.NodePrototype for the representation
+	// Representation returns a datamodel.NodePrototype for the representation
 	// form of the prototype.
 	Representation() datamodel.NodePrototype
 }

--- a/traversal/focus.go
+++ b/traversal/focus.go
@@ -29,7 +29,7 @@ func Get(n datamodel.Node, p datamodel.Path) (datamodel.Node, error) {
 	return Progress{}.Get(n, p)
 }
 
-// FocusedTransform traverses an datamodel.Node graph, reaches a single Node,
+// FocusedTransform traverses a datamodel.Node graph, reaches a single Node,
 // and calls the given TransformFn to decide what new node to replace the visited node with.
 // A new Node tree will be returned (the original is unchanged).
 //
@@ -157,7 +157,7 @@ func (prog *Progress) get(n datamodel.Node, p datamodel.Path, trackProgress bool
 	return n, nil
 }
 
-// FocusedTransform traverses an datamodel.Node graph, reaches a single Node,
+// FocusedTransform traverses a datamodel.Node graph, reaches a single Node,
 // and calls the given TransformFn to decide what new node to replace the visited node with.
 // A new Node tree will be returned (the original is unchanged).
 //

--- a/traversal/selector/parse/selector_parse.go
+++ b/traversal/selector/parse/selector_parse.go
@@ -16,7 +16,7 @@ import (
 )
 
 // ParseJSONSelector accepts a string of json which will be parsed as a selector,
-// and returns an datamodel.Node of the parsed Data Model.
+// and returns a datamodel.Node of the parsed Data Model.
 // The returned datamodel.Node is suitable to hand to `selector.CompileSelector`,
 // or, could be composed programmatically with other Data Model selector clauses
 // and then compiled later.

--- a/traversal/selector/selector.go
+++ b/traversal/selector/selector.go
@@ -120,7 +120,7 @@ type ParseContext struct {
 	parentStack []ParsedParent
 }
 
-// CompileSelector accepts an datamodel.Node which should contain data that declares a Selector.
+// CompileSelector accepts a datamodel.Node which should contain data that declares a Selector.
 // The data layout expected for this declaration is documented in https://datamodel.io/specs/selectors/ .
 //
 // If the Selector is compiled successfully, it is returned.


### PR DESCRIPTION
(see commit message)