### PR TITLE
selectors: fix for edge case around recursion clauses with an immediate edge.

### DIFF
--- a/traversal/selector/exploreRecursiveEdge.go
+++ b/traversal/selector/exploreRecursiveEdge.go
@@ -16,9 +16,9 @@ import (
 // An ExploreRecursiveEdge without an enclosing ExploreRecursive is an error.
 type ExploreRecursiveEdge struct{}
 
-// Interests should ultimately never get called for an ExploreRecursiveEdge selector
+// Interests should almost never get called for an ExploreRecursiveEdge selector
 func (s ExploreRecursiveEdge) Interests() []datamodel.PathSegment {
-	panic("Traversed Explore Recursive Edge Node With No Parent")
+	return []datamodel.PathSegment{}
 }
 
 // Explore should ultimately never get called for an ExploreRecursiveEdge selector
@@ -26,9 +26,9 @@ func (s ExploreRecursiveEdge) Explore(n datamodel.Node, p datamodel.PathSegment)
 	panic("Traversed Explore Recursive Edge Node With No Parent")
 }
 
-// Decide should ultimately never get called for an ExploreRecursiveEdge selector
+// Decide should almost never get called for an ExploreRecursiveEdge selector
 func (s ExploreRecursiveEdge) Decide(n datamodel.Node) bool {
-	panic("Traversed Explore Recursive Edge Node With No Parent")
+	return false
 }
 
 // ParseExploreRecursiveEdge assembles a Selector

--- a/traversal/selector/selector.go
+++ b/traversal/selector/selector.go
@@ -81,8 +81,9 @@ type Selector interface {
 	// (If that happens, we're currently assuming the ADL has a reasonable caching behavior.  It's very likely that the traversal will look up the same paths that Explore just looked up (assuming the Condition told exploration to continue).)
 	//
 
-	// Interests should return either a list of PageSegment we're likely interested in,
+	// Interests should return either a list of PathSegment we're likely interested in,
 	// **or nil**, which indicates we're a high-cardinality or expression-based selection clause and thus we'll need all segments proposed to us.
+	// Note that a non-nil zero length list of PathSegment is distinguished from nil: this would mean this selector is interested absolutely nothing.
 	//
 	// Traversal will call this before calling Explore, and use it to try to call Explore less often (or even avoid iterating on the data node at all).
 	Interests() []datamodel.PathSegment

--- a/traversal/selector/spec_test.go
+++ b/traversal/selector/spec_test.go
@@ -18,7 +18,13 @@ import (
 )
 
 func TestSpecFixtures(t *testing.T) {
-	doc, err := testmark.ReadFile("../../.ipld/specs/selectors/fixtures/selector-fixtures-1.md")
+	dir := "../../.ipld/specs/selectors/fixtures/"
+	testOneSpecFixtureFile(t, dir+"selector-fixtures-1.md")
+	testOneSpecFixtureFile(t, dir+"selector-fixtures-recursion.md")
+}
+
+func testOneSpecFixtureFile(t *testing.T, filename string) {
+	doc, err := testmark.ReadFile(filename)
 	if os.IsNotExist(err) {
 		t.Skipf("not running spec suite: %s (did you clone the submodule with the data?)", err)
 	}
@@ -108,5 +114,4 @@ func TestSpecFixtures(t *testing.T) {
 			qt.Assert(t, visitLogString.String(), qt.CmpEquals(), fixtureExpectNormBuf.String())
 		})
 	}
-
 }

--- a/traversal/walk.go
+++ b/traversal/walk.go
@@ -203,6 +203,9 @@ func (prog Progress) walkAdv(n datamodel.Node, s selector.Selector, fn AdvVisitF
 	if attn == nil {
 		return prog.walkAdv_iterateAll(n, s, fn)
 	}
+	if len(attn) == 0 {
+		return nil
+	}
 	return prog.walkAdv_iterateSelective(n, attn, s, fn)
 
 }


### PR DESCRIPTION
See also the diff in the ipld/ipld repo for the new fixture,
which includes some explanation.

This would be a somewhat silly selector to write, but,
it doesn't seem to be something we should reject at compile time, either;
so, we must handle it gracefully.

Along the way, I documented some code that was sparse in comments.

I also added a shortcut to traversals so that a selector that
explicitly states it's not interested in anything (by returning a
non-nil but empty slice for its interests) is treated differently
than a nil return for interests (which means "I don't know; hit me
with everything you've got and lemme see").  This means that our
edge case here with edges (...heh) doesn't cause the traversal
to create an iterator that it doesn't really need, etc.

We turn out to need both that shortcut, *and* less panicky methods on
ExploreRecursiveEdge, *and* the edge case branch in ExploreRecursive...
because traversals are pre-order.  Decide is called first, then
Interests, and then Explore.  Therefore informing the Explore method
alone about this situation is not sufficient.

Previously, a recursion clause with an edge as its immediate and only
child would get a passing grade by the compiler (same as now),
but would panic when actually used (oh dear).