### PR TITLE
feat: add Garbage() Node generator

### DIFF
--- a/testutil/garbage/garbage.go
+++ b/testutil/garbage/garbage.go
@@ -36,7 +36,7 @@ var (
 	generators map[datamodel.Kind]generator
 )
 
-// Garbage produces random Nodes which can be useful for testing and benchmarking. By default, the
+// Generate produces random Nodes which can be useful for testing and benchmarking. By default, the
 // Nodes produced are relatively small, averaging near the 1024 byte range when encoded
 // (very roughly, with a wide spread).
 //
@@ -47,7 +47,7 @@ var (
 // the randomness is stable across test runs, or a seed is captured in such a way that a failure
 // can be reproduced (e.g. by printing it to stdout during the test run so it can be captured in
 // CI for a failure).
-func Garbage(rand *mathrand.Rand, opts ...Option) datamodel.Node {
+func Generate(rand *mathrand.Rand, opts ...Option) datamodel.Node {
 	options := applyOptions(opts...)
 	_, n := generate(rand, options.blockSize, options)
 	return n
@@ -289,7 +289,7 @@ func Weights(weights map[datamodel.Kind]int) Option {
 
 // TargetBlockSize sets a very rough bias in number of bytes that the resulting
 // Node may consume when encoded (i.e. the block size). This is a very
-// approximate measure, but over enough repeated Garbage() calls, the resulting
+// approximate measure, but over enough repeated Generate() calls, the resulting
 // Nodes, once encoded, should have a median that is somewhere in this vicinity.
 //
 // The default target block size is 1024. This should be tuned in accordance with

--- a/testutil/garbage/garbage.go
+++ b/testutil/garbage/garbage.go
@@ -1,0 +1,304 @@
+package garbage
+
+import (
+	"math"
+	"math/rand"
+	"strings"
+	"time"
+
+	"github.com/ipfs/go-cid"
+	"github.com/ipld/go-ipld-prime/datamodel"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/ipld/go-ipld-prime/must"
+	basicnode "github.com/ipld/go-ipld-prime/node/basic"
+	"github.com/multiformats/go-multihash"
+)
+
+type Options struct {
+	initialWeights map[datamodel.Kind]int
+	weights        map[datamodel.Kind]int
+	blockSize      uint64
+}
+
+type generator func(count uint64, opts Options) (uint64, datamodel.Node)
+
+type hasher struct {
+	code   uint64
+	length int
+}
+
+const charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789`~!@#$%^&*()-_=+[]{}|\\:;'\",.<>?/ \t\n☺💩"
+
+var codecs []uint64
+var hashes []hasher
+var kinds datamodel.KindSet
+var generators map[datamodel.Kind]generator
+var runes []rune
+
+// Garbage produces random Nodes which can be useful for testing and benchmarking. By default, the
+// Nodes produced are relatively small, averaging near the 100 byte range when encoded
+// (very roughly, with a wide spread).
+//
+// Options can be used to adjust the average size and weights of occurances of different kinds
+// within the complete Node graph.
+func Garbage(opts ...Option) datamodel.Node {
+	options := applyOptions(opts...)
+	rand.Seed(time.Now().UnixNano())
+	_, n := generate(options.blockSize, options)
+	return n
+}
+
+func generate(count uint64, opts Options) (uint64, datamodel.Node) {
+	weights := opts.weights
+	if opts.initialWeights != nil {
+		weights = opts.initialWeights
+		opts = Options{weights: opts.weights}
+	}
+	totWeight := 0
+	for _, kind := range kinds {
+		totWeight += weights[kind]
+	}
+	r := rand.Float64() * float64(totWeight)
+	var wacc int
+	for _, kind := range kinds {
+		wacc += weights[kind]
+		if float64(wacc) >= r {
+			return generators[kind](count, opts)
+		}
+	}
+	panic("bad options")
+}
+
+func rndSize(bias uint64) uint64 {
+	// @rv: OK, I'll admit that I've completely forgotten how I arrived at this, but it
+	// generates numbers that bias toward `bias`, but not strictly, they may vary wildly
+	// but be drawn toward the lower end of the range and tend to be suitable for lengths
+	// of arrays and such
+	m := math.Abs(math.Floor(5/(1-(math.Pow(rand.Float64(), 2))) - 5 + rand.Float64()*float64(bias)))
+	return uint64(m)
+}
+
+func rndRune() rune {
+	return runes[rand.Intn(len(runes))]
+}
+
+func listGenerator(count uint64, opts Options) (uint64, datamodel.Node) {
+	len := rndSize(5)
+	lb := basicnode.Prototype.List.NewBuilder()
+	la, err := lb.BeginList(int64(len))
+	if err != nil {
+		panic(err)
+	}
+	size := uint64(0)
+	for i := uint64(0); i < len && size < count; i++ {
+		c, n := generate(count-size, opts)
+		la.AssembleValue().AssignNode(n)
+		size += c
+	}
+	err = la.Finish()
+	if err != nil {
+		panic(err)
+	}
+	return size, lb.Build()
+}
+
+func mapGenerator(count uint64, opts Options) (uint64, datamodel.Node) {
+	length := rndSize(5)
+	mb := basicnode.Prototype.Map.NewBuilder()
+	ma, err := mb.BeginMap(int64(length))
+	if err != nil {
+		panic(err)
+	}
+	size := uint64(0)
+	keys := make(map[string]struct{})
+	for i := uint64(0); i < length && size < count; i++ {
+		var key string
+		for {
+			c, k := stringGenerator(5, opts)
+			key = must.String(k)
+			if _, ok := keys[key]; !ok && len(key) > 0 {
+				keys[key] = struct{}{}
+				size += c
+				break
+			}
+		}
+		sz := count - size
+		if size >= count { // the case where we've blown our budget already on the key
+			sz = 5
+		}
+		c, value := generate(sz, opts)
+		size += c
+		err := ma.AssembleKey().AssignString(key)
+		if err != nil {
+			panic(err)
+		}
+		err = ma.AssembleValue().AssignNode(value)
+		if err != nil {
+			panic(err)
+		}
+	}
+	err = ma.Finish()
+	if err != nil {
+		panic(err)
+	}
+	return size, mb.Build()
+}
+
+func stringGenerator(count uint64, opts Options) (uint64, datamodel.Node) {
+	len := rndSize(count)
+	sb := strings.Builder{}
+	for i := uint64(0); i < len; i++ {
+		sb.WriteRune(rndRune())
+	}
+	return len, basicnode.NewString(sb.String())
+}
+
+func bytesGenerator(count uint64, opts Options) (uint64, datamodel.Node) {
+	len := rndSize(count)
+	ba := make([]byte, len)
+	rand.Read(ba)
+	return len, basicnode.NewBytes(ba)
+}
+
+func boolGenerator(count uint64, opts Options) (uint64, datamodel.Node) {
+	return 0, basicnode.NewBool(rand.Float64() > 0.5)
+}
+
+func intGenerator(count uint64, opts Options) (uint64, datamodel.Node) {
+	i := rand.Int63()
+	if rand.Float64() > 0.5 {
+		i = -i
+	}
+	return 0, basicnode.NewInt(i)
+}
+
+func floatGenerator(count uint64, opts Options) (uint64, datamodel.Node) {
+	return 0, basicnode.NewFloat(math.Tan((rand.Float64() - 0.5) * math.Pi))
+}
+
+func nullGenerator(count uint64, opts Options) (uint64, datamodel.Node) {
+	return 0, datamodel.Null
+}
+
+func linkGenerator(count uint64, opts Options) (uint64, datamodel.Node) {
+	hasher := hashes[rand.Intn(len(hashes))]
+	codec := codecs[rand.Intn(len(codecs))]
+	ba := make([]byte, hasher.length/8)
+	rand.Read(ba)
+	mh, err := multihash.Encode(ba, hasher.code)
+	if err != nil {
+		panic(err)
+	}
+	return uint64(hasher.length / 8), basicnode.NewLink(cidlink.Link{Cid: cid.NewCidV1(codec, mh)})
+}
+
+type Option func(*Options)
+
+func applyOptions(opt ...Option) Options {
+	opts := Options{
+		blockSize:      100,
+		initialWeights: DefaultInitialWeights(),
+		weights:        DefaultWeights(),
+	}
+	for _, o := range opt {
+		o(&opts)
+	}
+	return opts
+}
+
+// DefaultInitialWeights provides the default map of weights that can be
+// overridden by the InitialWeights option. The default is an equal weighting
+// of 1 for every scalar kind and 10 for the recursive kinds.
+func DefaultInitialWeights() map[datamodel.Kind]int {
+	return map[datamodel.Kind]int{
+		datamodel.Kind_List:   10,
+		datamodel.Kind_Map:    10,
+		datamodel.Kind_Bool:   1,
+		datamodel.Kind_Bytes:  1,
+		datamodel.Kind_Float:  1,
+		datamodel.Kind_Int:    1,
+		datamodel.Kind_Link:   1,
+		datamodel.Kind_Null:   1,
+		datamodel.Kind_String: 1,
+	}
+}
+
+// DefaultWeights provides the default map of weights that can be overridden by
+// the Weights option. The default is an equal weighting of 1 for every kind.
+func DefaultWeights() map[datamodel.Kind]int {
+	return map[datamodel.Kind]int{
+		datamodel.Kind_List:   1,
+		datamodel.Kind_Map:    1,
+		datamodel.Kind_Bool:   1,
+		datamodel.Kind_Bytes:  1,
+		datamodel.Kind_Float:  1,
+		datamodel.Kind_Int:    1,
+		datamodel.Kind_Link:   1,
+		datamodel.Kind_Null:   1,
+		datamodel.Kind_String: 1,
+	}
+}
+
+// InitialWeights sets a per-kind weighting for the root node. That is, the weights
+// set here will determine the liklihood of the returned Node's direct .Kind().
+// These weights are ignored after the top-level Node (for recursive kinds,
+// obviously for scalar kinds there is only a top-level Node).
+//
+// The default initial weights bias toward Map and List kinds, by a ratio of
+// 10:1—i.e. the recursive kinds are more likely to appear at the top-level.
+func InitialWeights(initialWeights map[datamodel.Kind]int) Option {
+	return func(o *Options) {
+		o.initialWeights = initialWeights
+	}
+}
+
+// Weights sets a per-kind weighting for nodes appearing throughout the returned
+// graph. When assembling a graph, these weights determine the liklihood that
+// a given kind will be selected for that node.
+//
+// A weight of 0 will turn that kind off entirely. So, for example, if you
+// wanted output data with no maps or bytes, then set both of those weights to
+// zero, leaving the rest >0 and do the same for InitialWeights.
+//
+// The default weights are set to 1—i.e. there is an equal liklihood that any of
+// the valid kinds will be selected for any point in the graph.
+//
+// This option is overridden by InitialWeights (which also has a default even
+// if not set explicitly) for the top-level node.
+func Weights(weights map[datamodel.Kind]int) Option {
+	return func(o *Options) {
+		o.weights = weights
+	}
+}
+
+// TargetBlockSize sets a very rough bias in number of bytes that the resulting
+// Node may consume when encoded (i.e. the block size). This is a very
+// approximate measure, but over enough repeated Garbage() calls, the resulting
+// Nodes, once encoded, should have a median that is somewhere in this vicinity.
+//
+// The default target block size is 100. This should be tuned in accordance with
+// the anticipated average block size of the system under test.
+func TargetBlockSize(blockSize uint64) Option {
+	return func(o *Options) {
+		o.blockSize = blockSize
+	}
+}
+
+func init() {
+	kinds = append(datamodel.KindSet_Scalar, datamodel.KindSet_Recursive...)
+	runes = []rune(charset)
+	codecs = []uint64{0x55, 0x70, 0x71, 0x0129}
+	hashes = []hasher{{0x12, 256}, {0x16, 256}, {0x1b, 256}, {0xb220, 256}, {0x13, 512}, {0x15, 384}, {0x14, 512}}
+
+	generators = map[datamodel.Kind]generator{
+		datamodel.Kind_List:   listGenerator,
+		datamodel.Kind_Map:    mapGenerator,
+		datamodel.Kind_String: stringGenerator,
+		datamodel.Kind_Bytes:  bytesGenerator,
+		datamodel.Kind_Bool:   boolGenerator,
+		datamodel.Kind_Int:    intGenerator,
+		datamodel.Kind_Float:  floatGenerator,
+		datamodel.Kind_Null:   nullGenerator,
+		datamodel.Kind_Link:   linkGenerator,
+	}
+}

--- a/testutil/garbage/garbage.go
+++ b/testutil/garbage/garbage.go
@@ -2,7 +2,7 @@ package garbage
 
 import (
 	"math"
-	"math/rand"
+	mathrand "math/rand"
 	"strings"
 
 	"github.com/ipfs/go-cid"
@@ -19,7 +19,7 @@ type Options struct {
 	blockSize      uint64
 }
 
-type generator func(rand *rand.Rand, count uint64, opts Options) (uint64, datamodel.Node)
+type generator func(rand *mathrand.Rand, count uint64, opts Options) (uint64, datamodel.Node)
 
 type hasher struct {
 	code   uint64
@@ -47,13 +47,13 @@ var (
 // the randomness is stable across test runs, or a seed is captured in such a way that a failure
 // can be reproduced (e.g. by printing it to stdout during the test run so it can be captured in
 // CI for a failure).
-func Garbage(rand *rand.Rand, opts ...Option) datamodel.Node {
+func Garbage(rand *mathrand.Rand, opts ...Option) datamodel.Node {
 	options := applyOptions(opts...)
 	_, n := generate(rand, options.blockSize, options)
 	return n
 }
 
-func generate(rand *rand.Rand, count uint64, opts Options) (uint64, datamodel.Node) {
+func generate(rand *mathrand.Rand, count uint64, opts Options) (uint64, datamodel.Node) {
 	weights := opts.weights
 	if opts.initialWeights != nil {
 		weights = opts.initialWeights
@@ -74,7 +74,7 @@ func generate(rand *rand.Rand, count uint64, opts Options) (uint64, datamodel.No
 	panic("bad options")
 }
 
-func rndSize(rand *rand.Rand, bias uint64) uint64 {
+func rndSize(rand *mathrand.Rand, bias uint64) uint64 {
 	if bias == 0 {
 		panic("size shouldn't be zero")
 	}
@@ -88,11 +88,11 @@ func rndSize(rand *rand.Rand, bias uint64) uint64 {
 	}
 }
 
-func rndRune(rand *rand.Rand) rune {
+func rndRune(rand *mathrand.Rand) rune {
 	return runes[rand.Intn(len(runes))]
 }
 
-func listGenerator(rand *rand.Rand, count uint64, opts Options) (uint64, datamodel.Node) {
+func listGenerator(rand *mathrand.Rand, count uint64, opts Options) (uint64, datamodel.Node) {
 	len := rndSize(rand, 10)
 	lb := basicnode.Prototype.List.NewBuilder()
 	la, err := lb.BeginList(int64(len))
@@ -115,7 +115,7 @@ func listGenerator(rand *rand.Rand, count uint64, opts Options) (uint64, datamod
 	return size, lb.Build()
 }
 
-func mapGenerator(rand *rand.Rand, count uint64, opts Options) (uint64, datamodel.Node) {
+func mapGenerator(rand *mathrand.Rand, count uint64, opts Options) (uint64, datamodel.Node) {
 	length := rndSize(rand, 10)
 	mb := basicnode.Prototype.Map.NewBuilder()
 	ma, err := mb.BeginMap(int64(length))
@@ -157,7 +157,7 @@ func mapGenerator(rand *rand.Rand, count uint64, opts Options) (uint64, datamode
 	return size, mb.Build()
 }
 
-func stringGenerator(rand *rand.Rand, count uint64, opts Options) (uint64, datamodel.Node) {
+func stringGenerator(rand *mathrand.Rand, count uint64, opts Options) (uint64, datamodel.Node) {
 	len := rndSize(rand, count/2+1)
 	sb := strings.Builder{}
 	for i := uint64(0); i < len; i++ {
@@ -166,7 +166,7 @@ func stringGenerator(rand *rand.Rand, count uint64, opts Options) (uint64, datam
 	return len, basicnode.NewString(sb.String())
 }
 
-func bytesGenerator(rand *rand.Rand, count uint64, opts Options) (uint64, datamodel.Node) {
+func bytesGenerator(rand *mathrand.Rand, count uint64, opts Options) (uint64, datamodel.Node) {
 	len := rndSize(rand, count/2+1)
 	ba := make([]byte, len)
 	_, err := rand.Read(ba)
@@ -176,11 +176,11 @@ func bytesGenerator(rand *rand.Rand, count uint64, opts Options) (uint64, datamo
 	return len, basicnode.NewBytes(ba)
 }
 
-func boolGenerator(rand *rand.Rand, count uint64, opts Options) (uint64, datamodel.Node) {
+func boolGenerator(rand *mathrand.Rand, count uint64, opts Options) (uint64, datamodel.Node) {
 	return 0, basicnode.NewBool(rand.Float64() > 0.5)
 }
 
-func intGenerator(rand *rand.Rand, count uint64, opts Options) (uint64, datamodel.Node) {
+func intGenerator(rand *mathrand.Rand, count uint64, opts Options) (uint64, datamodel.Node) {
 	i := rand.Int63()
 	if rand.Float64() > 0.5 {
 		i = -i
@@ -188,15 +188,15 @@ func intGenerator(rand *rand.Rand, count uint64, opts Options) (uint64, datamode
 	return 0, basicnode.NewInt(i)
 }
 
-func floatGenerator(rand *rand.Rand, count uint64, opts Options) (uint64, datamodel.Node) {
+func floatGenerator(rand *mathrand.Rand, count uint64, opts Options) (uint64, datamodel.Node) {
 	return 0, basicnode.NewFloat(math.Tan((rand.Float64() - 0.5) * math.Pi))
 }
 
-func nullGenerator(rand *rand.Rand, count uint64, opts Options) (uint64, datamodel.Node) {
+func nullGenerator(rand *mathrand.Rand, count uint64, opts Options) (uint64, datamodel.Node) {
 	return 0, datamodel.Null
 }
 
-func linkGenerator(rand *rand.Rand, count uint64, opts Options) (uint64, datamodel.Node) {
+func linkGenerator(rand *mathrand.Rand, count uint64, opts Options) (uint64, datamodel.Node) {
 	hasher := hashes[rand.Intn(len(hashes))]
 	codec := codecs[rand.Intn(len(codecs))]
 	ba := make([]byte, hasher.length/8)

--- a/testutil/garbage/garbage_test.go
+++ b/testutil/garbage/garbage_test.go
@@ -1,0 +1,56 @@
+package garbage
+
+import (
+	"bytes"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/codec/dagcbor"
+	"github.com/ipld/go-ipld-prime/datamodel"
+	"github.com/ipld/go-ipld-prime/node/basicnode"
+)
+
+func TestGarbageProducesAllKinds(t *testing.T) {
+	kindCount := make(map[datamodel.Kind]int)
+	for i := 0; i < 1000; i++ {
+		gbg := Garbage()
+		kindCount[gbg.Kind()]++
+	}
+	for _, kind := range append(datamodel.KindSet_Scalar, datamodel.KindSet_Recursive...) {
+		qt.Assert(t, kindCount[kind], qt.Not(qt.Equals), 0)
+	}
+}
+
+func TestGarbageProducesValidNodes(t *testing.T) {
+	// round-trip through a codec should pick up most possible problems with Node validity
+	for i := 0; i < 1000; i++ {
+		var buf bytes.Buffer
+		gbg := Garbage()
+		err := dagcbor.Encode(gbg, &buf)
+		qt.Assert(t, err, qt.IsNil)
+		nb := basicnode.Prototype.Any.NewBuilder()
+		err = dagcbor.Decode(nb, &buf)
+		qt.Assert(t, err, qt.IsNil)
+		ipld.DeepEqual(gbg, nb.Build())
+	}
+}
+
+func TestGarbageProducesSingleKind(t *testing.T) {
+	for _, kind := range append(datamodel.KindSet_Scalar, datamodel.KindSet_Recursive...) {
+		t.Run(kind.String(), func(t *testing.T) {
+			kindCount := make(map[datamodel.Kind]int)
+			for i := 0; i < 1000; i++ {
+				gbg := Garbage(InitialWeights(map[datamodel.Kind]int{kind: 1}))
+				kindCount[gbg.Kind()]++
+			}
+			for _, k := range append(datamodel.KindSet_Scalar, datamodel.KindSet_Recursive...) {
+				if k == kind {
+					qt.Assert(t, kindCount[k], qt.Equals, 1000)
+				} else {
+					qt.Assert(t, kindCount[k], qt.Equals, 0)
+				}
+			}
+		})
+	}
+}

--- a/testutil/garbage/garbage_test.go
+++ b/testutil/garbage/garbage_test.go
@@ -2,7 +2,6 @@ package garbage
 
 import (
 	"bytes"
-	"fmt"
 	"math/rand"
 	"testing"
 	"time"
@@ -17,7 +16,7 @@ import (
 func TestGarbageProducesAllKinds(t *testing.T) {
 	kindCount := make(map[datamodel.Kind]int)
 	seed := time.Now().Unix()
-	fmt.Printf("randomness seed: %v\n", seed)
+	t.Logf("randomness seed: %v\n", seed)
 	rnd := rand.New(rand.NewSource(seed))
 	for i := 0; i < 10000; i++ {
 		gbg := Garbage(rnd)
@@ -31,7 +30,7 @@ func TestGarbageProducesAllKinds(t *testing.T) {
 func TestGarbageProducesValidNodes(t *testing.T) {
 	// round-trip through a codec should pick up most possible problems with Node validity
 	seed := time.Now().Unix()
-	fmt.Printf("randomness seed: %v\n", seed)
+	t.Logf("randomness seed: %v\n", seed)
 	rnd := rand.New(rand.NewSource(seed))
 	for i := 0; i < 1000; i++ {
 		var buf bytes.Buffer
@@ -53,7 +52,7 @@ func TestGarbageProducesSameDataForSameRandomSource(t *testing.T) {
 
 func TestGarbageProducesSingleKind(t *testing.T) {
 	seed := time.Now().Unix()
-	fmt.Printf("randomness seed: %v\n", seed)
+	t.Logf("randomness seed: %v\n", seed)
 	rnd := rand.New(rand.NewSource(seed))
 	for _, kind := range append(datamodel.KindSet_Scalar, datamodel.KindSet_Recursive...) {
 		t.Run(kind.String(), func(t *testing.T) {

--- a/testutil/garbage/garbage_test.go
+++ b/testutil/garbage/garbage_test.go
@@ -19,7 +19,7 @@ func TestGarbageProducesAllKinds(t *testing.T) {
 	t.Logf("randomness seed: %v\n", seed)
 	rnd := rand.New(rand.NewSource(seed))
 	for i := 0; i < 10000; i++ {
-		gbg := Garbage(rnd)
+		gbg := Generate(rnd)
 		kindCount[gbg.Kind()]++
 	}
 	for _, kind := range append(datamodel.KindSet_Scalar, datamodel.KindSet_Recursive...) {
@@ -34,7 +34,7 @@ func TestGarbageProducesValidNodes(t *testing.T) {
 	rnd := rand.New(rand.NewSource(seed))
 	for i := 0; i < 1000; i++ {
 		var buf bytes.Buffer
-		gbg := Garbage(rnd)
+		gbg := Generate(rnd)
 		err := dagcbor.Encode(gbg, &buf)
 		qt.Assert(t, err, qt.IsNil)
 		nb := basicnode.Prototype.Any.NewBuilder()
@@ -45,8 +45,8 @@ func TestGarbageProducesValidNodes(t *testing.T) {
 }
 
 func TestGarbageProducesSameDataForSameRandomSource(t *testing.T) {
-	gbg1 := Garbage(rand.New(rand.NewSource(1)))
-	gbg2 := Garbage(rand.New(rand.NewSource(1)))
+	gbg1 := Generate(rand.New(rand.NewSource(1)))
+	gbg2 := Generate(rand.New(rand.NewSource(1)))
 	qt.Assert(t, ipld.DeepEqual(gbg1, gbg2), qt.IsTrue)
 }
 
@@ -58,7 +58,7 @@ func TestGarbageProducesSingleKind(t *testing.T) {
 		t.Run(kind.String(), func(t *testing.T) {
 			kindCount := make(map[datamodel.Kind]int)
 			for i := 0; i < 1000; i++ {
-				gbg := Garbage(rnd, InitialWeights(map[datamodel.Kind]int{kind: 1}))
+				gbg := Generate(rnd, InitialWeights(map[datamodel.Kind]int{kind: 1}))
 				kindCount[gbg.Kind()]++
 			}
 			for _, k := range append(datamodel.KindSet_Scalar, datamodel.KindSet_Recursive...) {


### PR DESCRIPTION
Bespoke garbage on a platter for all your testing and benchmarking needs. Modelled off https://github.com/rvagg/js-ipld-garbage, in fact it should produce roughly the same style of data.

It's not perfect, and it's not comprehensive, in fact it's garbage! But it's great for those tests where you need to throw random IPLD data at an API to see if it performs as you expect.

The API may need some critique, it feels comfortable to me but maybe it's too noisy with all the options and defaults.

A sampling of 10 pieces of garbage produced by this API with defaults:

```json
-0.815284567464555
[{"/":"baguqeerail77zjrvn52jkyv4wngs2x4sersmyf5xv3utayeme3x3tkn3ofpa"}]
{"-a`=D":{"/":{"bytes":"b0z9D15daxnyhWkKMwJHalyZYgBcZkApyJ+a2ofJNNVGrw"}},"LN_":{"-e@":{"[5B":{"/":"bafkreig6zjjdnwui43lfaugakyevsws7y3xv5xsa7vwe52m5mh63yrr4im"}},"?":null,"B{$t|":true,"hb💩P\ncl(_^wQ":2173616961668878594},"p`>=☺CR@s":-229867775964419454}
"3X39t6<X!v8yVX]<*QK;,zt@N[AKk+:4}{ijx/a;d9w0](]KzhoQQh3@G_vii/AXr02+a):Ir_ZVCT-U?kAP"
[{"CQ3Y":true,"U{8Y":601134118977126642,"X>zt":-0.03877292780261173,"[{\n<5P":"g\ts","h":true},{"'jS":{"/":{"bytes":"oxqlXpJCxL1uS8okyEMuBWoAu8IVKBiyTP1j+/8VOHQENsR3uNyHC9tHug"}},";h":false},[{"/":{"bytes":"ZmmdNbZzbO8YtgU"}},true,[{"UmH>Y|\tA#baANL)☺V\\l \"XY&.IwZf\"5Q~":7659331536677889261}]]]
[null,"j3M+@5oQ@#&=`x&[2X#~pEtocvN!70Y",false,{"PBj":{"/":"bafkrkmblwiedbdwui7woqf3y7zr366ywjclrcakryxuchvabgpe7huigskipbssohvpbwbhecb2ui5omz34q"},"Qk+\tG0Z;__$q💩(y&>kNJ@tqbxX_{M-;+EX7a%wb~jx>jW~s|":-1.2811529440381588}]
{"Zu":{":P":[{"/":{"bytes":"NWGx0k7eeiSb5pgn10HD1ZFnilnoCNyMFUPZQ3yQi/ZtVl1A9w"}},[{"/":{"bytes":"cLft/x96vA"}},null,4119241249922534669,"AnD0W-💩J",null,false,{"/":"bafk2bzacecjdasurd3g3fpapupw5nog3kev7mvvolp47ignmpb654n6mwanjg"}]]},"]{#!v":-10.969517253366307,"c\n?p ☺☺":-2.069906313212865}
{"?sd5|B":true,"☺0|y.mW_X":"7 dOoM;`/G<f~S%f","☺fy ":"DxW☺6tVQ9kpXrh2D25q#JxG$^☺,~#Fos]hN%3m<_w"}
{"fE}":"u5\nW~AiOu`6quwpFE6T!pf`0yj,{ad/<-iu,HA=o.2[klwn<g☺\\!Bp9v\t\nh#~IZc-)3\"N^E2*:sl0ML\nUTikQ\n3☺","s+x31":true}
[true,-0.46664879704136397,[5117978491893449015]]
```

When I was doing some work with Filecoin chain data I used this with maps and floats turned off.