### PR TITLE
Port `traversal` package tests to quicktest

### DIFF
--- a/traversal/focus_test.go
+++ b/traversal/focus_test.go
@@ -1,12 +1,13 @@
 package traversal_test
 
 import (
-	"fmt"
+	"reflect"
 	"testing"
 
-	. "github.com/warpfork/go-wish"
-
+	qt "github.com/frankban/quicktest"
+	"github.com/google/go-cmp/cmp"
 	"github.com/ipfs/go-cid"
+
 	_ "github.com/ipld/go-ipld-prime/codec/dagjson"
 	"github.com/ipld/go-ipld-prime/datamodel"
 	"github.com/ipld/go-ipld-prime/fluent"
@@ -14,12 +15,15 @@ import (
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/ipld/go-ipld-prime/must"
 	"github.com/ipld/go-ipld-prime/node/basicnode"
+	nodetests "github.com/ipld/go-ipld-prime/node/tests"
 	"github.com/ipld/go-ipld-prime/storage/memstore"
 	"github.com/ipld/go-ipld-prime/traversal"
 )
 
 // Do some fixture fabrication.
 // We assume all the builders and serialization must Just Work here.
+
+var deepEqualsAllowAllUnexported = qt.CmpEquals(cmp.Exporter(func(reflect.Type) bool { return true }))
 
 var store = memstore.Store{}
 var (
@@ -81,27 +85,27 @@ func encode(n datamodel.Node) (datamodel.Node, datamodel.Link) {
 func TestFocusSingleTree(t *testing.T) {
 	t.Run("empty path on scalar node returns start node", func(t *testing.T) {
 		err := traversal.Focus(basicnode.NewString("x"), datamodel.Path{}, func(prog traversal.Progress, n datamodel.Node) error {
-			Wish(t, n, ShouldEqual, basicnode.NewString("x"))
-			Wish(t, prog.Path.String(), ShouldEqual, datamodel.Path{}.String())
+			qt.Check(t, n, nodetests.NodeContentEquals, basicnode.NewString("x"))
+			qt.Check(t, prog.Path.String(), qt.Equals, datamodel.Path{}.String())
 			return nil
 		})
-		Wish(t, err, ShouldEqual, nil)
+		qt.Check(t, err, qt.IsNil)
 	})
 	t.Run("one step path on map node works", func(t *testing.T) {
 		err := traversal.Focus(middleMapNode, datamodel.ParsePath("foo"), func(prog traversal.Progress, n datamodel.Node) error {
-			Wish(t, n, ShouldEqual, basicnode.NewBool(true))
-			Wish(t, prog.Path, ShouldEqual, datamodel.ParsePath("foo"))
+			qt.Check(t, n, nodetests.NodeContentEquals, basicnode.NewBool(true))
+			qt.Check(t, prog.Path, deepEqualsAllowAllUnexported, datamodel.ParsePath("foo"))
 			return nil
 		})
-		Wish(t, err, ShouldEqual, nil)
+		qt.Check(t, err, qt.IsNil)
 	})
 	t.Run("two step path on map node works", func(t *testing.T) {
 		err := traversal.Focus(middleMapNode, datamodel.ParsePath("nested/nonlink"), func(prog traversal.Progress, n datamodel.Node) error {
-			Wish(t, n, ShouldEqual, basicnode.NewString("zoo"))
-			Wish(t, prog.Path, ShouldEqual, datamodel.ParsePath("nested/nonlink"))
+			qt.Check(t, n, nodetests.NodeContentEquals, basicnode.NewString("zoo"))
+			qt.Check(t, prog.Path, deepEqualsAllowAllUnexported, datamodel.ParsePath("nested/nonlink"))
 			return nil
 		})
-		Wish(t, err, ShouldEqual, nil)
+		qt.Check(t, err, qt.IsNil)
 	})
 }
 
@@ -110,18 +114,18 @@ func TestFocusSingleTree(t *testing.T) {
 func TestGetSingleTree(t *testing.T) {
 	t.Run("empty path on scalar node returns start node", func(t *testing.T) {
 		n, err := traversal.Get(basicnode.NewString("x"), datamodel.Path{})
-		Wish(t, err, ShouldEqual, nil)
-		Wish(t, n, ShouldEqual, basicnode.NewString("x"))
+		qt.Check(t, err, qt.IsNil)
+		qt.Check(t, n, nodetests.NodeContentEquals, basicnode.NewString("x"))
 	})
 	t.Run("one step path on map node works", func(t *testing.T) {
 		n, err := traversal.Get(middleMapNode, datamodel.ParsePath("foo"))
-		Wish(t, err, ShouldEqual, nil)
-		Wish(t, n, ShouldEqual, basicnode.NewBool(true))
+		qt.Check(t, err, qt.IsNil)
+		qt.Check(t, n, nodetests.NodeContentEquals, basicnode.NewBool(true))
 	})
 	t.Run("two step path on map node works", func(t *testing.T) {
 		n, err := traversal.Get(middleMapNode, datamodel.ParsePath("nested/nonlink"))
-		Wish(t, err, ShouldEqual, nil)
-		Wish(t, n, ShouldEqual, basicnode.NewString("zoo"))
+		qt.Check(t, err, qt.IsNil)
+		qt.Check(t, n, nodetests.NodeContentEquals, basicnode.NewString("zoo"))
 	})
 }
 
@@ -132,14 +136,14 @@ func TestFocusWithLinkLoading(t *testing.T) {
 				t.Errorf("should not be reached; no way to load this path")
 				return nil
 			})
-			Wish(t, err.Error(), ShouldEqual, `error traversing node at "nested/alink": could not load link "`+leafAlphaLnk.String()+`": no LinkTargetNodePrototypeChooser configured`)
+			qt.Check(t, err.Error(), qt.Equals, `error traversing node at "nested/alink": could not load link "`+leafAlphaLnk.String()+`": no LinkTargetNodePrototypeChooser configured`)
 		})
 		t.Run("mid-path link should fail", func(t *testing.T) {
 			err := traversal.Focus(rootNode, datamodel.ParsePath("linkedMap/nested/nonlink"), func(prog traversal.Progress, n datamodel.Node) error {
 				t.Errorf("should not be reached; no way to load this path")
 				return nil
 			})
-			Wish(t, err.Error(), ShouldEqual, `error traversing node at "linkedMap": could not load link "`+middleMapNodeLnk.String()+`": no LinkTargetNodePrototypeChooser configured`)
+			qt.Check(t, err.Error(), qt.Equals, `error traversing node at "linkedMap": could not load link "`+middleMapNodeLnk.String()+`": no LinkTargetNodePrototypeChooser configured`)
 		})
 	})
 	t.Run("link traversal with loader should work", func(t *testing.T) {
@@ -151,13 +155,13 @@ func TestFocusWithLinkLoading(t *testing.T) {
 				LinkTargetNodePrototypeChooser: basicnode.Chooser,
 			},
 		}.Focus(rootNode, datamodel.ParsePath("linkedMap/nested/nonlink"), func(prog traversal.Progress, n datamodel.Node) error {
-			Wish(t, n, ShouldEqual, basicnode.NewString("zoo"))
-			Wish(t, prog.Path, ShouldEqual, datamodel.ParsePath("linkedMap/nested/nonlink"))
-			Wish(t, prog.LastBlock.Link, ShouldEqual, middleMapNodeLnk)
-			Wish(t, prog.LastBlock.Path, ShouldEqual, datamodel.ParsePath("linkedMap"))
+			qt.Check(t, n, nodetests.NodeContentEquals, basicnode.NewString("zoo"))
+			qt.Check(t, prog.Path, deepEqualsAllowAllUnexported, datamodel.ParsePath("linkedMap/nested/nonlink"))
+			qt.Check(t, prog.LastBlock.Link, deepEqualsAllowAllUnexported, middleMapNodeLnk)
+			qt.Check(t, prog.LastBlock.Path, deepEqualsAllowAllUnexported, datamodel.ParsePath("linkedMap"))
 			return nil
 		})
-		Wish(t, err, ShouldEqual, nil)
+		qt.Check(t, err, qt.IsNil)
 	})
 }
 
@@ -165,11 +169,11 @@ func TestGetWithLinkLoading(t *testing.T) {
 	t.Run("link traversal with no configured loader should fail", func(t *testing.T) {
 		t.Run("terminal link should fail", func(t *testing.T) {
 			_, err := traversal.Get(middleMapNode, datamodel.ParsePath("nested/alink"))
-			Wish(t, err.Error(), ShouldEqual, `error traversing node at "nested/alink": could not load link "`+leafAlphaLnk.String()+`": no LinkTargetNodePrototypeChooser configured`)
+			qt.Check(t, err.Error(), qt.Equals, `error traversing node at "nested/alink": could not load link "`+leafAlphaLnk.String()+`": no LinkTargetNodePrototypeChooser configured`)
 		})
 		t.Run("mid-path link should fail", func(t *testing.T) {
 			_, err := traversal.Get(rootNode, datamodel.ParsePath("linkedMap/nested/nonlink"))
-			Wish(t, err.Error(), ShouldEqual, `error traversing node at "linkedMap": could not load link "`+middleMapNodeLnk.String()+`": no LinkTargetNodePrototypeChooser configured`)
+			qt.Check(t, err.Error(), qt.Equals, `error traversing node at "linkedMap": could not load link "`+middleMapNodeLnk.String()+`": no LinkTargetNodePrototypeChooser configured`)
 		})
 	})
 	t.Run("link traversal with loader should work", func(t *testing.T) {
@@ -181,135 +185,135 @@ func TestGetWithLinkLoading(t *testing.T) {
 				LinkTargetNodePrototypeChooser: basicnode.Chooser,
 			},
 		}.Get(rootNode, datamodel.ParsePath("linkedMap/nested/nonlink"))
-		Wish(t, err, ShouldEqual, nil)
-		Wish(t, n, ShouldEqual, basicnode.NewString("zoo"))
+		qt.Check(t, err, qt.IsNil)
+		qt.Check(t, n, nodetests.NodeContentEquals, basicnode.NewString("zoo"))
 	})
 }
 
 func TestFocusedTransform(t *testing.T) {
 	t.Run("UpdateMapEntry", func(t *testing.T) {
 		n, err := traversal.FocusedTransform(rootNode, datamodel.ParsePath("plain"), func(progress traversal.Progress, prev datamodel.Node) (datamodel.Node, error) {
-			Wish(t, progress.Path.String(), ShouldEqual, "plain")
-			Wish(t, must.String(prev), ShouldEqual, "olde string")
+			qt.Check(t, progress.Path.String(), qt.Equals, "plain")
+			qt.Check(t, must.String(prev), qt.Equals, "olde string")
 			nb := prev.Prototype().NewBuilder()
 			nb.AssignString("new string!")
 			return nb.Build(), nil
 		}, false)
-		Wish(t, err, ShouldEqual, nil)
-		Wish(t, n.Kind(), ShouldEqual, datamodel.Kind_Map)
+		qt.Check(t, err, qt.IsNil)
+		qt.Check(t, n.Kind(), qt.Equals, datamodel.Kind_Map)
 		// updated value should be there
-		Wish(t, must.Node(n.LookupByString("plain")), ShouldEqual, basicnode.NewString("new string!"))
+		qt.Check(t, must.Node(n.LookupByString("plain")), nodetests.NodeContentEquals, basicnode.NewString("new string!"))
 		// everything else should be there
-		Wish(t, must.Node(n.LookupByString("linkedString")), ShouldEqual, must.Node(rootNode.LookupByString("linkedString")))
-		Wish(t, must.Node(n.LookupByString("linkedMap")), ShouldEqual, must.Node(rootNode.LookupByString("linkedMap")))
-		Wish(t, must.Node(n.LookupByString("linkedList")), ShouldEqual, must.Node(rootNode.LookupByString("linkedList")))
+		qt.Check(t, must.Node(n.LookupByString("linkedString")), qt.Equals, must.Node(rootNode.LookupByString("linkedString")))
+		qt.Check(t, must.Node(n.LookupByString("linkedMap")), qt.Equals, must.Node(rootNode.LookupByString("linkedMap")))
+		qt.Check(t, must.Node(n.LookupByString("linkedList")), qt.Equals, must.Node(rootNode.LookupByString("linkedList")))
 		// everything should still be in the same order
-		Wish(t, keys(n), ShouldEqual, []string{"plain", "linkedString", "linkedMap", "linkedList"})
+		qt.Check(t, keys(n), qt.DeepEquals, []string{"plain", "linkedString", "linkedMap", "linkedList"})
 	})
 	t.Run("UpdateDeeperMap", func(t *testing.T) {
 		n, err := traversal.FocusedTransform(middleMapNode, datamodel.ParsePath("nested/alink"), func(progress traversal.Progress, prev datamodel.Node) (datamodel.Node, error) {
-			Wish(t, progress.Path.String(), ShouldEqual, "nested/alink")
-			Wish(t, prev, ShouldEqual, basicnode.NewLink(leafAlphaLnk))
+			qt.Check(t, progress.Path.String(), qt.Equals, "nested/alink")
+			qt.Check(t, prev, nodetests.NodeContentEquals, basicnode.NewLink(leafAlphaLnk))
 			return basicnode.NewString("new string!"), nil
 		}, false)
-		Wish(t, err, ShouldEqual, nil)
-		Wish(t, n.Kind(), ShouldEqual, datamodel.Kind_Map)
+		qt.Check(t, err, qt.IsNil)
+		qt.Check(t, n.Kind(), qt.Equals, datamodel.Kind_Map)
 		// updated value should be there
-		Wish(t, must.Node(must.Node(n.LookupByString("nested")).LookupByString("alink")), ShouldEqual, basicnode.NewString("new string!"))
+		qt.Check(t, must.Node(must.Node(n.LookupByString("nested")).LookupByString("alink")), nodetests.NodeContentEquals, basicnode.NewString("new string!"))
 		// everything else in the parent map should should be there!
-		Wish(t, must.Node(n.LookupByString("foo")), ShouldEqual, must.Node(middleMapNode.LookupByString("foo")))
-		Wish(t, must.Node(n.LookupByString("bar")), ShouldEqual, must.Node(middleMapNode.LookupByString("bar")))
+		qt.Check(t, must.Node(n.LookupByString("foo")), qt.Equals, must.Node(middleMapNode.LookupByString("foo")))
+		qt.Check(t, must.Node(n.LookupByString("bar")), qt.Equals, must.Node(middleMapNode.LookupByString("bar")))
 		// everything should still be in the same order
-		Wish(t, keys(n), ShouldEqual, []string{"foo", "bar", "nested"})
+		qt.Check(t, keys(n), qt.DeepEquals, []string{"foo", "bar", "nested"})
 	})
 	t.Run("AppendIfNotExists", func(t *testing.T) {
 		n, err := traversal.FocusedTransform(rootNode, datamodel.ParsePath("newpart"), func(progress traversal.Progress, prev datamodel.Node) (datamodel.Node, error) {
-			Wish(t, progress.Path.String(), ShouldEqual, "newpart")
-			Wish(t, prev, ShouldEqual, nil) // REVIEW: should datamodel.Absent be used here?  I lean towards "no" but am unsure what's least surprising here.
+			qt.Check(t, progress.Path.String(), qt.Equals, "newpart")
+			qt.Check(t, prev, qt.IsNil) // REVIEW: should datamodel.Absent be used here?  I lean towards "no" but am unsure what's least surprising here.
 			// An interesting thing to note about inserting a value this way is that you have no `prev.Prototype().NewBuilder()` to use if you wanted to.
 			//  But if that's an issue, then what you do is a focus or walk (transforming or not) to the parent node, get its child prototypes, and go from there.
 			return basicnode.NewString("new string!"), nil
 		}, false)
-		Wish(t, err, ShouldEqual, nil)
-		Wish(t, n.Kind(), ShouldEqual, datamodel.Kind_Map)
+		qt.Check(t, err, qt.IsNil)
+		qt.Check(t, n.Kind(), qt.Equals, datamodel.Kind_Map)
 		// updated value should be there
-		Wish(t, must.Node(n.LookupByString("newpart")), ShouldEqual, basicnode.NewString("new string!"))
+		qt.Check(t, must.Node(n.LookupByString("newpart")), nodetests.NodeContentEquals, basicnode.NewString("new string!"))
 		// everything should still be in the same order... with the new entry at the end.
-		Wish(t, keys(n), ShouldEqual, []string{"plain", "linkedString", "linkedMap", "linkedList", "newpart"})
+		qt.Check(t, keys(n), qt.DeepEquals, []string{"plain", "linkedString", "linkedMap", "linkedList", "newpart"})
 	})
 	t.Run("CreateParents", func(t *testing.T) {
 		n, err := traversal.FocusedTransform(rootNode, datamodel.ParsePath("newsection/newpart"), func(progress traversal.Progress, prev datamodel.Node) (datamodel.Node, error) {
-			Wish(t, progress.Path.String(), ShouldEqual, "newsection/newpart")
-			Wish(t, prev, ShouldEqual, nil) // REVIEW: should datamodel.Absent be used here?  I lean towards "no" but am unsure what's least surprising here.
+			qt.Check(t, progress.Path.String(), qt.Equals, "newsection/newpart")
+			qt.Check(t, prev, qt.IsNil) // REVIEW: should datamodel.Absent be used here?  I lean towards "no" but am unsure what's least surprising here.
 			return basicnode.NewString("new string!"), nil
 		}, true)
-		Wish(t, err, ShouldEqual, nil)
-		Wish(t, n.Kind(), ShouldEqual, datamodel.Kind_Map)
+		qt.Check(t, err, qt.IsNil)
+		qt.Check(t, n.Kind(), qt.Equals, datamodel.Kind_Map)
 		// a new map node in the middle should've been created
 		n2 := must.Node(n.LookupByString("newsection"))
-		Wish(t, n2.Kind(), ShouldEqual, datamodel.Kind_Map)
+		qt.Check(t, n2.Kind(), qt.Equals, datamodel.Kind_Map)
 		// updated value should in there
-		Wish(t, must.Node(n2.LookupByString("newpart")), ShouldEqual, basicnode.NewString("new string!"))
+		qt.Check(t, must.Node(n2.LookupByString("newpart")), nodetests.NodeContentEquals, basicnode.NewString("new string!"))
 		// everything in the root map should still be in the same order... with the new entry at the end.
-		Wish(t, keys(n), ShouldEqual, []string{"plain", "linkedString", "linkedMap", "linkedList", "newsection"})
+		qt.Check(t, keys(n), qt.DeepEquals, []string{"plain", "linkedString", "linkedMap", "linkedList", "newsection"})
 		// and the created intermediate map of course has just one entry.
-		Wish(t, keys(n2), ShouldEqual, []string{"newpart"})
+		qt.Check(t, keys(n2), qt.DeepEquals, []string{"newpart"})
 	})
 	t.Run("CreateParentsRequiresPermission", func(t *testing.T) {
 		_, err := traversal.FocusedTransform(rootNode, datamodel.ParsePath("newsection/newpart"), func(progress traversal.Progress, prev datamodel.Node) (datamodel.Node, error) {
-			Wish(t, true, ShouldEqual, false) // ought not be reached
+			qt.Check(t, true, qt.IsFalse) // ought not be reached
 			return nil, nil
 		}, false)
-		Wish(t, err, ShouldEqual, fmt.Errorf("transform: parent position at \"newsection\" did not exist (and createParents was false)"))
+		qt.Check(t, err.Error(), qt.Equals, "transform: parent position at \"newsection\" did not exist (and createParents was false)")
 	})
 	t.Run("UpdateListEntry", func(t *testing.T) {
 		n, err := traversal.FocusedTransform(middleListNode, datamodel.ParsePath("2"), func(progress traversal.Progress, prev datamodel.Node) (datamodel.Node, error) {
-			Wish(t, progress.Path.String(), ShouldEqual, "2")
-			Wish(t, prev, ShouldEqual, basicnode.NewLink(leafBetaLnk))
+			qt.Check(t, progress.Path.String(), qt.Equals, "2")
+			qt.Check(t, prev, nodetests.NodeContentEquals, basicnode.NewLink(leafBetaLnk))
 			return basicnode.NewString("new string!"), nil
 		}, false)
-		Wish(t, err, ShouldEqual, nil)
-		Wish(t, n.Kind(), ShouldEqual, datamodel.Kind_List)
+		qt.Check(t, err, qt.IsNil)
+		qt.Check(t, n.Kind(), qt.Equals, datamodel.Kind_List)
 		// updated value should be there
-		Wish(t, must.Node(n.LookupByIndex(2)), ShouldEqual, basicnode.NewString("new string!"))
+		qt.Check(t, must.Node(n.LookupByIndex(2)), nodetests.NodeContentEquals, basicnode.NewString("new string!"))
 		// everything else should be there
-		Wish(t, n.Length(), ShouldEqual, int64(4))
-		Wish(t, must.Node(n.LookupByIndex(0)), ShouldEqual, basicnode.NewLink(leafAlphaLnk))
-		Wish(t, must.Node(n.LookupByIndex(1)), ShouldEqual, basicnode.NewLink(leafAlphaLnk))
-		Wish(t, must.Node(n.LookupByIndex(3)), ShouldEqual, basicnode.NewLink(leafAlphaLnk))
+		qt.Check(t, n.Length(), qt.Equals, int64(4))
+		qt.Check(t, must.Node(n.LookupByIndex(0)), nodetests.NodeContentEquals, basicnode.NewLink(leafAlphaLnk))
+		qt.Check(t, must.Node(n.LookupByIndex(1)), nodetests.NodeContentEquals, basicnode.NewLink(leafAlphaLnk))
+		qt.Check(t, must.Node(n.LookupByIndex(3)), nodetests.NodeContentEquals, basicnode.NewLink(leafAlphaLnk))
 	})
 	t.Run("AppendToList", func(t *testing.T) {
 		n, err := traversal.FocusedTransform(middleListNode, datamodel.ParsePath("-"), func(progress traversal.Progress, prev datamodel.Node) (datamodel.Node, error) {
-			Wish(t, progress.Path.String(), ShouldEqual, "4")
-			Wish(t, prev, ShouldEqual, nil)
+			qt.Check(t, progress.Path.String(), qt.Equals, "4")
+			qt.Check(t, prev, qt.IsNil)
 			return basicnode.NewString("new string!"), nil
 		}, false)
-		Wish(t, err, ShouldEqual, nil)
-		Wish(t, n.Kind(), ShouldEqual, datamodel.Kind_List)
+		qt.Check(t, err, qt.IsNil)
+		qt.Check(t, n.Kind(), qt.Equals, datamodel.Kind_List)
 		// updated value should be there
-		Wish(t, must.Node(n.LookupByIndex(4)), ShouldEqual, basicnode.NewString("new string!"))
+		qt.Check(t, must.Node(n.LookupByIndex(4)), nodetests.NodeContentEquals, basicnode.NewString("new string!"))
 		// everything else should be there
-		Wish(t, n.Length(), ShouldEqual, int64(5))
+		qt.Check(t, n.Length(), qt.Equals, int64(5))
 	})
 	t.Run("ListBounds", func(t *testing.T) {
 		_, err := traversal.FocusedTransform(middleListNode, datamodel.ParsePath("4"), func(progress traversal.Progress, prev datamodel.Node) (datamodel.Node, error) {
-			Wish(t, true, ShouldEqual, false) // ought not be reached
+			qt.Check(t, true, qt.IsFalse) // ought not be reached
 			return nil, nil
 		}, false)
-		Wish(t, err, ShouldEqual, fmt.Errorf("transform: cannot navigate path segment \"4\" at \"\" because it is beyond the list bounds"))
+		qt.Check(t, err, qt.ErrorMatches, "transform: cannot navigate path segment \"4\" at \"\" because it is beyond the list bounds")
 	})
 	t.Run("ReplaceRoot", func(t *testing.T) { // a fairly degenerate case and no reason to do this, but should work.
 		n, err := traversal.FocusedTransform(middleListNode, datamodel.ParsePath(""), func(progress traversal.Progress, prev datamodel.Node) (datamodel.Node, error) {
-			Wish(t, progress.Path.String(), ShouldEqual, "")
-			Wish(t, prev, ShouldEqual, middleListNode)
+			qt.Check(t, progress.Path.String(), qt.Equals, "")
+			qt.Check(t, prev, nodetests.NodeContentEquals, middleListNode)
 			nb := basicnode.Prototype.Any.NewBuilder()
 			la, _ := nb.BeginList(0)
 			la.Finish()
 			return nb.Build(), nil
 		}, false)
-		Wish(t, err, ShouldEqual, nil)
-		Wish(t, n.Kind(), ShouldEqual, datamodel.Kind_List)
-		Wish(t, n.Length(), ShouldEqual, int64(0))
+		qt.Check(t, err, qt.IsNil)
+		qt.Check(t, n.Kind(), qt.Equals, datamodel.Kind_List)
+		qt.Check(t, n.Length(), qt.Equals, int64(0))
 	})
 }
 
@@ -326,18 +330,18 @@ func TestFocusedTransformWithLinks(t *testing.T) {
 		n, err := traversal.Progress{
 			Cfg: &cfg,
 		}.FocusedTransform(rootNode, datamodel.ParsePath("linkedMap/nested/nonlink"), func(progress traversal.Progress, prev datamodel.Node) (datamodel.Node, error) {
-			Wish(t, progress.Path.String(), ShouldEqual, "linkedMap/nested/nonlink")
-			Wish(t, must.String(prev), ShouldEqual, "zoo")
-			Wish(t, progress.LastBlock.Path.String(), ShouldEqual, "linkedMap")
-			Wish(t, progress.LastBlock.Link.String(), ShouldEqual, "baguqeeyezhlahvq")
+			qt.Check(t, progress.Path.String(), qt.Equals, "linkedMap/nested/nonlink")
+			qt.Check(t, must.String(prev), qt.Equals, "zoo")
+			qt.Check(t, progress.LastBlock.Path.String(), qt.Equals, "linkedMap")
+			qt.Check(t, progress.LastBlock.Link.String(), qt.Equals, "baguqeeyezhlahvq")
 			nb := prev.Prototype().NewBuilder()
 			nb.AssignString("new string!")
 			return nb.Build(), nil
 		}, false)
-		Wish(t, err, ShouldEqual, nil)
-		Wish(t, n.Kind(), ShouldEqual, datamodel.Kind_Map)
+		qt.Check(t, err, qt.IsNil)
+		qt.Check(t, n.Kind(), qt.Equals, datamodel.Kind_Map)
 		// there should be a new object in our new storage!
-		Wish(t, len(store2.Bag), ShouldEqual, 1)
+		qt.Check(t, store2.Bag, qt.HasLen, 1)
 		// cleanup for next test
 		store2 = memstore.Store{}
 	})
@@ -346,15 +350,15 @@ func TestFocusedTransformWithLinks(t *testing.T) {
 		n, err := traversal.Progress{
 			Cfg: &cfg,
 		}.FocusedTransform(rootNode, datamodel.ParsePath("linkedMap"), func(progress traversal.Progress, prev datamodel.Node) (datamodel.Node, error) {
-			Wish(t, progress.Path.String(), ShouldEqual, "linkedMap")
+			qt.Check(t, progress.Path.String(), qt.Equals, "linkedMap")
 			nb := prev.Prototype().NewBuilder()
 			nb.AssignString("new string!")
 			return nb.Build(), nil
 		}, false)
-		Wish(t, err, ShouldEqual, nil)
-		Wish(t, n.Kind(), ShouldEqual, datamodel.Kind_Map)
+		qt.Check(t, err, qt.IsNil)
+		qt.Check(t, n.Kind(), qt.Equals, datamodel.Kind_Map)
 		// there should be no new objects in our new storage!
-		Wish(t, len(store2.Bag), ShouldEqual, 0)
+		qt.Check(t, store2.Bag, qt.HasLen, 0)
 		// cleanup for next test
 		store2 = memstore.Store{}
 	})

--- a/traversal/select_links_test.go
+++ b/traversal/select_links_test.go
@@ -3,23 +3,23 @@ package traversal_test
 import (
 	"testing"
 
-	. "github.com/warpfork/go-wish"
-
+	qt "github.com/frankban/quicktest"
 	"github.com/ipld/go-ipld-prime/datamodel"
 	"github.com/ipld/go-ipld-prime/traversal"
 )
 
 func TestSelectLinks(t *testing.T) {
+
 	t.Run("Scalar", func(t *testing.T) {
 		lnks, _ := traversal.SelectLinks(leafAlpha)
-		Wish(t, lnks, ShouldEqual, []datamodel.Link(nil))
+		qt.Check(t, lnks, deepEqualsAllowAllUnexported, []datamodel.Link(nil))
 	})
 	t.Run("DeepMap", func(t *testing.T) {
 		lnks, _ := traversal.SelectLinks(middleMapNode)
-		Wish(t, lnks, ShouldEqual, []datamodel.Link{leafAlphaLnk})
+		qt.Check(t, lnks, deepEqualsAllowAllUnexported, []datamodel.Link{leafAlphaLnk})
 	})
 	t.Run("List", func(t *testing.T) {
 		lnks, _ := traversal.SelectLinks(rootNode)
-		Wish(t, lnks, ShouldEqual, []datamodel.Link{leafAlphaLnk, middleMapNodeLnk, middleListNodeLnk})
+		qt.Check(t, lnks, deepEqualsAllowAllUnexported, []datamodel.Link{leafAlphaLnk, middleMapNodeLnk, middleListNodeLnk})
 	})
 }

--- a/traversal/selector/builder/builder_test.go
+++ b/traversal/selector/builder/builder_test.go
@@ -1,30 +1,33 @@
-package builder
+package builder_test
 
 import (
 	"testing"
 
+	qt "github.com/frankban/quicktest"
+
 	"github.com/ipld/go-ipld-prime/fluent"
 	"github.com/ipld/go-ipld-prime/node/basicnode"
+	nodetests "github.com/ipld/go-ipld-prime/node/tests"
 	"github.com/ipld/go-ipld-prime/traversal/selector"
-	. "github.com/warpfork/go-wish"
+	"github.com/ipld/go-ipld-prime/traversal/selector/builder"
 )
 
 func TestBuildingSelectors(t *testing.T) {
 	np := basicnode.Prototype.Any
-	ssb := NewSelectorSpecBuilder(np)
+	ssb := builder.NewSelectorSpecBuilder(np)
 	t.Run("Matcher builds matcher nodes", func(t *testing.T) {
 		sn := ssb.Matcher().Node()
 		esn := fluent.MustBuildMap(np, 1, func(na fluent.MapAssembler) {
 			na.AssembleEntry(selector.SelectorKey_Matcher).CreateMap(0, func(na fluent.MapAssembler) {})
 		})
-		Wish(t, sn, ShouldEqual, esn)
+		qt.Check(t, sn, nodetests.NodeContentEquals, esn)
 	})
 	t.Run("ExploreRecursiveEdge builds ExploreRecursiveEdge nodes", func(t *testing.T) {
 		sn := ssb.ExploreRecursiveEdge().Node()
 		esn := fluent.MustBuildMap(np, 1, func(na fluent.MapAssembler) {
 			na.AssembleEntry(selector.SelectorKey_ExploreRecursiveEdge).CreateMap(0, func(na fluent.MapAssembler) {})
 		})
-		Wish(t, sn, ShouldEqual, esn)
+		qt.Check(t, sn, nodetests.NodeContentEquals, esn)
 	})
 	t.Run("ExploreAll builds ExploreAll nodes", func(t *testing.T) {
 		sn := ssb.ExploreAll(ssb.Matcher()).Node()
@@ -35,7 +38,7 @@ func TestBuildingSelectors(t *testing.T) {
 				})
 			})
 		})
-		Wish(t, sn, ShouldEqual, esn)
+		qt.Check(t, sn, nodetests.NodeContentEquals, esn)
 	})
 	t.Run("ExploreIndex builds ExploreIndex nodes", func(t *testing.T) {
 		sn := ssb.ExploreIndex(2, ssb.Matcher()).Node()
@@ -47,7 +50,7 @@ func TestBuildingSelectors(t *testing.T) {
 				})
 			})
 		})
-		Wish(t, sn, ShouldEqual, esn)
+		qt.Check(t, sn, nodetests.NodeContentEquals, esn)
 	})
 	t.Run("ExploreRange builds ExploreRange nodes", func(t *testing.T) {
 		sn := ssb.ExploreRange(2, 3, ssb.Matcher()).Node()
@@ -60,7 +63,7 @@ func TestBuildingSelectors(t *testing.T) {
 				})
 			})
 		})
-		Wish(t, sn, ShouldEqual, esn)
+		qt.Check(t, sn, nodetests.NodeContentEquals, esn)
 	})
 	t.Run("ExploreRecursive builds ExploreRecursive nodes", func(t *testing.T) {
 		sn := ssb.ExploreRecursive(selector.RecursionLimitDepth(2), ssb.ExploreAll(ssb.ExploreRecursiveEdge())).Node()
@@ -78,7 +81,7 @@ func TestBuildingSelectors(t *testing.T) {
 				})
 			})
 		})
-		Wish(t, sn, ShouldEqual, esn)
+		qt.Check(t, sn, nodetests.NodeContentEquals, esn)
 		sn = ssb.ExploreRecursive(selector.RecursionLimitNone(), ssb.ExploreAll(ssb.ExploreRecursiveEdge())).Node()
 		esn = fluent.MustBuildMap(np, 1, func(na fluent.MapAssembler) {
 			na.AssembleEntry(selector.SelectorKey_ExploreRecursive).CreateMap(2, func(na fluent.MapAssembler) {
@@ -94,7 +97,7 @@ func TestBuildingSelectors(t *testing.T) {
 				})
 			})
 		})
-		Wish(t, sn, ShouldEqual, esn)
+		qt.Check(t, sn, nodetests.NodeContentEquals, esn)
 	})
 	t.Run("ExploreUnion builds ExploreUnion nodes", func(t *testing.T) {
 		sn := ssb.ExploreUnion(ssb.Matcher(), ssb.ExploreIndex(2, ssb.Matcher())).Node()
@@ -113,10 +116,10 @@ func TestBuildingSelectors(t *testing.T) {
 				})
 			})
 		})
-		Wish(t, sn, ShouldEqual, esn)
+		qt.Check(t, sn, nodetests.NodeContentEquals, esn)
 	})
 	t.Run("ExploreFields builds ExploreFields nodes", func(t *testing.T) {
-		sn := ssb.ExploreFields(func(efsb ExploreFieldsSpecBuilder) { efsb.Insert("applesauce", ssb.Matcher()) }).Node()
+		sn := ssb.ExploreFields(func(efsb builder.ExploreFieldsSpecBuilder) { efsb.Insert("applesauce", ssb.Matcher()) }).Node()
 		esn := fluent.MustBuildMap(np, 1, func(na fluent.MapAssembler) {
 			na.AssembleEntry(selector.SelectorKey_ExploreFields).CreateMap(1, func(na fluent.MapAssembler) {
 				na.AssembleEntry(selector.SelectorKey_Fields).CreateMap(1, func(na fluent.MapAssembler) {
@@ -126,6 +129,6 @@ func TestBuildingSelectors(t *testing.T) {
 				})
 			})
 		})
-		Wish(t, sn, ShouldEqual, esn)
+		qt.Check(t, sn, nodetests.NodeContentEquals, esn)
 	})
 }

--- a/traversal/selector/condition_test.go
+++ b/traversal/selector/condition_test.go
@@ -1,27 +1,30 @@
 package selector
 
 import (
-	"fmt"
+	"reflect"
 	"testing"
 
+	qt "github.com/frankban/quicktest"
+	"github.com/google/go-cmp/cmp"
 	"github.com/ipfs/go-cid"
-	. "github.com/warpfork/go-wish"
 
 	"github.com/ipld/go-ipld-prime/fluent"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/ipld/go-ipld-prime/node/basicnode"
 )
 
+var deepEqualsAllowAllUnexported = qt.CmpEquals(cmp.Exporter(func(reflect.Type) bool { return true }))
+
 func TestParseCondition(t *testing.T) {
 	t.Run("parsing non map node should error", func(t *testing.T) {
 		sn := basicnode.NewInt(0)
 		_, err := ParseContext{}.ParseCondition(sn)
-		Wish(t, err, ShouldEqual, fmt.Errorf("selector spec parse rejected: condition body must be a map"))
+		qt.Check(t, err, qt.ErrorMatches, "selector spec parse rejected: condition body must be a map")
 	})
 	t.Run("parsing map node without field should error", func(t *testing.T) {
 		sn := fluent.MustBuildMap(basicnode.Prototype.Map, 0, func(na fluent.MapAssembler) {})
 		_, err := ParseContext{}.ParseCondition(sn)
-		Wish(t, err, ShouldEqual, fmt.Errorf("selector spec parse rejected: condition is a keyed union and thus must be single-entry map"))
+		qt.Check(t, err, qt.ErrorMatches, "selector spec parse rejected: condition is a keyed union and thus must be single-entry map")
 	})
 
 	t.Run("parsing map node keyed to invalid type should error", func(t *testing.T) {
@@ -29,7 +32,7 @@ func TestParseCondition(t *testing.T) {
 			na.AssembleEntry(string(ConditionMode_Link)).AssignInt(0)
 		})
 		_, err := ParseContext{}.ParseCondition(sn)
-		Wish(t, err, ShouldEqual, fmt.Errorf("selector spec parse rejected: condition_link must be a link"))
+		qt.Check(t, err, qt.ErrorMatches, "selector spec parse rejected: condition_link must be a link")
 	})
 	t.Run("parsing map node with condition field with valid selector node should parse", func(t *testing.T) {
 		lnk := cidlink.Link{Cid: cid.Undef}
@@ -37,8 +40,8 @@ func TestParseCondition(t *testing.T) {
 			na.AssembleEntry(string(ConditionMode_Link)).AssignLink(lnk)
 		})
 		s, err := ParseContext{}.ParseCondition(sn)
-		Wish(t, err, ShouldEqual, nil)
+		qt.Check(t, err, qt.IsNil)
 		lnkNode := basicnode.NewLink(lnk)
-		Wish(t, s, ShouldEqual, Condition{mode: ConditionMode_Link, match: lnkNode})
+		qt.Check(t, s, deepEqualsAllowAllUnexported, Condition{mode: ConditionMode_Link, match: lnkNode})
 	})
 }

--- a/traversal/selector/exploreAll_test.go
+++ b/traversal/selector/exploreAll_test.go
@@ -1,10 +1,9 @@
 package selector
 
 import (
-	"fmt"
 	"testing"
 
-	. "github.com/warpfork/go-wish"
+	qt "github.com/frankban/quicktest"
 
 	"github.com/ipld/go-ipld-prime/fluent"
 	"github.com/ipld/go-ipld-prime/node/basicnode"
@@ -14,12 +13,12 @@ func TestParseExploreAll(t *testing.T) {
 	t.Run("parsing non map node should error", func(t *testing.T) {
 		sn := basicnode.NewInt(0)
 		_, err := ParseContext{}.ParseExploreAll(sn)
-		Wish(t, err, ShouldEqual, fmt.Errorf("selector spec parse rejected: selector body must be a map"))
+		qt.Check(t, err, qt.ErrorMatches, "selector spec parse rejected: selector body must be a map")
 	})
 	t.Run("parsing map node without next field should error", func(t *testing.T) {
 		sn := fluent.MustBuildMap(basicnode.Prototype.Map, 0, func(na fluent.MapAssembler) {})
 		_, err := ParseContext{}.ParseExploreAll(sn)
-		Wish(t, err, ShouldEqual, fmt.Errorf("selector spec parse rejected: next field must be present in ExploreAll selector"))
+		qt.Check(t, err, qt.ErrorMatches, "selector spec parse rejected: next field must be present in ExploreAll selector")
 	})
 
 	t.Run("parsing map node without next field with invalid selector node should return child's error", func(t *testing.T) {
@@ -27,7 +26,7 @@ func TestParseExploreAll(t *testing.T) {
 			na.AssembleEntry(SelectorKey_Next).AssignInt(0)
 		})
 		_, err := ParseContext{}.ParseExploreAll(sn)
-		Wish(t, err, ShouldEqual, fmt.Errorf("selector spec parse rejected: selector is a keyed union and thus must be a map"))
+		qt.Check(t, err, qt.ErrorMatches, "selector spec parse rejected: selector is a keyed union and thus must be a map")
 	})
 	t.Run("parsing map node with next field with valid selector node should parse", func(t *testing.T) {
 		sn := fluent.MustBuildMap(basicnode.Prototype.Map, 1, func(na fluent.MapAssembler) {
@@ -36,7 +35,7 @@ func TestParseExploreAll(t *testing.T) {
 			})
 		})
 		s, err := ParseContext{}.ParseExploreAll(sn)
-		Wish(t, err, ShouldEqual, nil)
-		Wish(t, s, ShouldEqual, ExploreAll{Matcher{}})
+		qt.Check(t, err, qt.IsNil)
+		qt.Check(t, s, qt.Equals, ExploreAll{Matcher{}})
 	})
 }

--- a/traversal/selector/exploreFields_test.go
+++ b/traversal/selector/exploreFields_test.go
@@ -1,10 +1,9 @@
 package selector
 
 import (
-	"fmt"
 	"testing"
 
-	. "github.com/warpfork/go-wish"
+	qt "github.com/frankban/quicktest"
 
 	"github.com/ipld/go-ipld-prime/datamodel"
 	"github.com/ipld/go-ipld-prime/fluent"
@@ -15,19 +14,19 @@ func TestParseExploreFields(t *testing.T) {
 	t.Run("parsing non map node should error", func(t *testing.T) {
 		sn := basicnode.NewInt(0)
 		_, err := ParseContext{}.ParseExploreFields(sn)
-		Wish(t, err, ShouldEqual, fmt.Errorf("selector spec parse rejected: selector body must be a map"))
+		qt.Check(t, err, qt.ErrorMatches, "selector spec parse rejected: selector body must be a map")
 	})
 	t.Run("parsing map node without fields value should error", func(t *testing.T) {
 		sn := fluent.MustBuildMap(basicnode.Prototype.Map, 0, func(na fluent.MapAssembler) {})
 		_, err := ParseContext{}.ParseExploreFields(sn)
-		Wish(t, err, ShouldEqual, fmt.Errorf("selector spec parse rejected: fields in ExploreFields selector must be present"))
+		qt.Check(t, err, qt.ErrorMatches, "selector spec parse rejected: fields in ExploreFields selector must be present")
 	})
 	t.Run("parsing map node with fields value that is not a map should error", func(t *testing.T) {
 		sn := fluent.MustBuildMap(basicnode.Prototype.Map, 1, func(na fluent.MapAssembler) {
 			na.AssembleEntry(SelectorKey_Fields).AssignString("cheese")
 		})
 		_, err := ParseContext{}.ParseExploreFields(sn)
-		Wish(t, err, ShouldEqual, fmt.Errorf("selector spec parse rejected: fields in ExploreFields selector must be a map"))
+		qt.Check(t, err, qt.ErrorMatches, "selector spec parse rejected: fields in ExploreFields selector must be a map")
 	})
 	t.Run("parsing map node with selector node in fields that is invalid should return child's error", func(t *testing.T) {
 		sn := fluent.MustBuildMap(basicnode.Prototype.Map, 1, func(na fluent.MapAssembler) {
@@ -36,7 +35,7 @@ func TestParseExploreFields(t *testing.T) {
 			})
 		})
 		_, err := ParseContext{}.ParseExploreFields(sn)
-		Wish(t, err, ShouldEqual, fmt.Errorf("selector spec parse rejected: selector is a keyed union and thus must be a map"))
+		qt.Check(t, err, qt.ErrorMatches, "selector spec parse rejected: selector is a keyed union and thus must be a map")
 	})
 	t.Run("parsing map node with fields value that is map of only valid selector node should parse", func(t *testing.T) {
 		sn := fluent.MustBuildMap(basicnode.Prototype.Map, 1, func(na fluent.MapAssembler) {
@@ -47,7 +46,7 @@ func TestParseExploreFields(t *testing.T) {
 			})
 		})
 		s, err := ParseContext{}.ParseExploreFields(sn)
-		Wish(t, err, ShouldEqual, nil)
-		Wish(t, s, ShouldEqual, ExploreFields{map[string]Selector{"applesauce": Matcher{}}, []datamodel.PathSegment{datamodel.PathSegmentOfString("applesauce")}})
+		qt.Check(t, err, qt.IsNil)
+		qt.Check(t, s, deepEqualsAllowAllUnexported, ExploreFields{map[string]Selector{"applesauce": Matcher{}}, []datamodel.PathSegment{datamodel.PathSegmentOfString("applesauce")}})
 	})
 }

--- a/traversal/selector/exploreIndex_test.go
+++ b/traversal/selector/exploreIndex_test.go
@@ -1,10 +1,9 @@
 package selector
 
 import (
-	"fmt"
 	"testing"
 
-	. "github.com/warpfork/go-wish"
+	qt "github.com/frankban/quicktest"
 
 	"github.com/ipld/go-ipld-prime/datamodel"
 	"github.com/ipld/go-ipld-prime/fluent"
@@ -15,14 +14,14 @@ func TestParseExploreIndex(t *testing.T) {
 	t.Run("parsing non map node should error", func(t *testing.T) {
 		sn := basicnode.NewInt(0)
 		_, err := ParseContext{}.ParseExploreIndex(sn)
-		Wish(t, err, ShouldEqual, fmt.Errorf("selector spec parse rejected: selector body must be a map"))
+		qt.Check(t, err, qt.ErrorMatches, "selector spec parse rejected: selector body must be a map")
 	})
 	t.Run("parsing map node without next field should error", func(t *testing.T) {
 		sn := fluent.MustBuildMap(basicnode.Prototype__Map{}, 1, func(na fluent.MapAssembler) {
 			na.AssembleEntry(SelectorKey_Index).AssignInt(2)
 		})
 		_, err := ParseContext{}.ParseExploreIndex(sn)
-		Wish(t, err, ShouldEqual, fmt.Errorf("selector spec parse rejected: next field must be present in ExploreIndex selector"))
+		qt.Check(t, err, qt.ErrorMatches, "selector spec parse rejected: next field must be present in ExploreIndex selector")
 	})
 	t.Run("parsing map node without index field should error", func(t *testing.T) {
 		sn := fluent.MustBuildMap(basicnode.Prototype__Map{}, 1, func(na fluent.MapAssembler) {
@@ -31,7 +30,7 @@ func TestParseExploreIndex(t *testing.T) {
 			})
 		})
 		_, err := ParseContext{}.ParseExploreIndex(sn)
-		Wish(t, err, ShouldEqual, fmt.Errorf("selector spec parse rejected: index field must be present in ExploreIndex selector"))
+		qt.Check(t, err, qt.ErrorMatches, "selector spec parse rejected: index field must be present in ExploreIndex selector")
 	})
 	t.Run("parsing map node with index field that is not an int should error", func(t *testing.T) {
 		sn := fluent.MustBuildMap(basicnode.Prototype__Map{}, 2, func(na fluent.MapAssembler) {
@@ -41,7 +40,7 @@ func TestParseExploreIndex(t *testing.T) {
 			})
 		})
 		_, err := ParseContext{}.ParseExploreIndex(sn)
-		Wish(t, err, ShouldEqual, fmt.Errorf("selector spec parse rejected: index field must be a number in ExploreIndex selector"))
+		qt.Check(t, err, qt.ErrorMatches, "selector spec parse rejected: index field must be a number in ExploreIndex selector")
 	})
 	t.Run("parsing map node with next field with invalid selector node should return child's error", func(t *testing.T) {
 		sn := fluent.MustBuildMap(basicnode.Prototype__Map{}, 2, func(na fluent.MapAssembler) {
@@ -49,7 +48,7 @@ func TestParseExploreIndex(t *testing.T) {
 			na.AssembleEntry(SelectorKey_Next).AssignInt(0)
 		})
 		_, err := ParseContext{}.ParseExploreIndex(sn)
-		Wish(t, err, ShouldEqual, fmt.Errorf("selector spec parse rejected: selector is a keyed union and thus must be a map"))
+		qt.Check(t, err, qt.ErrorMatches, "selector spec parse rejected: selector is a keyed union and thus must be a map")
 	})
 	t.Run("parsing map node with next field with valid selector node should parse", func(t *testing.T) {
 		sn := fluent.MustBuildMap(basicnode.Prototype__Map{}, 2, func(na fluent.MapAssembler) {
@@ -59,8 +58,8 @@ func TestParseExploreIndex(t *testing.T) {
 			})
 		})
 		s, err := ParseContext{}.ParseExploreIndex(sn)
-		Wish(t, err, ShouldEqual, nil)
-		Wish(t, s, ShouldEqual, ExploreIndex{Matcher{}, [1]datamodel.PathSegment{datamodel.PathSegmentOfInt(2)}})
+		qt.Check(t, err, qt.IsNil)
+		qt.Check(t, s, qt.Equals, ExploreIndex{Matcher{}, [1]datamodel.PathSegment{datamodel.PathSegmentOfInt(2)}})
 	})
 }
 
@@ -69,7 +68,7 @@ func TestExploreIndexExplore(t *testing.T) {
 	t.Run("exploring should return nil unless node is a list", func(t *testing.T) {
 		n := fluent.MustBuildMap(basicnode.Prototype__Map{}, 0, func(na fluent.MapAssembler) {})
 		returnedSelector, _ := s.Explore(n, datamodel.PathSegmentOfInt(3))
-		Wish(t, returnedSelector, ShouldEqual, nil)
+		qt.Check(t, returnedSelector, qt.IsNil)
 	})
 	n := fluent.MustBuildList(basicnode.Prototype__List{}, 4, func(na fluent.ListAssembler) {
 		na.AssembleValue().AssignInt(0)
@@ -79,14 +78,14 @@ func TestExploreIndexExplore(t *testing.T) {
 	})
 	t.Run("exploring should return nil when given a path segment with a different index", func(t *testing.T) {
 		returnedSelector, _ := s.Explore(n, datamodel.PathSegmentOfInt(2))
-		Wish(t, returnedSelector, ShouldEqual, nil)
+		qt.Check(t, returnedSelector, qt.IsNil)
 	})
 	t.Run("exploring should return nil when given a path segment that isn't an index", func(t *testing.T) {
 		returnedSelector, _ := s.Explore(n, datamodel.PathSegmentOfString("cheese"))
-		Wish(t, returnedSelector, ShouldEqual, nil)
+		qt.Check(t, returnedSelector, qt.IsNil)
 	})
 	t.Run("exploring should return the next selector when given a path segment with the right index", func(t *testing.T) {
 		returnedSelector, _ := s.Explore(n, datamodel.PathSegmentOfInt(3))
-		Wish(t, returnedSelector, ShouldEqual, Matcher{})
+		qt.Check(t, returnedSelector, qt.Equals, Matcher{})
 	})
 }

--- a/traversal/selector/exploreRange_test.go
+++ b/traversal/selector/exploreRange_test.go
@@ -1,10 +1,9 @@
 package selector
 
 import (
-	"fmt"
 	"testing"
 
-	. "github.com/warpfork/go-wish"
+	qt "github.com/frankban/quicktest"
 
 	"github.com/ipld/go-ipld-prime/datamodel"
 	"github.com/ipld/go-ipld-prime/fluent"
@@ -15,7 +14,7 @@ func TestParseExploreRange(t *testing.T) {
 	t.Run("parsing non map node should error", func(t *testing.T) {
 		sn := basicnode.NewInt(0)
 		_, err := ParseContext{}.ParseExploreRange(sn)
-		Wish(t, err, ShouldEqual, fmt.Errorf("selector spec parse rejected: selector body must be a map"))
+		qt.Check(t, err, qt.ErrorMatches, "selector spec parse rejected: selector body must be a map")
 	})
 	t.Run("parsing map node without next field should error", func(t *testing.T) {
 		sn := fluent.MustBuildMap(basicnode.Prototype__Map{}, 2, func(na fluent.MapAssembler) {
@@ -23,7 +22,7 @@ func TestParseExploreRange(t *testing.T) {
 			na.AssembleEntry(SelectorKey_End).AssignInt(3)
 		})
 		_, err := ParseContext{}.ParseExploreRange(sn)
-		Wish(t, err, ShouldEqual, fmt.Errorf("selector spec parse rejected: next field must be present in ExploreRange selector"))
+		qt.Check(t, err, qt.ErrorMatches, "selector spec parse rejected: next field must be present in ExploreRange selector")
 	})
 	t.Run("parsing map node without start field should error", func(t *testing.T) {
 		sn := fluent.MustBuildMap(basicnode.Prototype__Map{}, 2, func(na fluent.MapAssembler) {
@@ -33,7 +32,7 @@ func TestParseExploreRange(t *testing.T) {
 			})
 		})
 		_, err := ParseContext{}.ParseExploreRange(sn)
-		Wish(t, err, ShouldEqual, fmt.Errorf("selector spec parse rejected: start field must be present in ExploreRange selector"))
+		qt.Check(t, err, qt.ErrorMatches, "selector spec parse rejected: start field must be present in ExploreRange selector")
 	})
 	t.Run("parsing map node with start field that is not an int should error", func(t *testing.T) {
 		sn := fluent.MustBuildMap(basicnode.Prototype__Map{}, 3, func(na fluent.MapAssembler) {
@@ -44,7 +43,7 @@ func TestParseExploreRange(t *testing.T) {
 			})
 		})
 		_, err := ParseContext{}.ParseExploreRange(sn)
-		Wish(t, err, ShouldEqual, fmt.Errorf("selector spec parse rejected: start field must be a number in ExploreRange selector"))
+		qt.Check(t, err, qt.ErrorMatches, "selector spec parse rejected: start field must be a number in ExploreRange selector")
 	})
 	t.Run("parsing map node without end field should error", func(t *testing.T) {
 		sn := fluent.MustBuildMap(basicnode.Prototype__Map{}, 2, func(na fluent.MapAssembler) {
@@ -54,7 +53,7 @@ func TestParseExploreRange(t *testing.T) {
 			})
 		})
 		_, err := ParseContext{}.ParseExploreRange(sn)
-		Wish(t, err, ShouldEqual, fmt.Errorf("selector spec parse rejected: end field must be present in ExploreRange selector"))
+		qt.Check(t, err, qt.ErrorMatches, "selector spec parse rejected: end field must be present in ExploreRange selector")
 	})
 	t.Run("parsing map node with end field that is not an int should error", func(t *testing.T) {
 		sn := fluent.MustBuildMap(basicnode.Prototype__Map{}, 3, func(na fluent.MapAssembler) {
@@ -65,7 +64,7 @@ func TestParseExploreRange(t *testing.T) {
 			})
 		})
 		_, err := ParseContext{}.ParseExploreRange(sn)
-		Wish(t, err, ShouldEqual, fmt.Errorf("selector spec parse rejected: end field must be a number in ExploreRange selector"))
+		qt.Check(t, err, qt.ErrorMatches, "selector spec parse rejected: end field must be a number in ExploreRange selector")
 	})
 	t.Run("parsing map node where end is not greater than start should error", func(t *testing.T) {
 		sn := fluent.MustBuildMap(basicnode.Prototype__Map{}, 3, func(na fluent.MapAssembler) {
@@ -76,7 +75,7 @@ func TestParseExploreRange(t *testing.T) {
 			})
 		})
 		_, err := ParseContext{}.ParseExploreRange(sn)
-		Wish(t, err, ShouldEqual, fmt.Errorf("selector spec parse rejected: end field must be greater than start field in ExploreRange selector"))
+		qt.Check(t, err, qt.ErrorMatches, "selector spec parse rejected: end field must be greater than start field in ExploreRange selector")
 	})
 	t.Run("parsing map node with next field with invalid selector node should return child's error", func(t *testing.T) {
 		sn := fluent.MustBuildMap(basicnode.Prototype__Map{}, 3, func(na fluent.MapAssembler) {
@@ -85,7 +84,7 @@ func TestParseExploreRange(t *testing.T) {
 			na.AssembleEntry(SelectorKey_Next).AssignInt(0)
 		})
 		_, err := ParseContext{}.ParseExploreRange(sn)
-		Wish(t, err, ShouldEqual, fmt.Errorf("selector spec parse rejected: selector is a keyed union and thus must be a map"))
+		qt.Check(t, err, qt.ErrorMatches, "selector spec parse rejected: selector is a keyed union and thus must be a map")
 	})
 
 	t.Run("parsing map node with next field with valid selector node should parse", func(t *testing.T) {
@@ -97,8 +96,8 @@ func TestParseExploreRange(t *testing.T) {
 			})
 		})
 		s, err := ParseContext{}.ParseExploreRange(sn)
-		Wish(t, err, ShouldEqual, nil)
-		Wish(t, s, ShouldEqual, ExploreRange{Matcher{}, 2, 3, []datamodel.PathSegment{datamodel.PathSegmentOfInt(2)}})
+		qt.Check(t, err, qt.IsNil)
+		qt.Check(t, s, deepEqualsAllowAllUnexported, ExploreRange{Matcher{}, 2, 3, []datamodel.PathSegment{datamodel.PathSegmentOfInt(2)}})
 	})
 }
 
@@ -107,7 +106,7 @@ func TestExploreRangeExplore(t *testing.T) {
 	t.Run("exploring should return nil unless node is a list", func(t *testing.T) {
 		n := fluent.MustBuildMap(basicnode.Prototype__Map{}, 0, func(na fluent.MapAssembler) {})
 		returnedSelector, _ := s.Explore(n, datamodel.PathSegmentOfInt(3))
-		Wish(t, returnedSelector, ShouldEqual, nil)
+		qt.Check(t, returnedSelector, qt.IsNil)
 	})
 	n := fluent.MustBuildList(basicnode.Prototype__List{}, 4, func(na fluent.ListAssembler) {
 		na.AssembleValue().AssignInt(0)
@@ -117,14 +116,14 @@ func TestExploreRangeExplore(t *testing.T) {
 	})
 	t.Run("exploring should return nil when given a path segment out of range", func(t *testing.T) {
 		returnedSelector, _ := s.Explore(n, datamodel.PathSegmentOfInt(2))
-		Wish(t, returnedSelector, ShouldEqual, nil)
+		qt.Check(t, returnedSelector, qt.IsNil)
 	})
 	t.Run("exploring should return nil when given a path segment that isn't an index", func(t *testing.T) {
 		returnedSelector, _ := s.Explore(n, datamodel.PathSegmentOfString("cheese"))
-		Wish(t, returnedSelector, ShouldEqual, nil)
+		qt.Check(t, returnedSelector, qt.IsNil)
 	})
 	t.Run("exploring should return the next selector when given a path segment with index in range", func(t *testing.T) {
 		returnedSelector, _ := s.Explore(n, datamodel.PathSegmentOfInt(3))
-		Wish(t, returnedSelector, ShouldEqual, Matcher{})
+		qt.Check(t, returnedSelector, qt.Equals, Matcher{})
 	})
 }

--- a/traversal/selector/exploreRecursive_test.go
+++ b/traversal/selector/exploreRecursive_test.go
@@ -1,11 +1,10 @@
 package selector
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
-	. "github.com/warpfork/go-wish"
+	qt "github.com/frankban/quicktest"
 
 	"github.com/ipld/go-ipld-prime/codec/dagjson"
 	"github.com/ipld/go-ipld-prime/datamodel"
@@ -17,7 +16,7 @@ func TestParseExploreRecursive(t *testing.T) {
 	t.Run("parsing non map node should error", func(t *testing.T) {
 		sn := basicnode.NewInt(0)
 		_, err := ParseContext{}.ParseExploreRecursive(sn)
-		Wish(t, err, ShouldEqual, fmt.Errorf("selector spec parse rejected: selector body must be a map"))
+		qt.Check(t, err, qt.ErrorMatches, "selector spec parse rejected: selector body must be a map")
 	})
 	t.Run("parsing map node without sequence field should error", func(t *testing.T) {
 		sn := fluent.MustBuildMap(basicnode.Prototype__Map{}, 1, func(na fluent.MapAssembler) {
@@ -26,7 +25,7 @@ func TestParseExploreRecursive(t *testing.T) {
 			})
 		})
 		_, err := ParseContext{}.ParseExploreRecursive(sn)
-		Wish(t, err, ShouldEqual, fmt.Errorf("selector spec parse rejected: sequence field must be present in ExploreRecursive selector"))
+		qt.Check(t, err, qt.ErrorMatches, "selector spec parse rejected: sequence field must be present in ExploreRecursive selector")
 	})
 	t.Run("parsing map node without limit field should error", func(t *testing.T) {
 		sn := fluent.MustBuildMap(basicnode.Prototype__Map{}, 1, func(na fluent.MapAssembler) {
@@ -35,7 +34,7 @@ func TestParseExploreRecursive(t *testing.T) {
 			})
 		})
 		_, err := ParseContext{}.ParseExploreRecursive(sn)
-		Wish(t, err, ShouldEqual, fmt.Errorf("selector spec parse rejected: limit field must be present in ExploreRecursive selector"))
+		qt.Check(t, err, qt.ErrorMatches, "selector spec parse rejected: limit field must be present in ExploreRecursive selector")
 	})
 	t.Run("parsing map node with limit field that is not a map should fail", func(t *testing.T) {
 		sn := fluent.MustBuildMap(basicnode.Prototype__Map{}, 2, func(na fluent.MapAssembler) {
@@ -45,7 +44,7 @@ func TestParseExploreRecursive(t *testing.T) {
 			})
 		})
 		_, err := ParseContext{}.ParseExploreRecursive(sn)
-		Wish(t, err, ShouldEqual, fmt.Errorf("selector spec parse rejected: limit in ExploreRecursive is a keyed union and thus must be a map"))
+		qt.Check(t, err, qt.ErrorMatches, "selector spec parse rejected: limit in ExploreRecursive is a keyed union and thus must be a map")
 	})
 	t.Run("parsing map node with limit field that is not a single entry map should fail", func(t *testing.T) {
 		sn := fluent.MustBuildMap(basicnode.Prototype__Map{}, 2, func(na fluent.MapAssembler) {
@@ -58,7 +57,7 @@ func TestParseExploreRecursive(t *testing.T) {
 			})
 		})
 		_, err := ParseContext{}.ParseExploreRecursive(sn)
-		Wish(t, err, ShouldEqual, fmt.Errorf("selector spec parse rejected: limit in ExploreRecursive is a keyed union and thus must be a single-entry map"))
+		qt.Check(t, err, qt.ErrorMatches, "selector spec parse rejected: limit in ExploreRecursive is a keyed union and thus must be a single-entry map")
 	})
 	t.Run("parsing map node with limit field that does not have a known key should fail", func(t *testing.T) {
 		sn := fluent.MustBuildMap(basicnode.Prototype__Map{}, 2, func(na fluent.MapAssembler) {
@@ -70,7 +69,7 @@ func TestParseExploreRecursive(t *testing.T) {
 			})
 		})
 		_, err := ParseContext{}.ParseExploreRecursive(sn)
-		Wish(t, err, ShouldEqual, fmt.Errorf("selector spec parse rejected: \"applesauce\" is not a known member of the limit union in ExploreRecursive"))
+		qt.Check(t, err, qt.ErrorMatches, "selector spec parse rejected: \"applesauce\" is not a known member of the limit union in ExploreRecursive")
 	})
 	t.Run("parsing map node with limit field of type depth that is not an int should error", func(t *testing.T) {
 		sn := fluent.MustBuildMap(basicnode.Prototype__Map{}, 2, func(na fluent.MapAssembler) {
@@ -82,7 +81,7 @@ func TestParseExploreRecursive(t *testing.T) {
 			})
 		})
 		_, err := ParseContext{}.ParseExploreRecursive(sn)
-		Wish(t, err, ShouldEqual, fmt.Errorf("selector spec parse rejected: limit field of type depth must be a number in ExploreRecursive selector"))
+		qt.Check(t, err, qt.ErrorMatches, "selector spec parse rejected: limit field of type depth must be a number in ExploreRecursive selector")
 	})
 	t.Run("parsing map node with sequence field with invalid selector node should return child's error", func(t *testing.T) {
 		sn := fluent.MustBuildMap(basicnode.Prototype__Map{}, 2, func(na fluent.MapAssembler) {
@@ -92,7 +91,7 @@ func TestParseExploreRecursive(t *testing.T) {
 			na.AssembleEntry(SelectorKey_Sequence).AssignInt(0)
 		})
 		_, err := ParseContext{}.ParseExploreRecursive(sn)
-		Wish(t, err, ShouldEqual, fmt.Errorf("selector spec parse rejected: selector is a keyed union and thus must be a map"))
+		qt.Check(t, err, qt.ErrorMatches, "selector spec parse rejected: selector is a keyed union and thus must be a map")
 	})
 	t.Run("parsing map node with sequence field with valid selector w/o ExploreRecursiveEdge should not parse", func(t *testing.T) {
 		sn := fluent.MustBuildMap(basicnode.Prototype__Map{}, 2, func(na fluent.MapAssembler) {
@@ -108,12 +107,12 @@ func TestParseExploreRecursive(t *testing.T) {
 			})
 		})
 		_, err := ParseContext{}.ParseExploreRecursive(sn)
-		Wish(t, err, ShouldEqual, fmt.Errorf("selector spec parse rejected: ExploreRecursive must have at least one ExploreRecursiveEdge"))
+		qt.Check(t, err, qt.ErrorMatches, "selector spec parse rejected: ExploreRecursive must have at least one ExploreRecursiveEdge")
 	})
 	t.Run("parsing map node that is ExploreRecursiveEdge without ExploreRecursive parent should not parse", func(t *testing.T) {
 		sn := fluent.MustBuildMap(basicnode.Prototype__Map{}, 0, func(na fluent.MapAssembler) {})
 		_, err := ParseContext{}.ParseExploreRecursiveEdge(sn)
-		Wish(t, err, ShouldEqual, fmt.Errorf("selector spec parse rejected: ExploreRecursiveEdge must be beneath ExploreRecursive"))
+		qt.Check(t, err, qt.ErrorMatches, "selector spec parse rejected: ExploreRecursiveEdge must be beneath ExploreRecursive")
 	})
 	t.Run("parsing map node with sequence field with valid selector node should parse", func(t *testing.T) {
 		sn := fluent.MustBuildMap(basicnode.Prototype__Map{}, 2, func(na fluent.MapAssembler) {
@@ -129,8 +128,8 @@ func TestParseExploreRecursive(t *testing.T) {
 			})
 		})
 		s, err := ParseContext{}.ParseExploreRecursive(sn)
-		Wish(t, err, ShouldEqual, nil)
-		Wish(t, s, ShouldEqual, ExploreRecursive{ExploreAll{ExploreRecursiveEdge{}}, ExploreAll{ExploreRecursiveEdge{}}, RecursionLimit{RecursionLimit_Depth, 2}, nil})
+		qt.Check(t, err, qt.IsNil)
+		qt.Check(t, s, qt.Equals, ExploreRecursive{ExploreAll{ExploreRecursiveEdge{}}, ExploreAll{ExploreRecursiveEdge{}}, RecursionLimit{RecursionLimit_Depth, 2}, nil})
 	})
 
 	t.Run("parsing map node with sequence field with valid selector node and limit type none should parse", func(t *testing.T) {
@@ -147,8 +146,8 @@ func TestParseExploreRecursive(t *testing.T) {
 			})
 		})
 		s, err := ParseContext{}.ParseExploreRecursive(sn)
-		Wish(t, err, ShouldEqual, nil)
-		Wish(t, s, ShouldEqual, ExploreRecursive{ExploreAll{ExploreRecursiveEdge{}}, ExploreAll{ExploreRecursiveEdge{}}, RecursionLimit{RecursionLimit_None, 0}, nil})
+		qt.Check(t, err, qt.IsNil)
+		qt.Check(t, s, qt.Equals, ExploreRecursive{ExploreAll{ExploreRecursiveEdge{}}, ExploreAll{ExploreRecursiveEdge{}}, RecursionLimit{RecursionLimit_None, 0}, nil})
 	})
 
 }
@@ -200,33 +199,33 @@ func TestExploreRecursiveExplore(t *testing.T) {
 		`
 		nb := basicnode.Prototype__Any{}.NewBuilder()
 		err := dagjson.Decode(nb, strings.NewReader(nodeString))
-		Wish(t, err, ShouldEqual, nil)
+		qt.Check(t, err, qt.IsNil)
 		rn := nb.Build()
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupByString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil})
-		Wish(t, err, ShouldEqual, nil)
+		qt.Check(t, rs, deepEqualsAllowAllUnexported, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil})
+		qt.Check(t, err, qt.IsNil)
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfInt(0))
 		rn, err = rn.LookupByIndex(0)
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil})
-		Wish(t, err, ShouldEqual, nil)
+		qt.Check(t, rs, deepEqualsAllowAllUnexported, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil})
+		qt.Check(t, err, qt.IsNil)
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfString("Parents"))
 
 		rn, err = rn.LookupByString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil})
-		Wish(t, err, ShouldEqual, nil)
+		qt.Check(t, rs, deepEqualsAllowAllUnexported, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil})
+		qt.Check(t, err, qt.IsNil)
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfInt(0))
 		rn, err = rn.LookupByIndex(0)
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_Depth, maxDepth - 2}, nil})
-		Wish(t, err, ShouldEqual, nil)
+		qt.Check(t, rs, deepEqualsAllowAllUnexported, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_Depth, maxDepth - 2}, nil})
+		qt.Check(t, err, qt.IsNil)
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupByString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 2}, nil})
-		Wish(t, err, ShouldEqual, nil)
+		qt.Check(t, rs, deepEqualsAllowAllUnexported, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 2}, nil})
+		qt.Check(t, err, qt.IsNil)
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfInt(0))
 		rn, err = rn.LookupByIndex(0)
-		Wish(t, rs, ShouldEqual, nil)
-		Wish(t, err, ShouldEqual, nil)
+		qt.Check(t, rs, qt.IsNil)
+		qt.Check(t, err, qt.IsNil)
 	})
 
 	t.Run("exploring should traverse indefinitely if no depth specified", func(t *testing.T) {
@@ -251,36 +250,36 @@ func TestExploreRecursiveExplore(t *testing.T) {
 		`
 		nb := basicnode.Prototype__Any{}.NewBuilder()
 		err := dagjson.Decode(nb, strings.NewReader(nodeString))
-		Wish(t, err, ShouldEqual, nil)
+		qt.Check(t, err, qt.IsNil)
 		rn := nb.Build()
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupByString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_None, 0}, nil})
-		Wish(t, err, ShouldEqual, nil)
+		qt.Check(t, rs, deepEqualsAllowAllUnexported, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_None, 0}, nil})
+		qt.Check(t, err, qt.IsNil)
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfInt(0))
 		rn, err = rn.LookupByIndex(0)
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_None, 0}, nil})
-		Wish(t, err, ShouldEqual, nil)
+		qt.Check(t, rs, deepEqualsAllowAllUnexported, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_None, 0}, nil})
+		qt.Check(t, err, qt.IsNil)
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupByString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_None, 0}, nil})
-		Wish(t, err, ShouldEqual, nil)
+		qt.Check(t, rs, deepEqualsAllowAllUnexported, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_None, 0}, nil})
+		qt.Check(t, err, qt.IsNil)
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfInt(0))
 		rn, err = rn.LookupByIndex(0)
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_None, 0}, nil})
-		Wish(t, err, ShouldEqual, nil)
+		qt.Check(t, rs, deepEqualsAllowAllUnexported, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_None, 0}, nil})
+		qt.Check(t, err, qt.IsNil)
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupByString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_None, 0}, nil})
-		Wish(t, err, ShouldEqual, nil)
+		qt.Check(t, rs, deepEqualsAllowAllUnexported, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_None, 0}, nil})
+		qt.Check(t, err, qt.IsNil)
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfInt(0))
 		rn, err = rn.LookupByIndex(0)
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_None, 0}, nil})
-		Wish(t, err, ShouldEqual, nil)
+		qt.Check(t, rs, deepEqualsAllowAllUnexported, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_None, 0}, nil})
+		qt.Check(t, err, qt.IsNil)
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupByString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_None, 0}, nil})
-		Wish(t, err, ShouldEqual, nil)
+		qt.Check(t, rs, deepEqualsAllowAllUnexported, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_None, 0}, nil})
+		qt.Check(t, err, qt.IsNil)
 	})
 
 	t.Run("exploring should continue till we get to selector that returns nil on explore", func(t *testing.T) {
@@ -294,14 +293,14 @@ func TestExploreRecursiveExplore(t *testing.T) {
 		`
 		nb := basicnode.Prototype__Any{}.NewBuilder()
 		err := dagjson.Decode(nb, strings.NewReader(nodeString))
-		Wish(t, err, ShouldEqual, nil)
+		qt.Check(t, err, qt.IsNil)
 		rn := nb.Build()
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupByString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil})
-		Wish(t, err, ShouldEqual, nil)
+		qt.Check(t, rs, deepEqualsAllowAllUnexported, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil})
+		qt.Check(t, err, qt.IsNil)
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfInt(0))
-		Wish(t, rs, ShouldEqual, nil)
+		qt.Check(t, rs, qt.IsNil)
 	})
 	t.Run("exploring should work when there is nested recursion", func(t *testing.T) {
 		parentsSelector := ExploreAll{recursiveEdge}
@@ -339,7 +338,7 @@ func TestExploreRecursiveExplore(t *testing.T) {
 		`
 		nb := basicnode.Prototype__Any{}.NewBuilder()
 		err := dagjson.Decode(nb, strings.NewReader(nodeString))
-		Wish(t, err, ShouldEqual, nil)
+		qt.Check(t, err, qt.IsNil)
 		n := nb.Build()
 
 		// traverse down Parent nodes
@@ -347,60 +346,60 @@ func TestExploreRecursiveExplore(t *testing.T) {
 		rs = s
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupByString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil})
-		Wish(t, err, ShouldEqual, nil)
+		qt.Check(t, rs, deepEqualsAllowAllUnexported, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil})
+		qt.Check(t, err, qt.IsNil)
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfInt(0))
 		rn, err = rn.LookupByIndex(0)
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil})
-		Wish(t, err, ShouldEqual, nil)
+		qt.Check(t, rs, deepEqualsAllowAllUnexported, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil})
+		qt.Check(t, err, qt.IsNil)
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupByString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil})
-		Wish(t, err, ShouldEqual, nil)
+		qt.Check(t, rs, deepEqualsAllowAllUnexported, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil})
+		qt.Check(t, err, qt.IsNil)
 
 		// traverse down top level Side tree (nested recursion)
 		rn = n
 		rs = s
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfString("Side"))
 		rn, err = rn.LookupByString("Side")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil}, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil})
-		Wish(t, err, ShouldEqual, nil)
+		qt.Check(t, rs, deepEqualsAllowAllUnexported, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil}, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil})
+		qt.Check(t, err, qt.IsNil)
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfString("real"))
 		rn, err = rn.LookupByString("real")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil}, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil})
-		Wish(t, err, ShouldEqual, nil)
+		qt.Check(t, rs, deepEqualsAllowAllUnexported, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil}, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil})
+		qt.Check(t, err, qt.IsNil)
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfString("apple"))
 		rn, err = rn.LookupByString("apple")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 2}, nil}, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil})
-		Wish(t, err, ShouldEqual, nil)
+		qt.Check(t, rs, deepEqualsAllowAllUnexported, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 2}, nil}, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil})
+		qt.Check(t, err, qt.IsNil)
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfString("sauce"))
 		rn, err = rn.LookupByString("sauce")
-		Wish(t, rs, ShouldEqual, nil)
-		Wish(t, err, ShouldEqual, nil)
+		qt.Check(t, rs, qt.IsNil)
+		qt.Check(t, err, qt.IsNil)
 
 		// traverse once down Parent (top level recursion) then down Side tree (nested recursion)
 		rn = n
 		rs = s
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupByString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil})
-		Wish(t, err, ShouldEqual, nil)
+		qt.Check(t, rs, deepEqualsAllowAllUnexported, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil})
+		qt.Check(t, err, qt.IsNil)
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfInt(0))
 		rn, err = rn.LookupByIndex(0)
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil})
-		Wish(t, err, ShouldEqual, nil)
+		qt.Check(t, rs, deepEqualsAllowAllUnexported, ExploreRecursive{subTree, subTree, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil})
+		qt.Check(t, err, qt.IsNil)
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfString("Side"))
 		rn, err = rn.LookupByString("Side")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil}, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil})
-		Wish(t, err, ShouldEqual, nil)
+		qt.Check(t, rs, deepEqualsAllowAllUnexported, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil}, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil})
+		qt.Check(t, err, qt.IsNil)
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfString("cheese"))
 		rn, err = rn.LookupByString("cheese")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil}, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil})
-		Wish(t, err, ShouldEqual, nil)
+		qt.Check(t, rs, deepEqualsAllowAllUnexported, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil}, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil})
+		qt.Check(t, err, qt.IsNil)
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfString("whiz"))
 		rn, err = rn.LookupByString("whiz")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 2}, nil}, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil})
-		Wish(t, err, ShouldEqual, nil)
+		qt.Check(t, rs, deepEqualsAllowAllUnexported, ExploreRecursive{subTree, ExploreRecursive{sideSelector, sideSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 2}, nil}, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil})
+		qt.Check(t, err, qt.IsNil)
 	})
 	t.Run("exploring should work with explore union and recursion", func(t *testing.T) {
 		parentsSelector := ExploreUnion{[]Selector{ExploreAll{Matcher{}}, ExploreIndex{recursiveEdge, [1]datamodel.PathSegment{datamodel.PathSegmentOfInt(0)}}}}
@@ -424,24 +423,24 @@ func TestExploreRecursiveExplore(t *testing.T) {
 		`
 		nb := basicnode.Prototype__Any{}.NewBuilder()
 		err := dagjson.Decode(nb, strings.NewReader(nodeString))
-		Wish(t, err, ShouldEqual, nil)
+		qt.Check(t, err, qt.IsNil)
 		rn := nb.Build()
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfString("Parents"))
 		rn, err = rn.LookupByString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil})
-		Wish(t, err, ShouldEqual, nil)
+		qt.Check(t, rs, deepEqualsAllowAllUnexported, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth}, nil})
+		qt.Check(t, err, qt.IsNil)
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfInt(0))
 		rn, err = rn.LookupByIndex(0)
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreUnion{[]Selector{Matcher{}, subTree}}, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil})
-		Wish(t, err, ShouldEqual, nil)
+		qt.Check(t, rs, deepEqualsAllowAllUnexported, ExploreRecursive{subTree, ExploreUnion{[]Selector{Matcher{}, subTree}}, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil})
+		qt.Check(t, err, qt.IsNil)
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfString("Parents"))
 
 		rn, err = rn.LookupByString("Parents")
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil})
-		Wish(t, err, ShouldEqual, nil)
+		qt.Check(t, rs, deepEqualsAllowAllUnexported, ExploreRecursive{subTree, parentsSelector, RecursionLimit{RecursionLimit_Depth, maxDepth - 1}, nil})
+		qt.Check(t, err, qt.IsNil)
 		rs, _ = rs.Explore(rn, datamodel.PathSegmentOfInt(0))
 		rn, err = rn.LookupByIndex(0)
-		Wish(t, rs, ShouldEqual, ExploreRecursive{subTree, ExploreUnion{[]Selector{Matcher{}, subTree}}, RecursionLimit{RecursionLimit_Depth, maxDepth - 2}, nil})
-		Wish(t, err, ShouldEqual, nil)
+		qt.Check(t, rs, deepEqualsAllowAllUnexported, ExploreRecursive{subTree, ExploreUnion{[]Selector{Matcher{}, subTree}}, RecursionLimit{RecursionLimit_Depth, maxDepth - 2}, nil})
+		qt.Check(t, err, qt.IsNil)
 	})
 }

--- a/traversal/walk_test.go
+++ b/traversal/walk_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
-	. "github.com/warpfork/go-wish"
 
 	_ "github.com/ipld/go-ipld-prime/codec/dagjson"
 	"github.com/ipld/go-ipld-prime/datamodel"
@@ -16,6 +15,7 @@ import (
 	"github.com/ipld/go-ipld-prime/linking"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/ipld/go-ipld-prime/node/basicnode"
+	nodetests "github.com/ipld/go-ipld-prime/node/tests"
 	"github.com/ipld/go-ipld-prime/storage"
 	"github.com/ipld/go-ipld-prime/traversal"
 	"github.com/ipld/go-ipld-prime/traversal/selector"
@@ -61,19 +61,19 @@ func TestWalkMatching(t *testing.T) {
 	ssb := builder.NewSelectorSpecBuilder(basicnode.Prototype.Any)
 	t.Run("traverse selecting true should visit the root", func(t *testing.T) {
 		err := traversal.WalkMatching(basicnode.NewString("x"), selector.Matcher{}, func(prog traversal.Progress, n datamodel.Node) error {
-			Wish(t, n, ShouldEqual, basicnode.NewString("x"))
-			Wish(t, prog.Path.String(), ShouldEqual, datamodel.Path{}.String())
+			qt.Check(t, n, nodetests.NodeContentEquals, basicnode.NewString("x"))
+			qt.Check(t, prog.Path.String(), qt.Equals, datamodel.Path{}.String())
 			return nil
 		})
-		Wish(t, err, ShouldEqual, nil)
+		qt.Check(t, err, qt.IsNil)
 	})
 	t.Run("traverse selecting true should visit only the root and no deeper", func(t *testing.T) {
 		err := traversal.WalkMatching(middleMapNode, selector.Matcher{}, func(prog traversal.Progress, n datamodel.Node) error {
-			Wish(t, n, ShouldEqual, middleMapNode)
-			Wish(t, prog.Path.String(), ShouldEqual, datamodel.Path{}.String())
+			qt.Check(t, n, qt.Equals, middleMapNode)
+			qt.Check(t, prog.Path.String(), qt.Equals, datamodel.Path{}.String())
 			return nil
 		})
-		Wish(t, err, ShouldEqual, nil)
+		qt.Check(t, err, qt.IsNil)
 	})
 	t.Run("traverse selecting fields should work", func(t *testing.T) {
 		ss := ssb.ExploreFields(func(efsb builder.ExploreFieldsSpecBuilder) {
@@ -81,22 +81,22 @@ func TestWalkMatching(t *testing.T) {
 			efsb.Insert("bar", ssb.Matcher())
 		})
 		s, err := ss.Selector()
-		Require(t, err, ShouldEqual, nil)
+		qt.Assert(t, err, qt.IsNil)
 		var order int
 		err = traversal.WalkMatching(middleMapNode, s, func(prog traversal.Progress, n datamodel.Node) error {
 			switch order {
 			case 0:
-				Wish(t, n, ShouldEqual, basicnode.NewBool(true))
-				Wish(t, prog.Path.String(), ShouldEqual, "foo")
+				qt.Check(t, n, nodetests.NodeContentEquals, basicnode.NewBool(true))
+				qt.Check(t, prog.Path.String(), qt.Equals, "foo")
 			case 1:
-				Wish(t, n, ShouldEqual, basicnode.NewBool(false))
-				Wish(t, prog.Path.String(), ShouldEqual, "bar")
+				qt.Check(t, n, nodetests.NodeContentEquals, basicnode.NewBool(false))
+				qt.Check(t, prog.Path.String(), qt.Equals, "bar")
 			}
 			order++
 			return nil
 		})
-		Wish(t, err, ShouldEqual, nil)
-		Wish(t, order, ShouldEqual, 2)
+		qt.Check(t, err, qt.IsNil)
+		qt.Check(t, order, qt.Equals, 2)
 	})
 	t.Run("traverse selecting fields recursively should work", func(t *testing.T) {
 		ss := ssb.ExploreFields(func(efsb builder.ExploreFieldsSpecBuilder) {
@@ -106,22 +106,22 @@ func TestWalkMatching(t *testing.T) {
 			}))
 		})
 		s, err := ss.Selector()
-		Require(t, err, ShouldEqual, nil)
+		qt.Assert(t, err, qt.IsNil)
 		var order int
 		err = traversal.WalkMatching(middleMapNode, s, func(prog traversal.Progress, n datamodel.Node) error {
 			switch order {
 			case 0:
-				Wish(t, n, ShouldEqual, basicnode.NewBool(true))
-				Wish(t, prog.Path.String(), ShouldEqual, "foo")
+				qt.Check(t, n, nodetests.NodeContentEquals, basicnode.NewBool(true))
+				qt.Check(t, prog.Path.String(), qt.Equals, "foo")
 			case 1:
-				Wish(t, n, ShouldEqual, basicnode.NewString("zoo"))
-				Wish(t, prog.Path.String(), ShouldEqual, "nested/nonlink")
+				qt.Check(t, n, nodetests.NodeContentEquals, basicnode.NewString("zoo"))
+				qt.Check(t, prog.Path.String(), qt.Equals, "nested/nonlink")
 			}
 			order++
 			return nil
 		})
-		Wish(t, err, ShouldEqual, nil)
-		Wish(t, order, ShouldEqual, 2)
+		qt.Check(t, err, qt.IsNil)
+		qt.Check(t, order, qt.Equals, 2)
 	})
 	t.Run("traversing across nodes should work", func(t *testing.T) {
 		ss := ssb.ExploreRecursive(selector.RecursionLimitDepth(3), ssb.ExploreUnion(
@@ -140,35 +140,35 @@ func TestWalkMatching(t *testing.T) {
 		}.WalkMatching(middleMapNode, s, func(prog traversal.Progress, n datamodel.Node) error {
 			switch order {
 			case 0:
-				Wish(t, n, ShouldEqual, middleMapNode)
-				Wish(t, prog.Path.String(), ShouldEqual, "")
+				qt.Check(t, n, qt.Equals, middleMapNode)
+				qt.Check(t, prog.Path.String(), qt.Equals, "")
 			case 1:
-				Wish(t, n, ShouldEqual, basicnode.NewBool(true))
-				Wish(t, prog.Path.String(), ShouldEqual, "foo")
+				qt.Check(t, n, nodetests.NodeContentEquals, basicnode.NewBool(true))
+				qt.Check(t, prog.Path.String(), qt.Equals, "foo")
 			case 2:
-				Wish(t, n, ShouldEqual, basicnode.NewBool(false))
-				Wish(t, prog.Path.String(), ShouldEqual, "bar")
+				qt.Check(t, n, nodetests.NodeContentEquals, basicnode.NewBool(false))
+				qt.Check(t, prog.Path.String(), qt.Equals, "bar")
 			case 3:
-				Wish(t, n, ShouldEqual, fluent.MustBuildMap(basicnode.Prototype.Map, 2, func(na fluent.MapAssembler) {
+				qt.Check(t, n, nodetests.NodeContentEquals, fluent.MustBuildMap(basicnode.Prototype.Map, 2, func(na fluent.MapAssembler) {
 					na.AssembleEntry("alink").AssignLink(leafAlphaLnk)
 					na.AssembleEntry("nonlink").AssignString("zoo")
 				}))
-				Wish(t, prog.Path.String(), ShouldEqual, "nested")
+				qt.Check(t, prog.Path.String(), qt.Equals, "nested")
 			case 4:
-				Wish(t, n, ShouldEqual, basicnode.NewString("alpha"))
-				Wish(t, prog.Path.String(), ShouldEqual, "nested/alink")
-				Wish(t, prog.LastBlock.Path.String(), ShouldEqual, "nested/alink")
-				Wish(t, prog.LastBlock.Link.String(), ShouldEqual, leafAlphaLnk.String())
+				qt.Check(t, n, nodetests.NodeContentEquals, basicnode.NewString("alpha"))
+				qt.Check(t, prog.Path.String(), qt.Equals, "nested/alink")
+				qt.Check(t, prog.LastBlock.Path.String(), qt.Equals, "nested/alink")
+				qt.Check(t, prog.LastBlock.Link.String(), qt.Equals, leafAlphaLnk.String())
 
 			case 5:
-				Wish(t, n, ShouldEqual, basicnode.NewString("zoo"))
-				Wish(t, prog.Path.String(), ShouldEqual, "nested/nonlink")
+				qt.Check(t, n, nodetests.NodeContentEquals, basicnode.NewString("zoo"))
+				qt.Check(t, prog.Path.String(), qt.Equals, "nested/nonlink")
 			}
 			order++
 			return nil
 		})
-		Wish(t, err, ShouldEqual, nil)
-		Wish(t, order, ShouldEqual, 6)
+		qt.Check(t, err, qt.IsNil)
+		qt.Check(t, order, qt.Equals, 6)
 	})
 	t.Run("traversing lists should work", func(t *testing.T) {
 		ss := ssb.ExploreRange(0, 3, ssb.Matcher())
@@ -184,26 +184,26 @@ func TestWalkMatching(t *testing.T) {
 		}.WalkMatching(middleListNode, s, func(prog traversal.Progress, n datamodel.Node) error {
 			switch order {
 			case 0:
-				Wish(t, n, ShouldEqual, basicnode.NewString("alpha"))
-				Wish(t, prog.Path.String(), ShouldEqual, "0")
-				Wish(t, prog.LastBlock.Path.String(), ShouldEqual, "0")
-				Wish(t, prog.LastBlock.Link.String(), ShouldEqual, leafAlphaLnk.String())
+				qt.Check(t, n, nodetests.NodeContentEquals, basicnode.NewString("alpha"))
+				qt.Check(t, prog.Path.String(), qt.Equals, "0")
+				qt.Check(t, prog.LastBlock.Path.String(), qt.Equals, "0")
+				qt.Check(t, prog.LastBlock.Link.String(), qt.Equals, leafAlphaLnk.String())
 			case 1:
-				Wish(t, n, ShouldEqual, basicnode.NewString("alpha"))
-				Wish(t, prog.Path.String(), ShouldEqual, "1")
-				Wish(t, prog.LastBlock.Path.String(), ShouldEqual, "1")
-				Wish(t, prog.LastBlock.Link.String(), ShouldEqual, leafAlphaLnk.String())
+				qt.Check(t, n, nodetests.NodeContentEquals, basicnode.NewString("alpha"))
+				qt.Check(t, prog.Path.String(), qt.Equals, "1")
+				qt.Check(t, prog.LastBlock.Path.String(), qt.Equals, "1")
+				qt.Check(t, prog.LastBlock.Link.String(), qt.Equals, leafAlphaLnk.String())
 			case 2:
-				Wish(t, n, ShouldEqual, basicnode.NewString("beta"))
-				Wish(t, prog.Path.String(), ShouldEqual, "2")
-				Wish(t, prog.LastBlock.Path.String(), ShouldEqual, "2")
-				Wish(t, prog.LastBlock.Link.String(), ShouldEqual, leafBetaLnk.String())
+				qt.Check(t, n, nodetests.NodeContentEquals, basicnode.NewString("beta"))
+				qt.Check(t, prog.Path.String(), qt.Equals, "2")
+				qt.Check(t, prog.LastBlock.Path.String(), qt.Equals, "2")
+				qt.Check(t, prog.LastBlock.Link.String(), qt.Equals, leafBetaLnk.String())
 			}
 			order++
 			return nil
 		})
-		Wish(t, err, ShouldEqual, nil)
-		Wish(t, order, ShouldEqual, 3)
+		qt.Check(t, err, qt.IsNil)
+		qt.Check(t, order, qt.Equals, 3)
 	})
 	t.Run("multiple layers of link traversal should work", func(t *testing.T) {
 		ss := ssb.ExploreFields(func(efsb builder.ExploreFieldsSpecBuilder) {
@@ -227,46 +227,46 @@ func TestWalkMatching(t *testing.T) {
 		}.WalkMatching(rootNode, s, func(prog traversal.Progress, n datamodel.Node) error {
 			switch order {
 			case 0:
-				Wish(t, n, ShouldEqual, basicnode.NewString("alpha"))
-				Wish(t, prog.Path.String(), ShouldEqual, "linkedList/0")
-				Wish(t, prog.LastBlock.Path.String(), ShouldEqual, "linkedList/0")
-				Wish(t, prog.LastBlock.Link.String(), ShouldEqual, leafAlphaLnk.String())
+				qt.Check(t, n, nodetests.NodeContentEquals, basicnode.NewString("alpha"))
+				qt.Check(t, prog.Path.String(), qt.Equals, "linkedList/0")
+				qt.Check(t, prog.LastBlock.Path.String(), qt.Equals, "linkedList/0")
+				qt.Check(t, prog.LastBlock.Link.String(), qt.Equals, leafAlphaLnk.String())
 			case 1:
-				Wish(t, n, ShouldEqual, basicnode.NewString("alpha"))
-				Wish(t, prog.Path.String(), ShouldEqual, "linkedList/1")
-				Wish(t, prog.LastBlock.Path.String(), ShouldEqual, "linkedList/1")
-				Wish(t, prog.LastBlock.Link.String(), ShouldEqual, leafAlphaLnk.String())
+				qt.Check(t, n, nodetests.NodeContentEquals, basicnode.NewString("alpha"))
+				qt.Check(t, prog.Path.String(), qt.Equals, "linkedList/1")
+				qt.Check(t, prog.LastBlock.Path.String(), qt.Equals, "linkedList/1")
+				qt.Check(t, prog.LastBlock.Link.String(), qt.Equals, leafAlphaLnk.String())
 			case 2:
-				Wish(t, n, ShouldEqual, basicnode.NewString("beta"))
-				Wish(t, prog.Path.String(), ShouldEqual, "linkedList/2")
-				Wish(t, prog.LastBlock.Path.String(), ShouldEqual, "linkedList/2")
-				Wish(t, prog.LastBlock.Link.String(), ShouldEqual, leafBetaLnk.String())
+				qt.Check(t, n, nodetests.NodeContentEquals, basicnode.NewString("beta"))
+				qt.Check(t, prog.Path.String(), qt.Equals, "linkedList/2")
+				qt.Check(t, prog.LastBlock.Path.String(), qt.Equals, "linkedList/2")
+				qt.Check(t, prog.LastBlock.Link.String(), qt.Equals, leafBetaLnk.String())
 			case 3:
-				Wish(t, n, ShouldEqual, basicnode.NewString("alpha"))
-				Wish(t, prog.Path.String(), ShouldEqual, "linkedList/3")
-				Wish(t, prog.LastBlock.Path.String(), ShouldEqual, "linkedList/3")
-				Wish(t, prog.LastBlock.Link.String(), ShouldEqual, leafAlphaLnk.String())
+				qt.Check(t, n, nodetests.NodeContentEquals, basicnode.NewString("alpha"))
+				qt.Check(t, prog.Path.String(), qt.Equals, "linkedList/3")
+				qt.Check(t, prog.LastBlock.Path.String(), qt.Equals, "linkedList/3")
+				qt.Check(t, prog.LastBlock.Link.String(), qt.Equals, leafAlphaLnk.String())
 			case 4:
-				Wish(t, n, ShouldEqual, basicnode.NewBool(true))
-				Wish(t, prog.Path.String(), ShouldEqual, "linkedMap/foo")
-				Wish(t, prog.LastBlock.Path.String(), ShouldEqual, "linkedMap")
-				Wish(t, prog.LastBlock.Link.String(), ShouldEqual, middleMapNodeLnk.String())
+				qt.Check(t, n, nodetests.NodeContentEquals, basicnode.NewBool(true))
+				qt.Check(t, prog.Path.String(), qt.Equals, "linkedMap/foo")
+				qt.Check(t, prog.LastBlock.Path.String(), qt.Equals, "linkedMap")
+				qt.Check(t, prog.LastBlock.Link.String(), qt.Equals, middleMapNodeLnk.String())
 			case 5:
-				Wish(t, n, ShouldEqual, basicnode.NewString("zoo"))
-				Wish(t, prog.Path.String(), ShouldEqual, "linkedMap/nested/nonlink")
-				Wish(t, prog.LastBlock.Path.String(), ShouldEqual, "linkedMap")
-				Wish(t, prog.LastBlock.Link.String(), ShouldEqual, middleMapNodeLnk.String())
+				qt.Check(t, n, nodetests.NodeContentEquals, basicnode.NewString("zoo"))
+				qt.Check(t, prog.Path.String(), qt.Equals, "linkedMap/nested/nonlink")
+				qt.Check(t, prog.LastBlock.Path.String(), qt.Equals, "linkedMap")
+				qt.Check(t, prog.LastBlock.Link.String(), qt.Equals, middleMapNodeLnk.String())
 			case 6:
-				Wish(t, n, ShouldEqual, basicnode.NewString("alpha"))
-				Wish(t, prog.Path.String(), ShouldEqual, "linkedMap/nested/alink")
-				Wish(t, prog.LastBlock.Path.String(), ShouldEqual, "linkedMap/nested/alink")
-				Wish(t, prog.LastBlock.Link.String(), ShouldEqual, leafAlphaLnk.String())
+				qt.Check(t, n, nodetests.NodeContentEquals, basicnode.NewString("alpha"))
+				qt.Check(t, prog.Path.String(), qt.Equals, "linkedMap/nested/alink")
+				qt.Check(t, prog.LastBlock.Path.String(), qt.Equals, "linkedMap/nested/alink")
+				qt.Check(t, prog.LastBlock.Link.String(), qt.Equals, leafAlphaLnk.String())
 			}
 			order++
 			return nil
 		})
-		Wish(t, err, ShouldEqual, nil)
-		Wish(t, order, ShouldEqual, 7)
+		qt.Check(t, err, qt.IsNil)
+		qt.Check(t, order, qt.Equals, 7)
 	})
 }
 
@@ -287,7 +287,7 @@ func TestWalkBudgets(t *testing.T) {
 		err = prog.WalkMatching(middleMapNode, s, func(prog traversal.Progress, n datamodel.Node) error {
 			switch order {
 			case 0:
-				qt.Assert(t, n, qt.CmpEquals(), basicnode.NewBool(true))
+				qt.Assert(t, n, nodetests.NodeContentEquals, basicnode.NewBool(true))
 				qt.Assert(t, prog.Path.String(), qt.Equals, "foo")
 			}
 			order++
@@ -316,13 +316,13 @@ func TestWalkBudgets(t *testing.T) {
 		}.WalkMatching(middleListNode, s, func(prog traversal.Progress, n datamodel.Node) error {
 			switch order {
 			case 0:
-				qt.Assert(t, n, qt.CmpEquals(), basicnode.NewString("alpha"))
+				qt.Assert(t, n, nodetests.NodeContentEquals, basicnode.NewString("alpha"))
 				qt.Assert(t, prog.Path.String(), qt.Equals, "0")
 			case 1:
-				qt.Assert(t, n, qt.CmpEquals(), basicnode.NewString("alpha"))
+				qt.Assert(t, n, nodetests.NodeContentEquals, basicnode.NewString("alpha"))
 				qt.Assert(t, prog.Path.String(), qt.Equals, "1")
 			case 2:
-				qt.Assert(t, n, qt.CmpEquals(), basicnode.NewString("beta"))
+				qt.Assert(t, n, nodetests.NodeContentEquals, basicnode.NewString("beta"))
 				qt.Assert(t, prog.Path.String(), qt.Equals, "2")
 			}
 			order++
@@ -395,13 +395,13 @@ func TestWalkBlockLoadOrder(t *testing.T) {
 		var count int
 		lsys := cidlink.DefaultLinkSystem()
 		lsys.StorageReadOpener = func(lc linking.LinkContext, l datamodel.Link) (io.Reader, error) {
-			Wish(t, l.String(), ShouldEqual, expected[count].String())
+			qt.Check(t, l.String(), qt.Equals, expected[count].String())
 			log.Printf("%v (%v) %s<> %v (%v)\n", l, linkNames[l], strings.Repeat(" ", 17-len(linkNames[l])), expected[count], linkNames[expected[count]])
 			count++
 			return readFn(lc, l)
 		}
 		sel, err := selector.CompileSelector(s)
-		Wish(t, err, ShouldEqual, nil)
+		qt.Check(t, err, qt.IsNil)
 		err = traversal.Progress{
 			Cfg: &traversal.Config{
 				LinkSystem:                     lsys,
@@ -411,8 +411,8 @@ func TestWalkBlockLoadOrder(t *testing.T) {
 		}.WalkMatching(newRootNode, sel, func(prog traversal.Progress, n datamodel.Node) error {
 			return nil
 		})
-		Wish(t, err, ShouldEqual, nil)
-		Wish(t, count, ShouldEqual, len(expected))
+		qt.Check(t, err, qt.IsNil)
+		qt.Check(t, count, qt.Equals, len(expected))
 	}
 
 	t.Run("CommonSelector_MatchAllRecursively", func(t *testing.T) {

--- a/traversal/walk_with_stop_test.go
+++ b/traversal/walk_with_stop_test.go
@@ -4,13 +4,14 @@ import (
 	"fmt"
 	"testing"
 
-	. "github.com/warpfork/go-wish"
+	qt "github.com/frankban/quicktest"
 
 	_ "github.com/ipld/go-ipld-prime/codec/dagjson"
 	"github.com/ipld/go-ipld-prime/datamodel"
 	"github.com/ipld/go-ipld-prime/fluent"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/ipld/go-ipld-prime/node/basicnode"
+	nodetests "github.com/ipld/go-ipld-prime/node/tests"
 	"github.com/ipld/go-ipld-prime/traversal"
 	"github.com/ipld/go-ipld-prime/traversal/selector"
 	"github.com/ipld/go-ipld-prime/traversal/selector/builder"
@@ -104,23 +105,23 @@ func TestStopAtLink(t *testing.T) {
 			switch order {
 			case 0:
 				// Root
-				Wish(t, prog.Path.String(), ShouldEqual, "")
+				qt.Check(t, prog.Path.String(), qt.Equals, "")
 			case 1:
-				Wish(t, prog.Path.String(), ShouldEqual, "plain")
-				Wish(t, n, ShouldEqual, basicnode.NewString("olde string"))
+				qt.Check(t, prog.Path.String(), qt.Equals, "plain")
+				qt.Check(t, n, nodetests.NodeContentEquals, basicnode.NewString("olde string"))
 			case 2:
-				Wish(t, prog.Path.String(), ShouldEqual, "linkedString")
+				qt.Check(t, prog.Path.String(), qt.Equals, "linkedString")
 			case 3:
-				Wish(t, prog.Path.String(), ShouldEqual, "linkedList")
+				qt.Check(t, prog.Path.String(), qt.Equals, "linkedList")
 			// We are starting to traverse the linkedList, we passed through the map already
 			case 4:
-				Wish(t, prog.Path.String(), ShouldEqual, "linkedList/0")
+				qt.Check(t, prog.Path.String(), qt.Equals, "linkedList/0")
 			}
 			order++
 			return nil
 		})
-		Wish(t, err, ShouldEqual, nil)
-		Wish(t, order, ShouldEqual, 8)
+		qt.Check(t, err, qt.IsNil)
+		qt.Check(t, order, qt.Equals, 8)
 	})
 }
 
@@ -227,12 +228,12 @@ func stopAtInChainTest(t *testing.T, chainNode datamodel.Node, stopLnk datamodel
 			},
 		}.WalkMatching(chainNode, s, func(prog traversal.Progress, n datamodel.Node) error {
 			//fmt.Println("Order", order, prog.Path.String())
-			Wish(t, order < len(expectedPaths), ShouldEqual, true)
-			Wish(t, prog.Path.String(), ShouldEqual, expectedPaths[order])
+			qt.Check(t, order < len(expectedPaths), qt.IsTrue)
+			qt.Check(t, prog.Path.String(), qt.Equals, expectedPaths[order])
 			order++
 			return nil
 		})
-		Wish(t, err, ShouldEqual, nil)
-		Wish(t, order, ShouldEqual, len(expectedPaths))
+		qt.Check(t, err, qt.IsNil)
+		qt.Check(t, order, qt.Equals, len(expectedPaths))
 	})
 }


### PR DESCRIPTION
Port the tests in `traversal` package to quicktest; use:
 - `qt.Check` for `wish.Wish`
 - `qt.Assert` for `wish.Require`
 - `qt.IsNil` for `ShouldEqual` over `nil`
 - `qt.IsTrue` for `ShouldEqual` over `true`
 - `qt.IsFalse` for `ShouldEqual` over `false`
 - `qt.HasLen` for `ShouldEqual` over slice length
 - `qt.DeepEquals` for `ShouldEqual` over slices
 - `CmpEquals` for `ShouldEqual` over types with unexported fields
    excluding `datamodel.Node` with custom exporter to allow checking
    of all unexported fields
      - Defined checker once and reused across packages. Did not add
        this to `node/tests` to avoid cycle package dependency.
 - `nodetests.NodeContentEquals` over `datamodel.DeepEqual` and
   `ShouldEqual` over `datamodel.Node`

Fixes #219