### PR TITLE
feat: add dagcbor.EncodedLength(Node) to calculate byte length without encoding

### DIFF
--- a/codec/dagcbor/marshal_test.go
+++ b/codec/dagcbor/marshal_test.go
@@ -1,0 +1,70 @@
+package dagcbor
+
+import (
+	"bytes"
+	"math/rand"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/ipld/go-ipld-prime/datamodel"
+	basicnode "github.com/ipld/go-ipld-prime/node/basic"
+	"github.com/ipld/go-ipld-prime/testutil/garbage"
+)
+
+func calculateActualLength(t *testing.T, n datamodel.Node) int64 {
+	var buf bytes.Buffer
+	err := Encode(n, &buf)
+	qt.Assert(t, err, qt.IsNil)
+	return int64(buf.Len())
+}
+
+func verifyEstimatedSize(t *testing.T, n datamodel.Node) {
+	estimatedLength, err := EncodedLength(n)
+	qt.Assert(t, err, qt.IsNil)
+	actualLength := calculateActualLength(t, n)
+	qt.Assert(t, estimatedLength, qt.Equals, actualLength)
+}
+
+func TestEncodedLength(t *testing.T) {
+	t.Run("int boundaries", func(t *testing.T) {
+		for ii := 0; ii < 4; ii++ {
+			verifyEstimatedSize(t, basicnode.NewInt(int64(lengthBoundaries[ii].upperBound)))
+			verifyEstimatedSize(t, basicnode.NewInt(int64(lengthBoundaries[ii].upperBound)-1))
+			verifyEstimatedSize(t, basicnode.NewInt(int64(lengthBoundaries[ii].upperBound)+1))
+			verifyEstimatedSize(t, basicnode.NewInt(-1*int64(lengthBoundaries[ii].upperBound)))
+			verifyEstimatedSize(t, basicnode.NewInt(-1*int64(lengthBoundaries[ii].upperBound)-1))
+			verifyEstimatedSize(t, basicnode.NewInt(-1*int64(lengthBoundaries[ii].upperBound)+1))
+		}
+	})
+
+	t.Run("small garbage", func(t *testing.T) {
+		seed := time.Now().Unix()
+		t.Logf("randomness seed: %v\n", seed)
+		rnd := rand.New(rand.NewSource(seed))
+		for i := 0; i < 1000; i++ {
+			gbg := garbage.Generate(rnd, garbage.TargetBlockSize(1<<6))
+			verifyEstimatedSize(t, gbg)
+		}
+	})
+
+	t.Run("medium garbage", func(t *testing.T) {
+		seed := time.Now().Unix()
+		t.Logf("randomness seed: %v\n", seed)
+		rnd := rand.New(rand.NewSource(seed))
+		for i := 0; i < 100; i++ {
+			gbg := garbage.Generate(rnd, garbage.TargetBlockSize(1<<16))
+			verifyEstimatedSize(t, gbg)
+		}
+	})
+
+	t.Run("large garbage", func(t *testing.T) {
+		seed := time.Now().Unix()
+		t.Logf("randomness seed: %v\n", seed)
+		rnd := rand.New(rand.NewSource(seed))
+		for i := 0; i < 10; i++ {
+			gbg := garbage.Generate(rnd, garbage.TargetBlockSize(1<<20))
+			verifyEstimatedSize(t, gbg)
+		}
+	})
+}

--- a/codec/dagcbor/roundtrip_test.go
+++ b/codec/dagcbor/roundtrip_test.go
@@ -56,6 +56,11 @@ func TestRoundtrip(t *testing.T) {
 		qt.Assert(t, err, qt.IsNil)
 		qt.Check(t, buf.String(), qt.Equals, serial)
 	})
+	t.Run("length", func(t *testing.T) {
+		length, err := EncodedLength(n)
+		qt.Assert(t, err, qt.IsNil)
+		qt.Check(t, length, qt.Equals, int64(len(serial)))
+	})
 	t.Run("decoding", func(t *testing.T) {
 		buf := strings.NewReader(serial)
 		nb := basicnode.Prototype.Map.NewBuilder()


### PR DESCRIPTION
For pre-allocation if it's going to be more efficient to walk the graph twice than have sloppy allocation during encode.

Seeing a need here: https://github.com/ipfs/go-graphsync/pull/332#discussion_r792178486 - mainly because graphsync keeps a tight reign over its allocations so being able to predict helps with that process.

For this reason, it's kind of important this is absolutely correct! Do we have code for generating garbage nodes that I can run through this to get some more certainty about correctness? Something like https://github.com/rvagg/js-ipld-garbage?

(Also feel free to object if you think this is a terrible addition, that's a valid response too.)