### PR TITLE
Allow parsing padding in dag-json bytes fields

### DIFF
--- a/codec/dagjson/roundtripBytes_test.go
+++ b/codec/dagjson/roundtripBytes_test.go
@@ -61,3 +61,14 @@ func TestEncapsulatedBytes(t *testing.T) {
 		qt.Check(t, nb.Build(), nodetests.NodeContentEquals, encapsulatedNode)
 	})
 }
+
+var withPadding = `{"/": {"bytes": "Bxrk96XO8cwr3hrcL4VeWtVdYudzHv47BbBl7CesWvmjRrRPOLZp9Ukg6sivn5Nqg4V5X2w43mk4Ppuzr+M+DA=="}}`
+
+func TestPaddedBytes(t *testing.T) {
+	t.Run("decoding", func(t *testing.T) {
+		buf := strings.NewReader(withPadding)
+		nb := basicnode.Prototype.Bytes.NewBuilder()
+		err := dagjson.Decode(nb, buf)
+		qt.Assert(t, err, qt.IsNil)
+	})
+}

--- a/codec/dagjson/unmarshal.go
+++ b/codec/dagjson/unmarshal.go
@@ -267,7 +267,7 @@ func (st *unmarshalState) bytesLookahead(na datamodel.NodeAssembler, tokSrc shar
 		return false, nil
 	}
 	// Okay, we made it -- this looks like bytes.  Parse it.
-	elBytes, err := base64.RawStdEncoding.DecodeString(st.tk[4].Str)
+	elBytes, err := base64.StdEncoding.DecodeString(st.tk[4].Str)
 	if err != nil {
 		return false, err
 	}

--- a/codec/dagjson/unmarshal.go
+++ b/codec/dagjson/unmarshal.go
@@ -267,9 +267,14 @@ func (st *unmarshalState) bytesLookahead(na datamodel.NodeAssembler, tokSrc shar
 		return false, nil
 	}
 	// Okay, we made it -- this looks like bytes.  Parse it.
-	elBytes, err := base64.StdEncoding.DecodeString(st.tk[4].Str)
+	elBytes, err := base64.RawStdEncoding.DecodeString(st.tk[4].Str)
 	if err != nil {
-		return false, err
+		if _, isInput := err.(base64.CorruptInputError); isInput {
+			elBytes, err = base64.StdEncoding.DecodeString(st.tk[4].Str)
+		}
+		if err != nil {
+			return false, err
+		}
 	}
 	if err := na.AssignBytes(elBytes); err != nil {
 		return false, err


### PR DESCRIPTION
While we specify that the bytes field in dag-json is canonically the un-padded variant of the base64 encoding, there are existing records / dags created on versions of this library which did use padding. We should be able to parse these nodes.