### PR TITLE
Gracefully handle `TypedNode` with `nil` type of kind `Map`

### DIFF
--- a/printer/printer.go
+++ b/printer/printer.go
@@ -124,11 +124,15 @@ func (cfg Config) useCmplxKeys(mapn datamodel.Node) bool {
 	if !ok {
 		return false
 	}
-	force, ok := cfg.UseMapComplexStyleOnType[tn.Type().Name()]
+	tnt := tn.Type()
+	if tnt == nil {
+		return false
+	}
+	force, ok := cfg.UseMapComplexStyleOnType[tnt.Name()]
 	if ok {
 		return force
 	}
-	ti, ok := tn.Type().(*schema.TypeMap)
+	ti, ok := tnt.(*schema.TypeMap)
 	if !ok { // Probably should never even have been asked, then?
 		panic("how did you get here?")
 	}

--- a/printer/printer_test.go
+++ b/printer/printer_test.go
@@ -226,16 +226,21 @@ func TestTypedData(t *testing.T) {
 		})
 	})
 	t.Run("invalid-nil-typed-node", func(t *testing.T) {
-		qt.Check(t, Sprint(nilTypedNode{}), qt.CmpEquals(), "invalid<?!nil>{?!}")
+		qt.Check(t, Sprint(&nilTypedNode{datamodel.Kind_Invalid}), qt.CmpEquals(), "invalid<?!nil>{?!}")
+	})
+	t.Run("invalid-nil-typed-node-with-map-kind", func(t *testing.T) {
+		qt.Check(t, Sprint(&nilTypedNode{datamodel.Kind_Map}), qt.CmpEquals(), "invalid<?!nil>{?!}{}")
 	})
 }
 
 var _ schema.TypedNode = (*nilTypedNode)(nil)
 
-type nilTypedNode struct{}
+type nilTypedNode struct {
+	kind datamodel.Kind
+}
 
-func (n nilTypedNode) Kind() datamodel.Kind {
-	return datamodel.Kind_Invalid
+func (n *nilTypedNode) Kind() datamodel.Kind {
+	return n.kind
 }
 
 func (n nilTypedNode) LookupByString(key string) (datamodel.Node, error) {


### PR DESCRIPTION
When the kind of `TypedNode` is a `Map`, the printer checks the type to
determine print complexity. Always use simple printing when type is
`nil`.

Relates to: #296