### PR TITLE
Port `node` package tests to quicktest

### DIFF
--- a/node/tests/listSpecs.go
+++ b/node/tests/listSpecs.go
@@ -3,7 +3,7 @@ package tests
 import (
 	"testing"
 
-	. "github.com/warpfork/go-wish"
+	qt "github.com/frankban/quicktest"
 
 	"github.com/ipld/go-ipld-prime/datamodel"
 	"github.com/ipld/go-ipld-prime/fluent"
@@ -18,46 +18,46 @@ func SpecTestListString(t *testing.T, np datamodel.NodePrototype) {
 			la.AssembleValue().AssignString("three")
 		})
 		t.Run("reads back out", func(t *testing.T) {
-			Wish(t, n.Length(), ShouldEqual, int64(3))
+			qt.Check(t, n.Length(), qt.Equals, int64(3))
 
 			v, err := n.LookupByIndex(0)
-			Wish(t, err, ShouldEqual, nil)
-			Wish(t, must.String(v), ShouldEqual, "one")
+			qt.Check(t, err, qt.IsNil)
+			qt.Check(t, must.String(v), qt.Equals, "one")
 
 			v, err = n.LookupByIndex(1)
-			Wish(t, err, ShouldEqual, nil)
-			Wish(t, must.String(v), ShouldEqual, "two")
+			qt.Check(t, err, qt.IsNil)
+			qt.Check(t, must.String(v), qt.Equals, "two")
 
 			v, err = n.LookupByIndex(2)
-			Wish(t, err, ShouldEqual, nil)
-			Wish(t, must.String(v), ShouldEqual, "three")
+			qt.Check(t, err, qt.IsNil)
+			qt.Check(t, must.String(v), qt.Equals, "three")
 		})
 		t.Run("reads via iteration", func(t *testing.T) {
 			itr := n.ListIterator()
 
-			Wish(t, itr.Done(), ShouldEqual, false)
+			qt.Check(t, itr.Done(), qt.IsFalse)
 			idx, v, err := itr.Next()
-			Wish(t, err, ShouldEqual, nil)
-			Wish(t, idx, ShouldEqual, int64(0))
-			Wish(t, must.String(v), ShouldEqual, "one")
+			qt.Check(t, err, qt.IsNil)
+			qt.Check(t, idx, qt.Equals, int64(0))
+			qt.Check(t, must.String(v), qt.Equals, "one")
 
-			Wish(t, itr.Done(), ShouldEqual, false)
+			qt.Check(t, itr.Done(), qt.IsFalse)
 			idx, v, err = itr.Next()
-			Wish(t, err, ShouldEqual, nil)
-			Wish(t, idx, ShouldEqual, int64(1))
-			Wish(t, must.String(v), ShouldEqual, "two")
+			qt.Check(t, err, qt.IsNil)
+			qt.Check(t, idx, qt.Equals, int64(1))
+			qt.Check(t, must.String(v), qt.Equals, "two")
 
-			Wish(t, itr.Done(), ShouldEqual, false)
+			qt.Check(t, itr.Done(), qt.IsFalse)
 			idx, v, err = itr.Next()
-			Wish(t, err, ShouldEqual, nil)
-			Wish(t, idx, ShouldEqual, int64(2))
-			Wish(t, must.String(v), ShouldEqual, "three")
+			qt.Check(t, err, qt.IsNil)
+			qt.Check(t, idx, qt.Equals, int64(2))
+			qt.Check(t, must.String(v), qt.Equals, "three")
 
-			Wish(t, itr.Done(), ShouldEqual, true)
+			qt.Check(t, itr.Done(), qt.IsTrue)
 			idx, v, err = itr.Next()
-			Wish(t, err, ShouldEqual, datamodel.ErrIteratorOverread{})
-			Wish(t, idx, ShouldEqual, int64(-1))
-			Wish(t, v, ShouldEqual, nil)
+			qt.Check(t, err, qt.Equals, datamodel.ErrIteratorOverread{})
+			qt.Check(t, idx, qt.Equals, int64(-1))
+			qt.Check(t, v, qt.IsNil)
 		})
 	})
 }

--- a/node/tests/mapSpecs.go
+++ b/node/tests/mapSpecs.go
@@ -3,7 +3,7 @@ package tests
 import (
 	"testing"
 
-	. "github.com/warpfork/go-wish"
+	qt "github.com/frankban/quicktest"
 
 	"github.com/ipld/go-ipld-prime/datamodel"
 	"github.com/ipld/go-ipld-prime/must"
@@ -13,70 +13,70 @@ func SpecTestMapStrInt(t *testing.T, np datamodel.NodePrototype) {
 	t.Run("map<str,int>, 3 entries", func(t *testing.T) {
 		n := buildMapStrIntN3(np)
 		t.Run("reads back out", func(t *testing.T) {
-			Wish(t, n.Length(), ShouldEqual, int64(3))
+			qt.Check(t, n.Length(), qt.Equals, int64(3))
 
 			v, err := n.LookupByString("whee")
-			Wish(t, err, ShouldEqual, nil)
+			qt.Check(t, err, qt.IsNil)
 			v2, err := v.AsInt()
-			Wish(t, err, ShouldEqual, nil)
-			Wish(t, v2, ShouldEqual, int64(1))
+			qt.Check(t, err, qt.IsNil)
+			qt.Check(t, v2, qt.Equals, int64(1))
 
 			v, err = n.LookupByString("waga")
-			Wish(t, err, ShouldEqual, nil)
+			qt.Check(t, err, qt.IsNil)
 			v2, err = v.AsInt()
-			Wish(t, err, ShouldEqual, nil)
-			Wish(t, v2, ShouldEqual, int64(3))
+			qt.Check(t, err, qt.IsNil)
+			qt.Check(t, v2, qt.Equals, int64(3))
 
 			v, err = n.LookupByString("woot")
-			Wish(t, err, ShouldEqual, nil)
+			qt.Check(t, err, qt.IsNil)
 			v2, err = v.AsInt()
-			Wish(t, err, ShouldEqual, nil)
-			Wish(t, v2, ShouldEqual, int64(2))
+			qt.Check(t, err, qt.IsNil)
+			qt.Check(t, v2, qt.Equals, int64(2))
 		})
 		t.Run("reads via iteration", func(t *testing.T) {
 			itr := n.MapIterator()
 
-			Wish(t, itr.Done(), ShouldEqual, false)
+			qt.Check(t, itr.Done(), qt.IsFalse)
 			k, v, err := itr.Next()
-			Wish(t, err, ShouldEqual, nil)
+			qt.Check(t, err, qt.IsNil)
 			k2, err := k.AsString()
-			Wish(t, err, ShouldEqual, nil)
-			Wish(t, k2, ShouldEqual, "whee")
+			qt.Check(t, err, qt.IsNil)
+			qt.Check(t, k2, qt.Equals, "whee")
 			v2, err := v.AsInt()
-			Wish(t, err, ShouldEqual, nil)
-			Wish(t, v2, ShouldEqual, int64(1))
+			qt.Check(t, err, qt.IsNil)
+			qt.Check(t, v2, qt.Equals, int64(1))
 
-			Wish(t, itr.Done(), ShouldEqual, false)
+			qt.Check(t, itr.Done(), qt.IsFalse)
 			k, v, err = itr.Next()
-			Wish(t, err, ShouldEqual, nil)
+			qt.Check(t, err, qt.IsNil)
 			k2, err = k.AsString()
-			Wish(t, err, ShouldEqual, nil)
-			Wish(t, k2, ShouldEqual, "woot")
+			qt.Check(t, err, qt.IsNil)
+			qt.Check(t, k2, qt.Equals, "woot")
 			v2, err = v.AsInt()
-			Wish(t, err, ShouldEqual, nil)
-			Wish(t, v2, ShouldEqual, int64(2))
+			qt.Check(t, err, qt.IsNil)
+			qt.Check(t, v2, qt.Equals, int64(2))
 
-			Wish(t, itr.Done(), ShouldEqual, false)
+			qt.Check(t, itr.Done(), qt.IsFalse)
 			k, v, err = itr.Next()
-			Wish(t, err, ShouldEqual, nil)
+			qt.Check(t, err, qt.IsNil)
 			k2, err = k.AsString()
-			Wish(t, err, ShouldEqual, nil)
-			Wish(t, k2, ShouldEqual, "waga")
+			qt.Check(t, err, qt.IsNil)
+			qt.Check(t, k2, qt.Equals, "waga")
 			v2, err = v.AsInt()
-			Wish(t, err, ShouldEqual, nil)
-			Wish(t, v2, ShouldEqual, int64(3))
+			qt.Check(t, err, qt.IsNil)
+			qt.Check(t, v2, qt.Equals, int64(3))
 
-			Wish(t, itr.Done(), ShouldEqual, true)
+			qt.Check(t, itr.Done(), qt.IsTrue)
 			k, v, err = itr.Next()
-			Wish(t, err, ShouldEqual, datamodel.ErrIteratorOverread{})
-			Wish(t, k, ShouldEqual, nil)
-			Wish(t, v, ShouldEqual, nil)
+			qt.Check(t, err, qt.Equals, datamodel.ErrIteratorOverread{})
+			qt.Check(t, k, qt.IsNil)
+			qt.Check(t, v, qt.IsNil)
 		})
 		t.Run("reads for absent keys error sensibly", func(t *testing.T) {
 			v, err := n.LookupByString("nope")
-			Wish(t, err, ShouldBeSameTypeAs, datamodel.ErrNotExists{})
-			Wish(t, err.Error(), ShouldEqual, `key not found: "nope"`)
-			Wish(t, v, ShouldEqual, nil)
+			qt.Check(t, err, qt.ErrorAs, &datamodel.ErrNotExists{})
+			qt.Check(t, err, qt.ErrorMatches, `key not found: "nope"`)
+			qt.Check(t, v, qt.IsNil)
 		})
 	})
 	t.Run("repeated key should error", func(t *testing.T) {
@@ -92,7 +92,7 @@ func SpecTestMapStrInt(t *testing.T, np datamodel.NodePrototype) {
 			panic(err)
 		}
 		if err := ma.AssembleKey().AssignString("whee"); err != nil {
-			Wish(t, err, ShouldBeSameTypeAs, datamodel.ErrRepeatedMapKey{})
+			qt.Check(t, err, qt.ErrorAs, &datamodel.ErrRepeatedMapKey{})
 			// No string assertion at present -- how that should be presented for typed stuff is unsettled
 			//  (and if it's clever, it'll differ from untyped, which will mean no assertion possible!).
 		}
@@ -122,14 +122,14 @@ func SpecTestMapStrInt(t *testing.T, np datamodel.NodePrototype) {
 		}()
 
 		// ... and neither of these should've had visible effects!
-		Wish(t, ma.Finish(), ShouldEqual, nil)
+		qt.Check(t, ma.Finish(), qt.IsNil)
 		n := nb.Build()
-		Wish(t, n.Length(), ShouldEqual, int64(1))
+		qt.Check(t, n.Length(), qt.Equals, int64(1))
 		v, err := n.LookupByString("whee")
-		Wish(t, err, ShouldEqual, nil)
+		qt.Check(t, err, qt.IsNil)
 		v2, err := v.AsInt()
-		Wish(t, err, ShouldEqual, nil)
-		Wish(t, v2, ShouldEqual, int64(1))
+		qt.Check(t, err, qt.IsNil)
+		qt.Check(t, v2, qt.Equals, int64(1))
 	})
 	t.Run("builder reset works", func(t *testing.T) {
 		// TODO
@@ -169,20 +169,20 @@ func SpecTestMapStrMapStrInt(t *testing.T, np datamodel.NodePrototype) {
 		n := nb.Build()
 
 		t.Run("reads back out", func(t *testing.T) {
-			Wish(t, n.Length(), ShouldEqual, int64(3))
+			qt.Check(t, n.Length(), qt.Equals, int64(3))
 
 			v, err := n.LookupByString("woot")
-			Wish(t, err, ShouldEqual, nil)
+			qt.Check(t, err, qt.IsNil)
 			v2, err := v.LookupByString("m2k1")
-			Wish(t, err, ShouldEqual, nil)
+			qt.Check(t, err, qt.IsNil)
 			v3, err := v2.AsInt()
-			Wish(t, err, ShouldEqual, nil)
-			Wish(t, v3, ShouldEqual, int64(3))
+			qt.Check(t, err, qt.IsNil)
+			qt.Check(t, v3, qt.Equals, int64(3))
 			v2, err = v.LookupByString("m2k2")
-			Wish(t, err, ShouldEqual, nil)
+			qt.Check(t, err, qt.IsNil)
 			v3, err = v2.AsInt()
-			Wish(t, err, ShouldEqual, nil)
-			Wish(t, v3, ShouldEqual, int64(4))
+			qt.Check(t, err, qt.IsNil)
+			qt.Check(t, v3, qt.Equals, int64(4))
 		})
 	})
 }
@@ -214,15 +214,15 @@ func SpecTestMapStrListStr(t *testing.T, np datamodel.NodePrototype) {
 		n := nb.Build()
 
 		t.Run("reads back out", func(t *testing.T) {
-			Wish(t, n.Length(), ShouldEqual, int64(3))
+			qt.Check(t, n.Length(), qt.Equals, int64(3))
 
 			v, err := n.LookupByString("qwer")
-			Wish(t, err, ShouldEqual, nil)
+			qt.Check(t, err, qt.IsNil)
 			v2, err := v.LookupByIndex(1)
-			Wish(t, err, ShouldEqual, nil)
+			qt.Check(t, err, qt.IsNil)
 			v3, err := v2.AsString()
-			Wish(t, err, ShouldEqual, nil)
-			Wish(t, v3, ShouldEqual, "twentytwo")
+			qt.Check(t, err, qt.IsNil)
+			qt.Check(t, v3, qt.Equals, "twentytwo")
 		})
 	})
 }

--- a/node/tests/schemaLinks.go
+++ b/node/tests/schemaLinks.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	. "github.com/warpfork/go-wish"
+	qt "github.com/frankban/quicktest"
 
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime/codec/dagjson"
@@ -92,7 +92,7 @@ func SchemaTestLinks(t *testing.T, engine Engine) {
 			ssb.ExploreAll(ssb.ExploreRecursiveEdge()),
 		))
 		s, err := ss.Selector()
-		Wish(t, err, ShouldEqual, nil)
+		qt.Check(t, err, qt.IsNil)
 
 		var order int
 		lsys := cidlink.DefaultLinkSystem()
@@ -113,26 +113,26 @@ func SchemaTestLinks(t *testing.T, engine Engine) {
 			fmt.Printf("Walked %d: %v\n", order, buf.String())
 			switch order {
 			case 0: // root
-				Wish(t, n.Prototype(), ShouldEqual, engine.PrototypeByName("LinkStruct"))
+				qt.Check(t, n.Prototype(), qt.Equals, engine.PrototypeByName("LinkStruct"))
 			case 1: // from an &Any
-				Wish(t, n.Prototype(), ShouldEqual, basicnode.Prototype__String{})
+				qt.Check(t, n.Prototype(), qt.Equals, basicnode.Prototype__String{})
 			case 2: // &Int
-				Wish(t, n.Prototype(), ShouldEqual, engine.PrototypeByName("Int"))
+				qt.Check(t, n.Prototype(), qt.Equals, engine.PrototypeByName("Int"))
 			case 3: // &String
-				Wish(t, n.Prototype(), ShouldEqual, engine.PrototypeByName("String"))
+				qt.Check(t, n.Prototype(), qt.Equals, engine.PrototypeByName("String"))
 			case 4: // &ListOfStrings
-				Wish(t, n.Prototype(), ShouldEqual, engine.PrototypeByName("ListOfStrings"))
+				qt.Check(t, n.Prototype(), qt.Equals, engine.PrototypeByName("ListOfStrings"))
 			case 5:
 				fallthrough
 			case 6:
 				fallthrough
 			case 7:
-				Wish(t, n.Prototype(), ShouldEqual, engine.PrototypeByName("String"))
+				qt.Check(t, n.Prototype(), qt.Equals, engine.PrototypeByName("String"))
 			}
 			order++
 			return nil
 		})
-		Wish(t, err, ShouldEqual, nil)
-		Wish(t, order, ShouldEqual, 8)
+		qt.Check(t, err, qt.IsNil)
+		qt.Check(t, order, qt.Equals, 8)
 	})
 }

--- a/node/tests/schemaLists.go
+++ b/node/tests/schemaLists.go
@@ -3,7 +3,7 @@ package tests
 import (
 	"testing"
 
-	. "github.com/warpfork/go-wish"
+	qt "github.com/frankban/quicktest"
 
 	"github.com/ipld/go-ipld-prime/datamodel"
 	"github.com/ipld/go-ipld-prime/fluent"
@@ -32,31 +32,31 @@ func SchemaTestListsContainingMaybe(t *testing.T, engine Engine) {
 				la.AssembleValue().AssignString("2")
 			}).(schema.TypedNode)
 			t.Run("typed-read", func(t *testing.T) {
-				Require(t, n.Kind(), ShouldEqual, datamodel.Kind_List)
-				Wish(t, n.Length(), ShouldEqual, int64(2))
+				qt.Assert(t, n.Kind(), qt.Equals, datamodel.Kind_List)
+				qt.Check(t, n.Length(), qt.Equals, int64(2))
 
-				Wish(t, must.String(must.Node(n.LookupByIndex(0))), ShouldEqual, "1")
-				Wish(t, must.String(must.Node(n.LookupByIndex(1))), ShouldEqual, "2")
+				qt.Check(t, must.String(must.Node(n.LookupByIndex(0))), qt.Equals, "1")
+				qt.Check(t, must.String(must.Node(n.LookupByIndex(1))), qt.Equals, "2")
 
-				Wish(t, must.String(must.Node(n.LookupBySegment(datamodel.PathSegmentOfInt(0)))), ShouldEqual, "1")
-				Wish(t, must.String(must.Node(n.LookupByNode(basicnode.NewInt(0)))), ShouldEqual, "1")
+				qt.Check(t, must.String(must.Node(n.LookupBySegment(datamodel.PathSegmentOfInt(0)))), qt.Equals, "1")
+				qt.Check(t, must.String(must.Node(n.LookupByNode(basicnode.NewInt(0)))), qt.Equals, "1")
 
 				_, err := n.LookupByIndex(3)
-				Wish(t, err, ShouldBeSameTypeAs, datamodel.ErrNotExists{})
+				qt.Check(t, err, qt.ErrorAs, &datamodel.ErrNotExists{})
 			})
 			t.Run("repr-read", func(t *testing.T) {
 				nr := n.Representation()
-				Require(t, nr.Kind(), ShouldEqual, datamodel.Kind_List)
-				Wish(t, nr.Length(), ShouldEqual, int64(2))
+				qt.Assert(t, nr.Kind(), qt.Equals, datamodel.Kind_List)
+				qt.Check(t, nr.Length(), qt.Equals, int64(2))
 
-				Wish(t, must.String(must.Node(nr.LookupByIndex(0))), ShouldEqual, "1")
-				Wish(t, must.String(must.Node(nr.LookupByIndex(1))), ShouldEqual, "2")
+				qt.Check(t, must.String(must.Node(nr.LookupByIndex(0))), qt.Equals, "1")
+				qt.Check(t, must.String(must.Node(nr.LookupByIndex(1))), qt.Equals, "2")
 
-				Wish(t, must.String(must.Node(n.LookupBySegment(datamodel.PathSegmentOfInt(0)))), ShouldEqual, "1")
-				Wish(t, must.String(must.Node(n.LookupByNode(basicnode.NewInt(0)))), ShouldEqual, "1")
+				qt.Check(t, must.String(must.Node(n.LookupBySegment(datamodel.PathSegmentOfInt(0)))), qt.Equals, "1")
+				qt.Check(t, must.String(must.Node(n.LookupByNode(basicnode.NewInt(0)))), qt.Equals, "1")
 
 				_, err := n.LookupByIndex(3)
-				Wish(t, err, ShouldBeSameTypeAs, datamodel.ErrNotExists{})
+				qt.Check(t, err, qt.ErrorAs, &datamodel.ErrNotExists{})
 			})
 		})
 		t.Run("repr-create", func(t *testing.T) {
@@ -64,7 +64,7 @@ func SchemaTestListsContainingMaybe(t *testing.T, engine Engine) {
 				la.AssembleValue().AssignString("1")
 				la.AssembleValue().AssignString("2")
 			})
-			Wish(t, datamodel.DeepEqual(n, nr), ShouldEqual, true)
+			qt.Check(t, datamodel.DeepEqual(n, nr), qt.IsTrue)
 		})
 	})
 	t.Run("nullable", func(t *testing.T) {
@@ -77,21 +77,21 @@ func SchemaTestListsContainingMaybe(t *testing.T, engine Engine) {
 				la.AssembleValue().AssignNull()
 			}).(schema.TypedNode)
 			t.Run("typed-read", func(t *testing.T) {
-				Require(t, n.Kind(), ShouldEqual, datamodel.Kind_List)
-				Wish(t, n.Length(), ShouldEqual, int64(2))
-				Wish(t, must.String(must.Node(n.LookupByIndex(0))), ShouldEqual, "1")
-				Wish(t, must.Node(n.LookupByIndex(1)), ShouldEqual, datamodel.Null)
+				qt.Assert(t, n.Kind(), qt.Equals, datamodel.Kind_List)
+				qt.Check(t, n.Length(), qt.Equals, int64(2))
+				qt.Check(t, must.String(must.Node(n.LookupByIndex(0))), qt.Equals, "1")
+				qt.Check(t, must.Node(n.LookupByIndex(1)), qt.Equals, datamodel.Null)
 				_, err := n.LookupByIndex(3)
-				Wish(t, err, ShouldBeSameTypeAs, datamodel.ErrNotExists{})
+				qt.Check(t, err, qt.ErrorAs, &datamodel.ErrNotExists{})
 			})
 			t.Run("repr-read", func(t *testing.T) {
 				nr := n.Representation()
-				Require(t, nr.Kind(), ShouldEqual, datamodel.Kind_List)
-				Wish(t, nr.Length(), ShouldEqual, int64(2))
-				Wish(t, must.String(must.Node(n.LookupByIndex(0))), ShouldEqual, "1")
-				Wish(t, must.Node(n.LookupByIndex(1)), ShouldEqual, datamodel.Null)
+				qt.Assert(t, nr.Kind(), qt.Equals, datamodel.Kind_List)
+				qt.Check(t, nr.Length(), qt.Equals, int64(2))
+				qt.Check(t, must.String(must.Node(n.LookupByIndex(0))), qt.Equals, "1")
+				qt.Check(t, must.Node(n.LookupByIndex(1)), qt.Equals, datamodel.Null)
 				_, err := n.LookupByIndex(3)
-				Wish(t, err, ShouldBeSameTypeAs, datamodel.ErrNotExists{})
+				qt.Check(t, err, qt.ErrorAs, &datamodel.ErrNotExists{})
 			})
 		})
 		t.Run("repr-create", func(t *testing.T) {
@@ -99,7 +99,7 @@ func SchemaTestListsContainingMaybe(t *testing.T, engine Engine) {
 				la.AssembleValue().AssignString("1")
 				la.AssembleValue().AssignNull()
 			})
-			Wish(t, datamodel.DeepEqual(n, nr), ShouldEqual, true)
+			qt.Check(t, datamodel.DeepEqual(n, nr), qt.IsTrue)
 		})
 	})
 }
@@ -145,29 +145,29 @@ func SchemaTestListsContainingLists(t *testing.T, engine Engine) {
 			})
 		}).(schema.TypedNode)
 		t.Run("typed-read", func(t *testing.T) {
-			Require(t, n.Kind(), ShouldEqual, datamodel.Kind_List)
-			Require(t, n.Length(), ShouldEqual, int64(3))
-			Require(t, must.Node(n.LookupByIndex(0)).Length(), ShouldEqual, int64(3))
-			Require(t, must.Node(n.LookupByIndex(1)).Length(), ShouldEqual, int64(1))
-			Require(t, must.Node(n.LookupByIndex(2)).Length(), ShouldEqual, int64(2))
+			qt.Assert(t, n.Kind(), qt.Equals, datamodel.Kind_List)
+			qt.Assert(t, n.Length(), qt.Equals, int64(3))
+			qt.Assert(t, must.Node(n.LookupByIndex(0)).Length(), qt.Equals, int64(3))
+			qt.Assert(t, must.Node(n.LookupByIndex(1)).Length(), qt.Equals, int64(1))
+			qt.Assert(t, must.Node(n.LookupByIndex(2)).Length(), qt.Equals, int64(2))
 
-			Wish(t, must.String(must.Node(must.Node(must.Node(n.LookupByIndex(0)).LookupByIndex(0)).LookupByString("field"))), ShouldEqual, "11")
-			Wish(t, must.String(must.Node(must.Node(must.Node(n.LookupByIndex(0)).LookupByIndex(2)).LookupByString("field"))), ShouldEqual, "13")
-			Wish(t, must.String(must.Node(must.Node(must.Node(n.LookupByIndex(1)).LookupByIndex(0)).LookupByString("field"))), ShouldEqual, "21")
-			Wish(t, must.String(must.Node(must.Node(must.Node(n.LookupByIndex(2)).LookupByIndex(1)).LookupByString("field"))), ShouldEqual, "32")
+			qt.Check(t, must.String(must.Node(must.Node(must.Node(n.LookupByIndex(0)).LookupByIndex(0)).LookupByString("field"))), qt.Equals, "11")
+			qt.Check(t, must.String(must.Node(must.Node(must.Node(n.LookupByIndex(0)).LookupByIndex(2)).LookupByString("field"))), qt.Equals, "13")
+			qt.Check(t, must.String(must.Node(must.Node(must.Node(n.LookupByIndex(1)).LookupByIndex(0)).LookupByString("field"))), qt.Equals, "21")
+			qt.Check(t, must.String(must.Node(must.Node(must.Node(n.LookupByIndex(2)).LookupByIndex(1)).LookupByString("field"))), qt.Equals, "32")
 		})
 		t.Run("repr-read", func(t *testing.T) {
 			nr := n.Representation()
-			Require(t, nr.Kind(), ShouldEqual, datamodel.Kind_List)
-			Require(t, nr.Length(), ShouldEqual, int64(3))
-			Require(t, must.Node(nr.LookupByIndex(0)).Length(), ShouldEqual, int64(3))
-			Require(t, must.Node(nr.LookupByIndex(1)).Length(), ShouldEqual, int64(1))
-			Require(t, must.Node(nr.LookupByIndex(2)).Length(), ShouldEqual, int64(2))
+			qt.Assert(t, nr.Kind(), qt.Equals, datamodel.Kind_List)
+			qt.Assert(t, nr.Length(), qt.Equals, int64(3))
+			qt.Assert(t, must.Node(nr.LookupByIndex(0)).Length(), qt.Equals, int64(3))
+			qt.Assert(t, must.Node(nr.LookupByIndex(1)).Length(), qt.Equals, int64(1))
+			qt.Assert(t, must.Node(nr.LookupByIndex(2)).Length(), qt.Equals, int64(2))
 
-			Wish(t, must.String(must.Node(must.Node(must.Node(nr.LookupByIndex(0)).LookupByIndex(0)).LookupByString("encoded"))), ShouldEqual, "11")
-			Wish(t, must.String(must.Node(must.Node(must.Node(nr.LookupByIndex(0)).LookupByIndex(2)).LookupByString("encoded"))), ShouldEqual, "13")
-			Wish(t, must.String(must.Node(must.Node(must.Node(nr.LookupByIndex(1)).LookupByIndex(0)).LookupByString("encoded"))), ShouldEqual, "21")
-			Wish(t, must.String(must.Node(must.Node(must.Node(nr.LookupByIndex(2)).LookupByIndex(1)).LookupByString("encoded"))), ShouldEqual, "32")
+			qt.Check(t, must.String(must.Node(must.Node(must.Node(nr.LookupByIndex(0)).LookupByIndex(0)).LookupByString("encoded"))), qt.Equals, "11")
+			qt.Check(t, must.String(must.Node(must.Node(must.Node(nr.LookupByIndex(0)).LookupByIndex(2)).LookupByString("encoded"))), qt.Equals, "13")
+			qt.Check(t, must.String(must.Node(must.Node(must.Node(nr.LookupByIndex(1)).LookupByIndex(0)).LookupByString("encoded"))), qt.Equals, "21")
+			qt.Check(t, must.String(must.Node(must.Node(must.Node(nr.LookupByIndex(2)).LookupByIndex(1)).LookupByString("encoded"))), qt.Equals, "32")
 		})
 	})
 	t.Run("repr-create", func(t *testing.T) {
@@ -186,6 +186,6 @@ func SchemaTestListsContainingLists(t *testing.T, engine Engine) {
 				la.AssembleValue().CreateMap(1, func(ma fluent.MapAssembler) { ma.AssembleEntry("encoded").AssignString("32") })
 			})
 		})
-		Wish(t, datamodel.DeepEqual(n, nr), ShouldEqual, true)
+		qt.Check(t, datamodel.DeepEqual(n, nr), qt.IsTrue)
 	})
 }

--- a/node/tests/schemaMaps.go
+++ b/node/tests/schemaMaps.go
@@ -3,7 +3,7 @@ package tests
 import (
 	"testing"
 
-	. "github.com/warpfork/go-wish"
+	qt "github.com/frankban/quicktest"
 
 	"github.com/ipld/go-ipld-prime/datamodel"
 	"github.com/ipld/go-ipld-prime/fluent"
@@ -31,21 +31,21 @@ func SchemaTestMapsContainingMaybe(t *testing.T, engine Engine) {
 				ma.AssembleEntry("two").AssignString("2")
 			}).(schema.TypedNode)
 			t.Run("typed-read", func(t *testing.T) {
-				Require(t, n.Kind(), ShouldEqual, datamodel.Kind_Map)
-				Wish(t, n.Length(), ShouldEqual, int64(2))
-				Wish(t, must.String(must.Node(n.LookupByString("one"))), ShouldEqual, "1")
-				Wish(t, must.String(must.Node(n.LookupByString("two"))), ShouldEqual, "2")
+				qt.Assert(t, n.Kind(), qt.Equals, datamodel.Kind_Map)
+				qt.Check(t, n.Length(), qt.Equals, int64(2))
+				qt.Check(t, must.String(must.Node(n.LookupByString("one"))), qt.Equals, "1")
+				qt.Check(t, must.String(must.Node(n.LookupByString("two"))), qt.Equals, "2")
 				_, err := n.LookupByString("miss")
-				Wish(t, err, ShouldBeSameTypeAs, datamodel.ErrNotExists{})
+				qt.Check(t, err, qt.ErrorAs, &datamodel.ErrNotExists{})
 			})
 			t.Run("repr-read", func(t *testing.T) {
 				nr := n.Representation()
-				Require(t, nr.Kind(), ShouldEqual, datamodel.Kind_Map)
-				Wish(t, nr.Length(), ShouldEqual, int64(2))
-				Wish(t, must.String(must.Node(nr.LookupByString("one"))), ShouldEqual, "1")
-				Wish(t, must.String(must.Node(nr.LookupByString("two"))), ShouldEqual, "2")
+				qt.Assert(t, nr.Kind(), qt.Equals, datamodel.Kind_Map)
+				qt.Check(t, nr.Length(), qt.Equals, int64(2))
+				qt.Check(t, must.String(must.Node(nr.LookupByString("one"))), qt.Equals, "1")
+				qt.Check(t, must.String(must.Node(nr.LookupByString("two"))), qt.Equals, "2")
 				_, err := nr.LookupByString("miss")
-				Wish(t, err, ShouldBeSameTypeAs, datamodel.ErrNotExists{})
+				qt.Check(t, err, qt.ErrorAs, &datamodel.ErrNotExists{})
 			})
 		})
 		t.Run("repr-create", func(t *testing.T) {
@@ -53,7 +53,7 @@ func SchemaTestMapsContainingMaybe(t *testing.T, engine Engine) {
 				ma.AssembleEntry("one").AssignString("1")
 				ma.AssembleEntry("two").AssignString("2")
 			})
-			Wish(t, datamodel.DeepEqual(n, nr), ShouldEqual, true)
+			qt.Check(t, datamodel.DeepEqual(n, nr), qt.IsTrue)
 		})
 	})
 	t.Run("nullable", func(t *testing.T) {
@@ -66,21 +66,21 @@ func SchemaTestMapsContainingMaybe(t *testing.T, engine Engine) {
 				ma.AssembleEntry("none").AssignNull()
 			}).(schema.TypedNode)
 			t.Run("typed-read", func(t *testing.T) {
-				Require(t, n.Kind(), ShouldEqual, datamodel.Kind_Map)
-				Wish(t, n.Length(), ShouldEqual, int64(2))
-				Wish(t, must.String(must.Node(n.LookupByString("one"))), ShouldEqual, "1")
-				Wish(t, must.Node(n.LookupByString("none")), ShouldEqual, datamodel.Null)
+				qt.Assert(t, n.Kind(), qt.Equals, datamodel.Kind_Map)
+				qt.Check(t, n.Length(), qt.Equals, int64(2))
+				qt.Check(t, must.String(must.Node(n.LookupByString("one"))), qt.Equals, "1")
+				qt.Check(t, must.Node(n.LookupByString("none")), qt.Equals, datamodel.Null)
 				_, err := n.LookupByString("miss")
-				Wish(t, err, ShouldBeSameTypeAs, datamodel.ErrNotExists{})
+				qt.Check(t, err, qt.ErrorAs, &datamodel.ErrNotExists{})
 			})
 			t.Run("repr-read", func(t *testing.T) {
 				nr := n.Representation()
-				Require(t, nr.Kind(), ShouldEqual, datamodel.Kind_Map)
-				Wish(t, nr.Length(), ShouldEqual, int64(2))
-				Wish(t, must.String(must.Node(nr.LookupByString("one"))), ShouldEqual, "1")
-				Wish(t, must.Node(nr.LookupByString("none")), ShouldEqual, datamodel.Null)
+				qt.Assert(t, nr.Kind(), qt.Equals, datamodel.Kind_Map)
+				qt.Check(t, nr.Length(), qt.Equals, int64(2))
+				qt.Check(t, must.String(must.Node(nr.LookupByString("one"))), qt.Equals, "1")
+				qt.Check(t, must.Node(nr.LookupByString("none")), qt.Equals, datamodel.Null)
 				_, err := nr.LookupByString("miss")
-				Wish(t, err, ShouldBeSameTypeAs, datamodel.ErrNotExists{})
+				qt.Check(t, err, qt.ErrorAs, &datamodel.ErrNotExists{})
 			})
 		})
 		t.Run("repr-create", func(t *testing.T) {
@@ -88,7 +88,7 @@ func SchemaTestMapsContainingMaybe(t *testing.T, engine Engine) {
 				ma.AssembleEntry("one").AssignString("1")
 				ma.AssembleEntry("none").AssignNull()
 			})
-			Wish(t, datamodel.DeepEqual(n, nr), ShouldEqual, true)
+			qt.Check(t, datamodel.DeepEqual(n, nr), qt.IsTrue)
 		})
 	})
 }
@@ -131,35 +131,35 @@ func SchemaTestMapsContainingMaps(t *testing.T, engine Engine) {
 	}
 	reading := func(t *testing.T, n datamodel.Node, fieldName string) {
 		withNode(n, func(n datamodel.Node) {
-			Require(t, n.Kind(), ShouldEqual, datamodel.Kind_Map)
-			Wish(t, n.Length(), ShouldEqual, int64(3))
+			qt.Assert(t, n.Kind(), qt.Equals, datamodel.Kind_Map)
+			qt.Check(t, n.Length(), qt.Equals, int64(3))
 			withNode(must.Node(n.LookupByString("one")), func(n datamodel.Node) {
-				Require(t, n.Kind(), ShouldEqual, datamodel.Kind_Map)
-				Wish(t, n.Length(), ShouldEqual, int64(2))
+				qt.Assert(t, n.Kind(), qt.Equals, datamodel.Kind_Map)
+				qt.Check(t, n.Length(), qt.Equals, int64(2))
 				withNode(must.Node(n.LookupByString("zot")), func(n datamodel.Node) {
-					Require(t, n.Kind(), ShouldEqual, datamodel.Kind_Map)
-					Wish(t, n.Length(), ShouldEqual, int64(1))
-					Wish(t, must.String(must.Node(n.LookupByString(fieldName))), ShouldEqual, "11")
+					qt.Assert(t, n.Kind(), qt.Equals, datamodel.Kind_Map)
+					qt.Check(t, n.Length(), qt.Equals, int64(1))
+					qt.Check(t, must.String(must.Node(n.LookupByString(fieldName))), qt.Equals, "11")
 				})
 				withNode(must.Node(n.LookupByString("zop")), func(n datamodel.Node) {
-					Require(t, n.Kind(), ShouldEqual, datamodel.Kind_Map)
-					Wish(t, n.Length(), ShouldEqual, int64(1))
-					Wish(t, must.String(must.Node(n.LookupByString(fieldName))), ShouldEqual, "12")
+					qt.Assert(t, n.Kind(), qt.Equals, datamodel.Kind_Map)
+					qt.Check(t, n.Length(), qt.Equals, int64(1))
+					qt.Check(t, must.String(must.Node(n.LookupByString(fieldName))), qt.Equals, "12")
 				})
 			})
 			withNode(must.Node(n.LookupByString("two")), func(n datamodel.Node) {
-				Wish(t, n.Length(), ShouldEqual, int64(1))
+				qt.Check(t, n.Length(), qt.Equals, int64(1))
 				withNode(must.Node(n.LookupByString("zim")), func(n datamodel.Node) {
-					Require(t, n.Kind(), ShouldEqual, datamodel.Kind_Map)
-					Wish(t, n.Length(), ShouldEqual, int64(1))
-					Wish(t, must.String(must.Node(n.LookupByString(fieldName))), ShouldEqual, "21")
+					qt.Assert(t, n.Kind(), qt.Equals, datamodel.Kind_Map)
+					qt.Check(t, n.Length(), qt.Equals, int64(1))
+					qt.Check(t, must.String(must.Node(n.LookupByString(fieldName))), qt.Equals, "21")
 				})
 			})
 			withNode(must.Node(n.LookupByString("none")), func(n datamodel.Node) {
-				Wish(t, datamodel.DeepEqual(n, datamodel.Null), ShouldEqual, true)
+				qt.Check(t, datamodel.DeepEqual(n, datamodel.Null), qt.IsTrue)
 			})
 			_, err := n.LookupByString("miss")
-			Wish(t, err, ShouldBeSameTypeAs, datamodel.ErrNotExists{})
+			qt.Check(t, err, qt.ErrorAs, &datamodel.ErrNotExists{})
 		})
 	}
 	var n schema.TypedNode
@@ -174,7 +174,7 @@ func SchemaTestMapsContainingMaps(t *testing.T, engine Engine) {
 	})
 	t.Run("repr-create", func(t *testing.T) {
 		nr := creation(t, nrp, "encoded")
-		Wish(t, datamodel.DeepEqual(n, nr), ShouldEqual, true)
+		qt.Check(t, datamodel.DeepEqual(n, nr), qt.IsTrue)
 	})
 }
 
@@ -215,19 +215,19 @@ func SchemaTestMapsWithComplexKeys(t *testing.T, engine Engine) {
 			ma.AssembleValue().AssignString("3")
 		}).(schema.TypedNode)
 		t.Run("typed-read", func(t *testing.T) {
-			Require(t, n.Kind(), ShouldEqual, datamodel.Kind_Map)
-			Wish(t, n.Length(), ShouldEqual, int64(3))
+			qt.Assert(t, n.Kind(), qt.Equals, datamodel.Kind_Map)
+			qt.Check(t, n.Length(), qt.Equals, int64(3))
 			n2 := must.Node(n.LookupByString("c:d"))
-			Require(t, n2.Kind(), ShouldEqual, datamodel.Kind_String)
-			Wish(t, must.String(n2), ShouldEqual, "2")
+			qt.Assert(t, n2.Kind(), qt.Equals, datamodel.Kind_String)
+			qt.Check(t, must.String(n2), qt.Equals, "2")
 		})
 		t.Run("repr-read", func(t *testing.T) {
 			nr := n.Representation()
-			Require(t, nr.Kind(), ShouldEqual, datamodel.Kind_Map)
-			Wish(t, nr.Length(), ShouldEqual, int64(3))
+			qt.Assert(t, nr.Kind(), qt.Equals, datamodel.Kind_Map)
+			qt.Check(t, nr.Length(), qt.Equals, int64(3))
 			n2 := must.Node(nr.LookupByString("c:d"))
-			Require(t, n2.Kind(), ShouldEqual, datamodel.Kind_String)
-			Wish(t, must.String(n2), ShouldEqual, "2")
+			qt.Assert(t, n2.Kind(), qt.Equals, datamodel.Kind_String)
+			qt.Check(t, must.String(n2), qt.Equals, "2")
 		})
 	})
 	t.Run("repr-create", func(t *testing.T) {
@@ -236,6 +236,6 @@ func SchemaTestMapsWithComplexKeys(t *testing.T, engine Engine) {
 			ma.AssembleEntry("c:d").AssignString("2")
 			ma.AssembleEntry("e:f").AssignString("3")
 		})
-		Wish(t, datamodel.DeepEqual(n, nr), ShouldEqual, true)
+		qt.Check(t, datamodel.DeepEqual(n, nr), qt.IsTrue)
 	})
 }

--- a/node/tests/schemaScalars.go
+++ b/node/tests/schemaScalars.go
@@ -77,17 +77,17 @@ func SchemaTestScalars(t *testing.T, engine Engine) {
 
 						// Assigning null, a list, or a map, should always fail.
 						err := nb.AssignNull()
-						qt.Assert(t, err, qt.Not(qt.IsNil))
+						qt.Check(t, err, qt.Not(qt.IsNil))
 						_, err = nb.BeginMap(-1)
-						qt.Assert(t, err, qt.Not(qt.IsNil))
+						qt.Check(t, err, qt.Not(qt.IsNil))
 						_, err = nb.BeginList(-1)
-						qt.Assert(t, err, qt.Not(qt.IsNil))
+						qt.Check(t, err, qt.Not(qt.IsNil))
 
 						// Assigning the right value for the kind should succeed.
 						if useAssignNode {
 							np2 := engine.PrototypeByName(testAssign.name)
 							nb2 := np2.NewBuilder()
-							qt.Assert(t, assignValue(nb2, testAssign.value), qt.IsNil)
+							qt.Check(t, assignValue(nb2, testAssign.value), qt.IsNil)
 							n2 := nb2.Build()
 
 							err = nb.AssignNode(n2)
@@ -95,13 +95,13 @@ func SchemaTestScalars(t *testing.T, engine Engine) {
 							err = assignValue(nb, testAssign.value)
 						}
 						if testAssign.kind == testProto.kind {
-							qt.Assert(t, err, qt.IsNil)
+							qt.Check(t, err, qt.IsNil)
 						} else {
-							qt.Assert(t, err, qt.Not(qt.IsNil))
+							qt.Check(t, err, qt.Not(qt.IsNil))
 
 							// Assign something anyway, just so we can Build later.
 							err := assignValue(nb, testProto.value)
-							qt.Assert(t, err, qt.IsNil)
+							qt.Check(t, err, qt.IsNil)
 						}
 
 						n := nb.Build()
@@ -123,24 +123,24 @@ func SchemaTestScalars(t *testing.T, engine Engine) {
 							t.Fatal(testAssign.kind)
 						}
 						if testAssign.kind == testProto.kind {
-							qt.Assert(t, err, qt.IsNil)
-							qt.Assert(t, gotValue, qt.DeepEquals, testAssign.value)
+							qt.Check(t, err, qt.IsNil)
+							qt.Check(t, gotValue, qt.DeepEquals, testAssign.value)
 						} else {
-							qt.Assert(t, err, qt.Not(qt.IsNil))
+							qt.Check(t, err, qt.Not(qt.IsNil))
 						}
 
 						// Using Node methods which should never
 						// work on scalar kinds.
 
 						_, err = n.LookupByString("foo")
-						qt.Assert(t, err, qt.Not(qt.IsNil))
+						qt.Check(t, err, qt.Not(qt.IsNil))
 						_, err = n.LookupByIndex(3)
-						qt.Assert(t, err, qt.Not(qt.IsNil))
-						qt.Assert(t, n.MapIterator(), qt.IsNil)
-						qt.Assert(t, n.ListIterator(), qt.IsNil)
-						qt.Assert(t, n.Length(), qt.Equals, int64(-1))
-						qt.Assert(t, n.IsAbsent(), qt.IsFalse)
-						qt.Assert(t, n.IsNull(), qt.IsFalse)
+						qt.Check(t, err, qt.Not(qt.IsNil))
+						qt.Check(t, n.MapIterator(), qt.IsNil)
+						qt.Check(t, n.ListIterator(), qt.IsNil)
+						qt.Check(t, n.Length(), qt.Equals, int64(-1))
+						qt.Check(t, n.IsAbsent(), qt.IsFalse)
+						qt.Check(t, n.IsNull(), qt.IsFalse)
 					})
 				}
 			}

--- a/node/tests/schemaStruct.go
+++ b/node/tests/schemaStruct.go
@@ -3,7 +3,7 @@ package tests
 import (
 	"testing"
 
-	. "github.com/warpfork/go-wish"
+	qt "github.com/frankban/quicktest"
 
 	"github.com/ipld/go-ipld-prime/datamodel"
 	"github.com/ipld/go-ipld-prime/fluent"
@@ -43,8 +43,8 @@ func SchemaTestRequiredFields(t *testing.T, engine Engine) {
 		ma, _ := nb.BeginMap(0)
 		err := ma.Finish()
 
-		Wish(t, err, ShouldBeSameTypeAs, schema.ErrMissingRequiredField{})
-		Wish(t, err.Error(), ShouldEqual, `missing required fields: a,b`)
+		qt.Check(t, err, qt.ErrorAs, &schema.ErrMissingRequiredField{})
+		qt.Check(t, err.Error(), qt.Equals, `missing required fields: a,b`)
 	})
 	t.Run("building-representation-without-required-fields-errors", func(t *testing.T) {
 		nrp := engine.PrototypeByName("StructOne.Repr")
@@ -53,8 +53,8 @@ func SchemaTestRequiredFields(t *testing.T, engine Engine) {
 		ma, _ := nb.BeginMap(0)
 		err := ma.Finish()
 
-		Wish(t, err, ShouldBeSameTypeAs, schema.ErrMissingRequiredField{})
-		Wish(t, err.Error(), ShouldEqual, `missing required fields: a,b`)
+		qt.Check(t, err, qt.ErrorAs, &schema.ErrMissingRequiredField{})
+		qt.Check(t, err.Error(), qt.Equals, `missing required fields: a,b`)
 	})
 	t.Run("building-representation-with-renames-without-required-fields-errors", func(t *testing.T) {
 		nrp := engine.PrototypeByName("StructTwo.Repr")
@@ -63,8 +63,8 @@ func SchemaTestRequiredFields(t *testing.T, engine Engine) {
 		ma, _ := nb.BeginMap(0)
 		err := ma.Finish()
 
-		Wish(t, err, ShouldBeSameTypeAs, schema.ErrMissingRequiredField{})
-		Wish(t, err.Error(), ShouldEqual, `missing required fields: a,b (serial:"z")`)
+		qt.Check(t, err, qt.ErrorAs, &schema.ErrMissingRequiredField{})
+		qt.Check(t, err.Error(), qt.Equals, `missing required fields: a,b (serial:"z")`)
 	})
 }
 
@@ -100,35 +100,35 @@ func SchemaTestStructNesting(t *testing.T, engine Engine) {
 			})
 		}).(schema.TypedNode)
 		t.Run("typed-read", func(t *testing.T) {
-			Require(t, n.Kind(), ShouldEqual, datamodel.Kind_Map)
-			Wish(t, n.Length(), ShouldEqual, int64(1))
+			qt.Assert(t, n.Kind(), qt.Equals, datamodel.Kind_Map)
+			qt.Check(t, n.Length(), qt.Equals, int64(1))
 
 			n2 := must.Node(n.LookupByString("x"))
-			Require(t, n2.Kind(), ShouldEqual, datamodel.Kind_Map)
+			qt.Assert(t, n2.Kind(), qt.Equals, datamodel.Kind_Map)
 
 			n2Seg := must.Node(n.LookupBySegment(datamodel.PathSegmentOfString("x")))
-			Wish(t, datamodel.DeepEqual(n2, n2Seg), ShouldEqual, true)
+			qt.Check(t, datamodel.DeepEqual(n2, n2Seg), qt.IsTrue)
 
 			n2Node := must.Node(n.LookupByNode(basicnode.NewString("x")))
-			Wish(t, datamodel.DeepEqual(n2, n2Node), ShouldEqual, true)
+			qt.Check(t, datamodel.DeepEqual(n2, n2Node), qt.IsTrue)
 
-			Wish(t, must.String(must.Node(n2.LookupByString("s"))), ShouldEqual, "woo")
+			qt.Check(t, must.String(must.Node(n2.LookupByString("s"))), qt.Equals, "woo")
 		})
 		t.Run("repr-read", func(t *testing.T) {
 			nr := n.Representation()
-			Require(t, nr.Kind(), ShouldEqual, datamodel.Kind_Map)
-			Wish(t, nr.Length(), ShouldEqual, int64(1))
+			qt.Assert(t, nr.Kind(), qt.Equals, datamodel.Kind_Map)
+			qt.Check(t, nr.Length(), qt.Equals, int64(1))
 
 			n2 := must.Node(nr.LookupByString("r"))
-			Require(t, n2.Kind(), ShouldEqual, datamodel.Kind_Map)
+			qt.Assert(t, n2.Kind(), qt.Equals, datamodel.Kind_Map)
 
 			n2Seg := must.Node(nr.LookupBySegment(datamodel.PathSegmentOfString("r")))
-			Wish(t, datamodel.DeepEqual(n2, n2Seg), ShouldEqual, true)
+			qt.Check(t, datamodel.DeepEqual(n2, n2Seg), qt.IsTrue)
 
 			n2Node := must.Node(nr.LookupByNode(basicnode.NewString("r")))
-			Wish(t, datamodel.DeepEqual(n2, n2Node), ShouldEqual, true)
+			qt.Check(t, datamodel.DeepEqual(n2, n2Node), qt.IsTrue)
 
-			Wish(t, must.String(must.Node(n2.LookupByString("q"))), ShouldEqual, "woo")
+			qt.Check(t, must.String(must.Node(n2.LookupByString("q"))), qt.Equals, "woo")
 		})
 	})
 	t.Run("repr-create", func(t *testing.T) {
@@ -137,6 +137,6 @@ func SchemaTestStructNesting(t *testing.T, engine Engine) {
 				ma.AssembleEntry("q").AssignString("woo")
 			})
 		})
-		Wish(t, datamodel.DeepEqual(n, nr), ShouldEqual, true)
+		qt.Check(t, datamodel.DeepEqual(n, nr), qt.IsTrue)
 	})
 }

--- a/node/tests/schemaStructReprStringjoin.go
+++ b/node/tests/schemaStructReprStringjoin.go
@@ -3,7 +3,7 @@ package tests
 import (
 	"testing"
 
-	. "github.com/warpfork/go-wish"
+	qt "github.com/frankban/quicktest"
 
 	"github.com/ipld/go-ipld-prime/datamodel"
 	"github.com/ipld/go-ipld-prime/fluent"
@@ -51,21 +51,21 @@ func SchemaTestStructReprStringjoin(t *testing.T, engine Engine) {
 				ma.AssembleEntry("field").AssignString("valoo")
 			}).(schema.TypedNode)
 			t.Run("typed-read", func(t *testing.T) {
-				Require(t, n.Kind(), ShouldEqual, datamodel.Kind_Map)
-				Wish(t, n.Length(), ShouldEqual, int64(1))
-				Wish(t, must.String(must.Node(n.LookupByString("field"))), ShouldEqual, "valoo")
+				qt.Assert(t, n.Kind(), qt.Equals, datamodel.Kind_Map)
+				qt.Check(t, n.Length(), qt.Equals, int64(1))
+				qt.Check(t, must.String(must.Node(n.LookupByString("field"))), qt.Equals, "valoo")
 			})
 			t.Run("repr-read", func(t *testing.T) {
 				nr := n.Representation()
-				Require(t, nr.Kind(), ShouldEqual, datamodel.Kind_String)
-				Wish(t, must.String(nr), ShouldEqual, "valoo")
+				qt.Assert(t, nr.Kind(), qt.Equals, datamodel.Kind_String)
+				qt.Check(t, must.String(nr), qt.Equals, "valoo")
 			})
 		})
 		t.Run("repr-create", func(t *testing.T) {
 			nr := fluent.MustBuild(nrp, func(na fluent.NodeAssembler) {
 				na.AssignString("valoo")
 			})
-			Wish(t, datamodel.DeepEqual(n, nr), ShouldEqual, true)
+			qt.Check(t, datamodel.DeepEqual(n, nr), qt.IsTrue)
 		})
 	})
 
@@ -79,22 +79,22 @@ func SchemaTestStructReprStringjoin(t *testing.T, engine Engine) {
 				ma.AssembleEntry("bar").AssignString("v2")
 			}).(schema.TypedNode)
 			t.Run("typed-read", func(t *testing.T) {
-				Require(t, n.Kind(), ShouldEqual, datamodel.Kind_Map)
-				Wish(t, n.Length(), ShouldEqual, int64(2))
-				Wish(t, must.String(must.Node(n.LookupByString("foo"))), ShouldEqual, "v1")
-				Wish(t, must.String(must.Node(n.LookupByString("bar"))), ShouldEqual, "v2")
+				qt.Assert(t, n.Kind(), qt.Equals, datamodel.Kind_Map)
+				qt.Check(t, n.Length(), qt.Equals, int64(2))
+				qt.Check(t, must.String(must.Node(n.LookupByString("foo"))), qt.Equals, "v1")
+				qt.Check(t, must.String(must.Node(n.LookupByString("bar"))), qt.Equals, "v2")
 			})
 			t.Run("repr-read", func(t *testing.T) {
 				nr := n.Representation()
-				Require(t, nr.Kind(), ShouldEqual, datamodel.Kind_String)
-				Wish(t, must.String(nr), ShouldEqual, "v1:v2")
+				qt.Assert(t, nr.Kind(), qt.Equals, datamodel.Kind_String)
+				qt.Check(t, must.String(nr), qt.Equals, "v1:v2")
 			})
 		})
 		t.Run("repr-create", func(t *testing.T) {
 			nr := fluent.MustBuild(nrp, func(na fluent.NodeAssembler) {
 				na.AssignString("v1:v2")
 			})
-			Wish(t, datamodel.DeepEqual(n, nr), ShouldEqual, true)
+			qt.Check(t, datamodel.DeepEqual(n, nr), qt.IsTrue)
 		})
 	})
 
@@ -108,22 +108,22 @@ func SchemaTestStructReprStringjoin(t *testing.T, engine Engine) {
 				ma.AssembleEntry("bar").AssignString("v2")
 			}).(schema.TypedNode)
 			t.Run("typed-read", func(t *testing.T) {
-				Require(t, n.Kind(), ShouldEqual, datamodel.Kind_Map)
-				Wish(t, n.Length(), ShouldEqual, int64(2))
-				Wish(t, must.String(must.Node(n.LookupByString("foo"))), ShouldEqual, "")
-				Wish(t, must.String(must.Node(n.LookupByString("bar"))), ShouldEqual, "v2")
+				qt.Assert(t, n.Kind(), qt.Equals, datamodel.Kind_Map)
+				qt.Check(t, n.Length(), qt.Equals, int64(2))
+				qt.Check(t, must.String(must.Node(n.LookupByString("foo"))), qt.Equals, "")
+				qt.Check(t, must.String(must.Node(n.LookupByString("bar"))), qt.Equals, "v2")
 			})
 			t.Run("repr-read", func(t *testing.T) {
 				nr := n.Representation()
-				Require(t, nr.Kind(), ShouldEqual, datamodel.Kind_String)
-				Wish(t, must.String(nr), ShouldEqual, ":v2") // Note the leading colon is still present.
+				qt.Assert(t, nr.Kind(), qt.Equals, datamodel.Kind_String)
+				qt.Check(t, must.String(nr), qt.Equals, ":v2") // Note the leading colon is still present.
 			})
 		})
 		t.Run("repr-create", func(t *testing.T) {
 			nr := fluent.MustBuild(nrp, func(na fluent.NodeAssembler) {
 				na.AssignString(":v2")
 			})
-			Wish(t, datamodel.DeepEqual(n, nr), ShouldEqual, true)
+			qt.Check(t, datamodel.DeepEqual(n, nr), qt.IsTrue)
 		})
 	})
 
@@ -141,26 +141,26 @@ func SchemaTestStructReprStringjoin(t *testing.T, engine Engine) {
 				ma.AssembleEntry("bar").AssignString("v4")
 			}).(schema.TypedNode)
 			t.Run("typed-read", func(t *testing.T) {
-				Require(t, n.Kind(), ShouldEqual, datamodel.Kind_Map)
-				Wish(t, n.Length(), ShouldEqual, int64(3))
-				Wish(t, must.String(must.Node(n.LookupByString("foo"))), ShouldEqual, "v1")
-				Wish(t, must.String(must.Node(n.LookupByString("bar"))), ShouldEqual, "v4")
+				qt.Assert(t, n.Kind(), qt.Equals, datamodel.Kind_Map)
+				qt.Check(t, n.Length(), qt.Equals, int64(3))
+				qt.Check(t, must.String(must.Node(n.LookupByString("foo"))), qt.Equals, "v1")
+				qt.Check(t, must.String(must.Node(n.LookupByString("bar"))), qt.Equals, "v4")
 				n2 := must.Node(n.LookupByString("zap"))
-				Wish(t, n2.Length(), ShouldEqual, int64(2))
-				Wish(t, must.String(must.Node(n2.LookupByString("foo"))), ShouldEqual, "v2")
-				Wish(t, must.String(must.Node(n2.LookupByString("bar"))), ShouldEqual, "v3")
+				qt.Check(t, n2.Length(), qt.Equals, int64(2))
+				qt.Check(t, must.String(must.Node(n2.LookupByString("foo"))), qt.Equals, "v2")
+				qt.Check(t, must.String(must.Node(n2.LookupByString("bar"))), qt.Equals, "v3")
 			})
 			t.Run("repr-read", func(t *testing.T) {
 				nr := n.Representation()
-				Require(t, nr.Kind(), ShouldEqual, datamodel.Kind_String)
-				Wish(t, must.String(nr), ShouldEqual, "v1-v2:v3-v4")
+				qt.Assert(t, nr.Kind(), qt.Equals, datamodel.Kind_String)
+				qt.Check(t, must.String(nr), qt.Equals, "v1-v2:v3-v4")
 			})
 		})
 		t.Run("repr-create", func(t *testing.T) {
 			nr := fluent.MustBuild(nrp, func(na fluent.NodeAssembler) {
 				na.AssignString("v1-v2:v3-v4")
 			})
-			Wish(t, datamodel.DeepEqual(n, nr), ShouldEqual, true)
+			qt.Check(t, datamodel.DeepEqual(n, nr), qt.IsTrue)
 		})
 	})
 }

--- a/node/tests/schemaStructReprTuple.go
+++ b/node/tests/schemaStructReprTuple.go
@@ -3,7 +3,7 @@ package tests
 import (
 	"testing"
 
-	. "github.com/warpfork/go-wish"
+	qt "github.com/frankban/quicktest"
 
 	"github.com/ipld/go-ipld-prime/datamodel"
 	"github.com/ipld/go-ipld-prime/fluent"
@@ -41,22 +41,22 @@ func SchemaTestStructReprTuple(t *testing.T, engine Engine) {
 				ma.AssembleEntry("field").AssignString("valoo")
 			}).(schema.TypedNode)
 			t.Run("typed-read", func(t *testing.T) {
-				Require(t, n.Kind(), ShouldEqual, datamodel.Kind_Map)
-				Wish(t, n.Length(), ShouldEqual, int64(1))
-				Wish(t, must.String(must.Node(n.LookupByString("field"))), ShouldEqual, "valoo")
+				qt.Assert(t, n.Kind(), qt.Equals, datamodel.Kind_Map)
+				qt.Check(t, n.Length(), qt.Equals, int64(1))
+				qt.Check(t, must.String(must.Node(n.LookupByString("field"))), qt.Equals, "valoo")
 			})
 			t.Run("repr-read", func(t *testing.T) {
 				nr := n.Representation()
-				Require(t, nr.Kind(), ShouldEqual, datamodel.Kind_List)
-				Wish(t, nr.Length(), ShouldEqual, int64(1))
-				Wish(t, must.String(must.Node(nr.LookupByIndex(0))), ShouldEqual, "valoo")
+				qt.Assert(t, nr.Kind(), qt.Equals, datamodel.Kind_List)
+				qt.Check(t, nr.Length(), qt.Equals, int64(1))
+				qt.Check(t, must.String(must.Node(nr.LookupByIndex(0))), qt.Equals, "valoo")
 			})
 		})
 		t.Run("repr-create", func(t *testing.T) {
 			nr := fluent.MustBuildList(nrp, 1, func(la fluent.ListAssembler) {
 				la.AssembleValue().AssignString("valoo")
 			})
-			Wish(t, datamodel.DeepEqual(n, nr), ShouldEqual, true)
+			qt.Check(t, datamodel.DeepEqual(n, nr), qt.IsTrue)
 		})
 	})
 
@@ -72,21 +72,21 @@ func SchemaTestStructReprTuple(t *testing.T, engine Engine) {
 				ma.AssembleEntry("qux").AssignString("3")
 			}).(schema.TypedNode)
 			t.Run("typed-read", func(t *testing.T) {
-				Require(t, n.Kind(), ShouldEqual, datamodel.Kind_Map)
-				Wish(t, n.Length(), ShouldEqual, int64(4))
-				Wish(t, must.String(must.Node(n.LookupByString("foo"))), ShouldEqual, "0")
-				Wish(t, must.String(must.Node(n.LookupByString("bar"))), ShouldEqual, "1")
-				Wish(t, must.String(must.Node(n.LookupByString("baz"))), ShouldEqual, "2")
-				Wish(t, must.String(must.Node(n.LookupByString("qux"))), ShouldEqual, "3")
+				qt.Assert(t, n.Kind(), qt.Equals, datamodel.Kind_Map)
+				qt.Check(t, n.Length(), qt.Equals, int64(4))
+				qt.Check(t, must.String(must.Node(n.LookupByString("foo"))), qt.Equals, "0")
+				qt.Check(t, must.String(must.Node(n.LookupByString("bar"))), qt.Equals, "1")
+				qt.Check(t, must.String(must.Node(n.LookupByString("baz"))), qt.Equals, "2")
+				qt.Check(t, must.String(must.Node(n.LookupByString("qux"))), qt.Equals, "3")
 			})
 			t.Run("repr-read", func(t *testing.T) {
 				nr := n.Representation()
-				Require(t, nr.Kind(), ShouldEqual, datamodel.Kind_List)
-				Wish(t, nr.Length(), ShouldEqual, int64(4))
-				Wish(t, must.String(must.Node(nr.LookupByIndex(0))), ShouldEqual, "0")
-				Wish(t, must.String(must.Node(nr.LookupByIndex(1))), ShouldEqual, "1")
-				Wish(t, must.String(must.Node(nr.LookupByIndex(2))), ShouldEqual, "2")
-				Wish(t, must.String(must.Node(nr.LookupByIndex(3))), ShouldEqual, "3")
+				qt.Assert(t, nr.Kind(), qt.Equals, datamodel.Kind_List)
+				qt.Check(t, nr.Length(), qt.Equals, int64(4))
+				qt.Check(t, must.String(must.Node(nr.LookupByIndex(0))), qt.Equals, "0")
+				qt.Check(t, must.String(must.Node(nr.LookupByIndex(1))), qt.Equals, "1")
+				qt.Check(t, must.String(must.Node(nr.LookupByIndex(2))), qt.Equals, "2")
+				qt.Check(t, must.String(must.Node(nr.LookupByIndex(3))), qt.Equals, "3")
 			})
 		})
 		t.Run("repr-create", func(t *testing.T) {
@@ -96,7 +96,7 @@ func SchemaTestStructReprTuple(t *testing.T, engine Engine) {
 				la.AssembleValue().AssignString("2")
 				la.AssembleValue().AssignString("3")
 			})
-			Wish(t, datamodel.DeepEqual(n, nr), ShouldEqual, true)
+			qt.Check(t, datamodel.DeepEqual(n, nr), qt.IsTrue)
 		})
 	})
 
@@ -110,19 +110,19 @@ func SchemaTestStructReprTuple(t *testing.T, engine Engine) {
 				ma.AssembleEntry("bar").AssignNull()
 			}).(schema.TypedNode)
 			t.Run("typed-read", func(t *testing.T) {
-				Require(t, n.Kind(), ShouldEqual, datamodel.Kind_Map)
-				Wish(t, n.Length(), ShouldEqual, int64(4))
-				Wish(t, must.String(must.Node(n.LookupByString("foo"))), ShouldEqual, "0")
-				Wish(t, must.Node(n.LookupByString("bar")), ShouldEqual, datamodel.Null)
-				Wish(t, must.Node(n.LookupByString("baz")), ShouldEqual, datamodel.Absent)
-				Wish(t, must.Node(n.LookupByString("qux")), ShouldEqual, datamodel.Absent)
+				qt.Assert(t, n.Kind(), qt.Equals, datamodel.Kind_Map)
+				qt.Check(t, n.Length(), qt.Equals, int64(4))
+				qt.Check(t, must.String(must.Node(n.LookupByString("foo"))), qt.Equals, "0")
+				qt.Check(t, must.Node(n.LookupByString("bar")), qt.Equals, datamodel.Null)
+				qt.Check(t, must.Node(n.LookupByString("baz")), qt.Equals, datamodel.Absent)
+				qt.Check(t, must.Node(n.LookupByString("qux")), qt.Equals, datamodel.Absent)
 			})
 			t.Run("repr-read", func(t *testing.T) {
 				nr := n.Representation()
-				Require(t, nr.Kind(), ShouldEqual, datamodel.Kind_List)
-				Wish(t, nr.Length(), ShouldEqual, int64(2))
-				Wish(t, must.String(must.Node(nr.LookupByIndex(0))), ShouldEqual, "0")
-				Wish(t, must.Node(nr.LookupByIndex(1)), ShouldEqual, datamodel.Null)
+				qt.Assert(t, nr.Kind(), qt.Equals, datamodel.Kind_List)
+				qt.Check(t, nr.Length(), qt.Equals, int64(2))
+				qt.Check(t, must.String(must.Node(nr.LookupByIndex(0))), qt.Equals, "0")
+				qt.Check(t, must.Node(nr.LookupByIndex(1)), qt.Equals, datamodel.Null)
 			})
 		})
 		t.Run("repr-create", func(t *testing.T) {
@@ -130,7 +130,7 @@ func SchemaTestStructReprTuple(t *testing.T, engine Engine) {
 				la.AssembleValue().AssignString("0")
 				la.AssembleValue().AssignNull()
 			})
-			Wish(t, datamodel.DeepEqual(n, nr), ShouldEqual, true)
+			qt.Check(t, datamodel.DeepEqual(n, nr), qt.IsTrue)
 		})
 	})
 }

--- a/node/tests/stringSpecs.go
+++ b/node/tests/stringSpecs.go
@@ -3,7 +3,7 @@ package tests
 import (
 	"testing"
 
-	. "github.com/warpfork/go-wish"
+	qt "github.com/frankban/quicktest"
 
 	"github.com/ipld/go-ipld-prime/datamodel"
 )
@@ -12,13 +12,13 @@ func SpecTestString(t *testing.T, np datamodel.NodePrototype) {
 	t.Run("string node", func(t *testing.T) {
 		nb := np.NewBuilder()
 		err := nb.AssignString("asdf")
-		Wish(t, err, ShouldEqual, nil)
+		qt.Check(t, err, qt.IsNil)
 		n := nb.Build()
 
-		Wish(t, n.Kind(), ShouldEqual, datamodel.Kind_String)
-		Wish(t, n.IsNull(), ShouldEqual, false)
+		qt.Check(t, n.Kind(), qt.Equals, datamodel.Kind_String)
+		qt.Check(t, n.IsNull(), qt.IsFalse)
 		x, err := n.AsString()
-		Wish(t, err, ShouldEqual, nil)
-		Wish(t, x, ShouldEqual, "asdf")
+		qt.Check(t, err, qt.IsNil)
+		qt.Check(t, x, qt.Equals, "asdf")
 	})
 }


### PR DESCRIPTION
Port the tests in `node` package to quicktest; use:
 - `qt.Assert` for `wish.Require`
 - `qt.Check` for `wish.Wish`
 - `qt.IsTrue` for ShouldEqual` over `true`
 - `qt.IsFalse` for `ShouldEqual` over `false`
 - `qt.IsNil` for `ShouldEqual` over `nil`

Port `closeEnough` Wish checker to its equivalent in quicktest.

Relates to:
 - https://github.com/ipld/go-ipld-prime/issues/219