### PR TITLE
Gracefully print typed nodes with `nil` type

### DIFF
--- a/printer/printer.go
+++ b/printer/printer.go
@@ -175,11 +175,21 @@ func (z *printBuf) doString(indentLevel int, printState uint8, n datamodel.Node)
 	//  Note: this can be somewhat overbearing -- for example, typed strings are going to get called out as `string<String>{"value"}`.
 	//   This is rather agonizingly verbose, but also accurate; I'm not sure if we'd want to elide information about typed-vs-untyped entirely.
 	if tn, ok := n.(schema.TypedNode); ok {
-		z.writeString(tn.Type().TypeKind().String())
+		var tnk schema.TypeKind
+		var tntName string
+		// Defensively check for nil node type
+		if tnt := tn.Type(); tnt == nil {
+			tntName = "?!nil"
+			tnk = schema.TypeKind_Invalid
+		} else {
+			tntName = tnt.Name()
+			tnk = tnt.TypeKind()
+		}
+		z.writeString(tnk.String())
 		z.writeString("<")
-		z.writeString(tn.Type().Name())
+		z.writeString(tntName)
 		z.writeString(">")
-		switch tn.Type().TypeKind() {
+		switch tnk {
 		case schema.TypeKind_Invalid:
 			z.writeString("{?!}")
 		case schema.TypeKind_Map:

--- a/printer/printer_test.go
+++ b/printer/printer_test.go
@@ -225,5 +225,87 @@ func TestTypedData(t *testing.T) {
 			))
 		})
 	})
+	t.Run("invalid-nil-typed-node", func(t *testing.T) {
+		qt.Check(t, Sprint(nilTypedNode{}), qt.CmpEquals(), "invalid<?!nil>{?!}")
+	})
+}
 
+var _ schema.TypedNode = (*nilTypedNode)(nil)
+
+type nilTypedNode struct{}
+
+func (n nilTypedNode) Kind() datamodel.Kind {
+	return datamodel.Kind_Invalid
+}
+
+func (n nilTypedNode) LookupByString(key string) (datamodel.Node, error) {
+	return nil, nil
+}
+
+func (n nilTypedNode) LookupByNode(key datamodel.Node) (datamodel.Node, error) {
+	return nil, nil
+}
+
+func (n nilTypedNode) LookupByIndex(idx int64) (datamodel.Node, error) {
+	return nil, nil
+}
+
+func (n nilTypedNode) LookupBySegment(seg datamodel.PathSegment) (datamodel.Node, error) {
+	return nil, nil
+}
+
+func (n nilTypedNode) MapIterator() datamodel.MapIterator {
+	return nil
+}
+
+func (n nilTypedNode) ListIterator() datamodel.ListIterator {
+	return nil
+}
+
+func (n nilTypedNode) Length() int64 {
+	return 0
+}
+
+func (n nilTypedNode) IsAbsent() bool {
+	return false
+}
+
+func (n nilTypedNode) IsNull() bool {
+	return false
+}
+
+func (n nilTypedNode) AsBool() (bool, error) {
+	panic("nil-typed-node")
+}
+
+func (n nilTypedNode) AsInt() (int64, error) {
+	panic("nil-typed-node")
+}
+
+func (n nilTypedNode) AsFloat() (float64, error) {
+	panic("nil-typed-node")
+}
+
+func (n nilTypedNode) AsString() (string, error) {
+	panic("nil-typed-node")
+}
+
+func (n nilTypedNode) AsBytes() ([]byte, error) {
+	panic("nil-typed-node")
+}
+
+func (n nilTypedNode) AsLink() (datamodel.Link, error) {
+	panic("nil-typed-node")
+}
+
+func (n nilTypedNode) Prototype() datamodel.NodePrototype {
+	return nil
+}
+
+func (n nilTypedNode) Type() schema.Type {
+	return nil
+}
+
+func (n nilTypedNode) Representation() datamodel.Node {
+	return nil
 }


### PR DESCRIPTION
Given an invalid `TypedNode` with `nil` type gracefully print a
representation of its content by using:
- `?!nil` as type name
- `schema.TypeKind_Invalid` as its `TypeKind`

Fixes #296