### PR TITLE
Port `datamodel` package tests to quicktest

### DIFF
--- a/datamodel/path_test.go
+++ b/datamodel/path_test.go
@@ -1,35 +1,39 @@
 package datamodel
 
 import (
+	"reflect"
 	"testing"
 
-	. "github.com/warpfork/go-wish"
+	qt "github.com/frankban/quicktest"
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestParsePath(t *testing.T) {
+	// Allow equality checker to check all unexported fields in PathSegment.
+	pathSegmentEquals := qt.CmpEquals(cmp.Exporter(func(reflect.Type) bool { return true }))
 	t.Run("parsing one segment", func(t *testing.T) {
-		Wish(t, ParsePath("0").segments, ShouldEqual, []PathSegment{{s: "0", i: -1}})
+		qt.Check(t, ParsePath("0").segments, pathSegmentEquals, []PathSegment{{s: "0", i: -1}})
 	})
 	t.Run("parsing three segments", func(t *testing.T) {
-		Wish(t, ParsePath("0/foo/2").segments, ShouldEqual, []PathSegment{{s: "0", i: -1}, {s: "foo", i: -1}, {s: "2", i: -1}})
+		qt.Check(t, ParsePath("0/foo/2").segments, pathSegmentEquals, []PathSegment{{s: "0", i: -1}, {s: "foo", i: -1}, {s: "2", i: -1}})
 	})
 	t.Run("eliding leading slashes", func(t *testing.T) {
-		Wish(t, ParsePath("/0/2").segments, ShouldEqual, []PathSegment{{s: "0", i: -1}, {s: "2", i: -1}})
+		qt.Check(t, ParsePath("/0/2").segments, pathSegmentEquals, []PathSegment{{s: "0", i: -1}, {s: "2", i: -1}})
 	})
 	t.Run("eliding trailing", func(t *testing.T) {
-		Wish(t, ParsePath("0/2/").segments, ShouldEqual, []PathSegment{{s: "0", i: -1}, {s: "2", i: -1}})
+		qt.Check(t, ParsePath("0/2/").segments, pathSegmentEquals, []PathSegment{{s: "0", i: -1}, {s: "2", i: -1}})
 	})
 	t.Run("eliding empty segments", func(t *testing.T) { // NOTE: a spec for string encoding might cause this to change in the future!
-		Wish(t, ParsePath("0//2").segments, ShouldEqual, []PathSegment{{s: "0", i: -1}, {s: "2", i: -1}})
+		qt.Check(t, ParsePath("0//2").segments, pathSegmentEquals, []PathSegment{{s: "0", i: -1}, {s: "2", i: -1}})
 	})
 	t.Run("escaping segments", func(t *testing.T) { // NOTE: a spec for string encoding might cause this to change in the future!
-		Wish(t, ParsePath(`0/\//2`).segments, ShouldEqual, []PathSegment{{s: "0", i: -1}, {s: `\`, i: -1}, {s: "2", i: -1}})
+		qt.Check(t, ParsePath(`0/\//2`).segments, pathSegmentEquals, []PathSegment{{s: "0", i: -1}, {s: `\`, i: -1}, {s: "2", i: -1}})
 	})
 }
 
 func TestPathSegmentZeroValue(t *testing.T) {
-	Wish(t, PathSegment{}.String(), ShouldEqual, "0")
+	qt.Check(t, PathSegment{}.String(), qt.Equals, "0")
 	i, err := PathSegment{}.Index()
-	Wish(t, err, ShouldEqual, nil)
-	Wish(t, i, ShouldEqual, int64(0))
+	qt.Check(t, err, qt.IsNil)
+	qt.Check(t, i, qt.Equals, int64(0))
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/frankban/quicktest v1.14.0
+	github.com/google/go-cmp v0.5.6
 	github.com/ipfs/go-cid v0.0.4
 	github.com/multiformats/go-multicodec v0.3.0
 	github.com/multiformats/go-multihash v0.0.15


### PR DESCRIPTION
Port the tests in `datamodel` package to quicktest; use:
 - `qt.Check` for `wish.Wish`
 - `qt.IsNil` for `ShouldEqual` over `nil`
 - `qt.CmpEquals` with custom `Exporter` that exports all fields for
   `ShouldEqual` over `PathSegment`

Relates to:
 - https://github.com/ipld/go-ipld-prime/issues/219