### PR TITLE
patch: first draft.

### DIFF
--- a/datamodel/path.go
+++ b/datamodel/path.go
@@ -213,6 +213,14 @@ func (p Path) Last() PathSegment {
 	return p.segments[len(p.segments)-1]
 }
 
+// Pop returns a path with all segments except the last.
+func (p Path) Pop() Path {
+	if len(p.segments) < 1 {
+		return Path{}
+	}
+	return Path{p.segments[0 : len(p.segments)-1]}
+}
+
 // Shift returns the first segment of the path together with the remaining path after that first segment.
 // If applied to a zero-length path, it returns an empty segment and the same zero-length path.
 func (p Path) Shift() (PathSegment, Path) {

--- a/traversal/patch/eval.go
+++ b/traversal/patch/eval.go
@@ -105,8 +105,14 @@ func EvalOne(n datamodel.Node, op Operation) (datamodel.Node, error) {
 		if err != nil {
 			return nil, err
 		}
-		return traversal.FocusedTransform(n, op.Path, func(_ traversal.Progress, point datamodel.Node) (datamodel.Node, error) {
+		n, err := traversal.FocusedTransform(n, op.Path, func(_ traversal.Progress, point datamodel.Node) (datamodel.Node, error) {
 			return source, nil // is this right?  what does FocusedTransform do re upsert?
+		}, false)
+		if err != nil {
+			return nil, err
+		}
+		return traversal.FocusedTransform(n, op.From, func(_ traversal.Progress, point datamodel.Node) (datamodel.Node, error) {
+			return nil, nil // Returning a nil value here means "remove what's here".
 		}, false)
 	case "copy":
 		// TODO i think you need a check that it's not landing under itself here

--- a/traversal/patch/eval.go
+++ b/traversal/patch/eval.go
@@ -39,8 +39,56 @@ func Eval(n datamodel.Node, ops []Operation) (datamodel.Node, error) {
 func EvalOne(n datamodel.Node, op Operation) (datamodel.Node, error) {
 	switch op.Op {
 	case "add":
-		return traversal.FocusedTransform(n, op.Path, func(_ traversal.Progress, point datamodel.Node) (datamodel.Node, error) {
-			return op.Value, nil // is this right?  what does FocusedTransform do re upsert?
+		// The behavior of the 'add' op in jsonpatch varies based on if the parent of the target path is a list.
+		// If the parent of the target path is a list, then 'add' is really more of an 'insert': it should slide the rest of the values down.
+		// There's also a special case for "-", which means "append to the end of the list".
+		// Otherwise, if the destination path exists, it's an error.  (No upserting.)
+		// Handling this requires looking at the parent of the destination node, so we split this into *two* traversal.FocusedTransform calls.
+		return traversal.FocusedTransform(n, op.Path.Pop(), func(prog traversal.Progress, parent datamodel.Node) (datamodel.Node, error) {
+			if parent.Kind() == datamodel.Kind_List {
+				seg := op.Path.Last()
+				var idx int64
+				if seg.String() == "-" {
+					idx = -1
+				}
+				var err error
+				idx, err = seg.Index()
+				if err != nil {
+					return nil, fmt.Errorf("patch-invalid-path-through-list: at %q", op.Path) // TODO error structuralization and review the code
+				}
+
+				nb := parent.Prototype().NewBuilder()
+				la, err := nb.BeginList(parent.Length() + 1)
+				if err != nil {
+					return nil, err
+				}
+				for itr := n.ListIterator(); !itr.Done(); {
+					i, v, err := itr.Next()
+					if err != nil {
+						return nil, err
+					}
+					if idx == i {
+						la.AssembleValue().AssignNode(op.Value)
+					}
+					if err := la.AssembleValue().AssignNode(v); err != nil {
+						return nil, err
+					}
+				}
+				// TODO: is one-past-the-end supposed to be supported or supposed to be ruled out?
+				if idx == -1 {
+					la.AssembleValue().AssignNode(op.Value)
+				}
+				if err := la.Finish(); err != nil {
+					return nil, err
+				}
+				return nb.Build(), nil
+			}
+			return prog.FocusedTransform(parent, datamodel.NewPath([]datamodel.PathSegment{op.Path.Last()}), func(prog traversal.Progress, point datamodel.Node) (datamodel.Node, error) {
+				if point != nil {
+					return nil, fmt.Errorf("patch-target-exists: at %q", op.Path) // TODO error structuralization and review the code
+				}
+				return op.Value, nil
+			}, false)
 		}, false)
 	case "remove":
 		return traversal.FocusedTransform(n, op.Path, func(_ traversal.Progress, point datamodel.Node) (datamodel.Node, error) {

--- a/traversal/patch/eval.go
+++ b/traversal/patch/eval.go
@@ -84,7 +84,7 @@ func EvalOne(n datamodel.Node, op Operation) (datamodel.Node, error) {
 				return nb.Build(), nil
 			}
 			return prog.FocusedTransform(parent, datamodel.NewPath([]datamodel.PathSegment{op.Path.Last()}), func(prog traversal.Progress, point datamodel.Node) (datamodel.Node, error) {
-				if point != nil {
+				if point != nil && !point.IsAbsent() {
 					return nil, fmt.Errorf("patch-target-exists: at %q", op.Path) // TODO error structuralization and review the code
 				}
 				return op.Value, nil
@@ -92,7 +92,7 @@ func EvalOne(n datamodel.Node, op Operation) (datamodel.Node, error) {
 		}, false)
 	case "remove":
 		return traversal.FocusedTransform(n, op.Path, func(_ traversal.Progress, point datamodel.Node) (datamodel.Node, error) {
-			return nil, nil
+			return nil, nil // Returning a nil value here means "remove what's here".
 		}, false)
 	case "replace":
 		// TODO i think you need a check that it's not landing under itself here

--- a/traversal/patch/eval.go
+++ b/traversal/patch/eval.go
@@ -25,10 +25,10 @@ type Operation struct {
 	From  datamodel.Path // Present on 'move', 'copy'.
 }
 
-func Apply(n datamodel.Node, ops []Operation) (datamodel.Node, error) {
+func Eval(n datamodel.Node, ops []Operation) (datamodel.Node, error) {
 	var err error
 	for _, op := range ops {
-		n, err = ApplyOne(n, op)
+		n, err = EvalOne(n, op)
 		if err != nil {
 			return nil, err
 		}
@@ -36,7 +36,7 @@ func Apply(n datamodel.Node, ops []Operation) (datamodel.Node, error) {
 	return n, nil
 }
 
-func ApplyOne(n datamodel.Node, op Operation) (datamodel.Node, error) {
+func EvalOne(n datamodel.Node, op Operation) (datamodel.Node, error) {
 	switch op.Op {
 	case "add":
 		return traversal.FocusedTransform(n, op.Path, func(_ traversal.Progress, point datamodel.Node) (datamodel.Node, error) {

--- a/traversal/patch/eval.go
+++ b/traversal/patch/eval.go
@@ -1,3 +1,10 @@
+// Package patch provides an implementation of the IPLD Patch specification.
+// IPLD Patch is a system for declaratively specifying patches to a document,
+// which can then be applied to produce a new, modified document.
+//
+//
+// This package is EXPERIMENTAL; its behavior and API might change as it's still
+// in development.
 package patch
 
 import (

--- a/traversal/patch/eval.go
+++ b/traversal/patch/eval.go
@@ -38,7 +38,7 @@ func Eval(n datamodel.Node, ops []Operation) (datamodel.Node, error) {
 
 func EvalOne(n datamodel.Node, op Operation) (datamodel.Node, error) {
 	switch op.Op {
-	case "add":
+	case Op_Add:
 		// The behavior of the 'add' op in jsonpatch varies based on if the parent of the target path is a list.
 		// If the parent of the target path is a list, then 'add' is really more of an 'insert': it should slide the rest of the values down.
 		// There's also a special case for "-", which means "append to the end of the list".
@@ -133,6 +133,6 @@ func EvalOne(n datamodel.Node, op Operation) (datamodel.Node, error) {
 		}
 		return n, fmt.Errorf("test failed") // TODO real error handling and a code
 	default:
-		return nil, fmt.Errorf("misuse: invalid operation") // TODO real error handling and a code
+		return nil, fmt.Errorf("misuse: invalid operation: %s", op.Op) // TODO real error handling and a code
 	}
 }

--- a/traversal/patch/parse.go
+++ b/traversal/patch/parse.go
@@ -19,7 +19,13 @@ var ts = func() schema.TypeSystem {
 	sch, err := schemadsl.Parse("", strings.NewReader(
 		// This could be more accurately modelled as an inline union,
 		// but that seems like work, given how high the overlap is.
+		//
+		// This schema may also belong in the specs repo,
+		// but if so, we'd still replicate it here,
+		// because as a rule, we don't require the specs repo submodule be present for the source to compile (just for all the tests to run).
 		`
+		# Operation and OperationSequence are the types that describe operations (but not what to apply them on).
+		# See the Instruction type for describing both operations and what to apply them on.
 		type Operation struct {
 			op String
 			path String
@@ -27,6 +33,21 @@ var ts = func() schema.TypeSystem {
 			from optional String
 		}
 		type OperationSequence [Operation]
+
+		type Instruction struct {
+			startAt Link
+			operations OperationSequence
+			# future: optional field for adl signalling and/or other lenses
+		}
+		type InstructionResult union {
+			| Error "error"
+			| Link "result"
+		} representation keyed
+		type Error struct {
+			code String # enum forthcoming
+			message String
+			details {String:String}
+		}
 	`))
 	if err != nil {
 		panic(err)

--- a/traversal/patch/parse.go
+++ b/traversal/patch/parse.go
@@ -22,10 +22,22 @@ var ts = func() *schema.TypeSystem {
 		// but if so, we'd still replicate it here,
 		// because as a rule, we don't require the specs repo submodule be present for the source to compile (just for all the tests to run).
 		[]byte(`
+		# Op represents the kind of operation to perfrom
+		# The current set is based on the JSON Patch specification
+		# We may end up adding more operations in the future
+		type Op enum {
+			| Op_Add     ("add")
+			| Op_Remove  ("remove")
+			| Op_Replace ("replace")
+			| Op_Move    ("move")
+			| Op_Copy    ("copy")
+			| Op_Test    ("test")
+		}
+
 		# Operation and OperationSequence are the types that describe operations (but not what to apply them on).
 		# See the Instruction type for describing both operations and what to apply them on.
 		type Operation struct {
-			op String
+			op Op
 			path String
 			value optional Any
 			from optional String

--- a/traversal/patch/parse.go
+++ b/traversal/patch/parse.go
@@ -3,27 +3,25 @@ package patch
 import (
 	"bytes"
 	"io"
-	"strings"
 
+	"github.com/ipld/go-ipld-prime"
 	"github.com/ipld/go-ipld-prime/codec"
 	"github.com/ipld/go-ipld-prime/node/bindnode"
 
 	"github.com/ipld/go-ipld-prime/codec/json"
 	"github.com/ipld/go-ipld-prime/datamodel"
 	"github.com/ipld/go-ipld-prime/schema"
-	schemadmt "github.com/ipld/go-ipld-prime/schema/dmt"
-	schemadsl "github.com/ipld/go-ipld-prime/schema/dsl"
 )
 
-var ts = func() schema.TypeSystem {
-	sch, err := schemadsl.Parse("", strings.NewReader(
+var ts = func() *schema.TypeSystem {
+	ts, err := ipld.LoadSchemaBytes(
 		// This could be more accurately modelled as an inline union,
 		// but that seems like work, given how high the overlap is.
 		//
 		// This schema may also belong in the specs repo,
 		// but if so, we'd still replicate it here,
 		// because as a rule, we don't require the specs repo submodule be present for the source to compile (just for all the tests to run).
-		`
+		[]byte(`
 		# Operation and OperationSequence are the types that describe operations (but not what to apply them on).
 		# See the Instruction type for describing both operations and what to apply them on.
 		type Operation struct {
@@ -50,11 +48,6 @@ var ts = func() schema.TypeSystem {
 		}
 	`))
 	if err != nil {
-		panic(err)
-	}
-	var ts schema.TypeSystem
-	ts.Init()
-	if err := schemadmt.Compile(&ts, sch); err != nil {
 		panic(err)
 	}
 	return ts

--- a/traversal/patch/parse.go
+++ b/traversal/patch/parse.go
@@ -1,64 +1,25 @@
 package patch
 
 import (
+	_ "embed"
+
 	"bytes"
 	"io"
 
 	"github.com/ipld/go-ipld-prime"
 	"github.com/ipld/go-ipld-prime/codec"
 	"github.com/ipld/go-ipld-prime/node/bindnode"
+	"github.com/ipld/go-ipld-prime/schema"
 
 	"github.com/ipld/go-ipld-prime/codec/json"
 	"github.com/ipld/go-ipld-prime/datamodel"
-	"github.com/ipld/go-ipld-prime/schema"
 )
 
+//go:embed patch.ipldsch
+var embedSchema []byte
+
 var ts = func() *schema.TypeSystem {
-	ts, err := ipld.LoadSchemaBytes(
-		// This could be more accurately modelled as an inline union,
-		// but that seems like work, given how high the overlap is.
-		//
-		// This schema may also belong in the specs repo,
-		// but if so, we'd still replicate it here,
-		// because as a rule, we don't require the specs repo submodule be present for the source to compile (just for all the tests to run).
-		[]byte(`
-		# Op represents the kind of operation to perfrom
-		# The current set is based on the JSON Patch specification
-		# We may end up adding more operations in the future
-		type Op enum {
-			| add
-			| remove
-			| replace
-			| move
-			| copy
-			| test
-		}
-
-		# Operation and OperationSequence are the types that describe operations (but not what to apply them on).
-		# See the Instruction type for describing both operations and what to apply them on.
-		type Operation struct {
-			op Op
-			path String
-			value optional Any
-			from optional String
-		}
-		type OperationSequence [Operation]
-
-		type Instruction struct {
-			startAt Link
-			operations OperationSequence
-			# future: optional field for adl signalling and/or other lenses
-		}
-		type InstructionResult union {
-			| Error "error"
-			| Link "result"
-		} representation keyed
-		type Error struct {
-			code String # enum forthcoming
-			message String
-			details {String:String}
-		}
-	`))
+	ts, err := ipld.LoadSchemaBytes(embedSchema)
 	if err != nil {
 		panic(err)
 	}
@@ -80,11 +41,9 @@ func Parse(r io.Reader, dec codec.Decoder) ([]Operation, error) {
 	for _, opRaw := range *opsRaw {
 		// TODO check the Op string
 		op := Operation{
-			Op:   Op(opRaw.Op),
-			Path: datamodel.ParsePath(opRaw.Path),
-		}
-		if opRaw.Value != nil {
-			op.Value = *opRaw.Value
+			Op:    Op(opRaw.Op),
+			Path:  datamodel.ParsePath(opRaw.Path),
+			Value: opRaw.Value,
 		}
 		if opRaw.From != nil {
 			op.From = datamodel.ParsePath(*opRaw.From)
@@ -99,6 +58,6 @@ func Parse(r io.Reader, dec codec.Decoder) ([]Operation, error) {
 type operationRaw struct {
 	Op    string
 	Path  string
-	Value *datamodel.Node
+	Value datamodel.Node
 	From  *string
 }

--- a/traversal/patch/parse.go
+++ b/traversal/patch/parse.go
@@ -26,12 +26,12 @@ var ts = func() *schema.TypeSystem {
 		# The current set is based on the JSON Patch specification
 		# We may end up adding more operations in the future
 		type Op enum {
-			| Op_Add     ("add")
-			| Op_Remove  ("remove")
-			| Op_Replace ("replace")
-			| Op_Move    ("move")
-			| Op_Copy    ("copy")
-			| Op_Test    ("test")
+			| add
+			| remove
+			| replace
+			| move
+			| copy
+			| test
 		}
 
 		# Operation and OperationSequence are the types that describe operations (but not what to apply them on).

--- a/traversal/patch/patch.go
+++ b/traversal/patch/patch.go
@@ -1,0 +1,84 @@
+package patch
+
+import (
+	"fmt"
+
+	"github.com/ipld/go-ipld-prime/datamodel"
+	"github.com/ipld/go-ipld-prime/traversal"
+)
+
+type Op string
+
+const (
+	Op_Add     = "add"
+	Op_Remove  = "remove"
+	Op_Replace = "replace"
+	Op_Move    = "move"
+	Op_Copy    = "copy"
+	Op_Test    = "test"
+)
+
+type Operation struct {
+	Op    Op             // Always required.
+	Path  datamodel.Path // Always required.
+	Value datamodel.Node // Present on 'add', 'replace', 'test'.
+	From  datamodel.Path // Present on 'move', 'copy'.
+}
+
+func Apply(n datamodel.Node, ops []Operation) (datamodel.Node, error) {
+	var err error
+	for _, op := range ops {
+		n, err = ApplyOne(n, op)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return n, nil
+}
+
+func ApplyOne(n datamodel.Node, op Operation) (datamodel.Node, error) {
+	switch op.Op {
+	case "add":
+		return traversal.FocusedTransform(n, op.Path, func(_ traversal.Progress, point datamodel.Node) (datamodel.Node, error) {
+			return op.Value, nil // is this right?  what does FocusedTransform do re upsert?
+		}, false)
+	case "remove":
+		return traversal.FocusedTransform(n, op.Path, func(_ traversal.Progress, point datamodel.Node) (datamodel.Node, error) {
+			return nil, nil
+		}, false)
+	case "replace":
+		// TODO i think you need a check that it's not landing under itself here
+		return traversal.FocusedTransform(n, op.Path, func(_ traversal.Progress, point datamodel.Node) (datamodel.Node, error) {
+			return op.Value, nil // is this right?  what does FocusedTransform do re upsert?
+		}, false)
+	case "move":
+		// TODO i think you need a check that it's not landing under itself here
+		source, err := traversal.Get(n, op.From)
+		if err != nil {
+			return nil, err
+		}
+		return traversal.FocusedTransform(n, op.Path, func(_ traversal.Progress, point datamodel.Node) (datamodel.Node, error) {
+			return source, nil // is this right?  what does FocusedTransform do re upsert?
+		}, false)
+	case "copy":
+		// TODO i think you need a check that it's not landing under itself here
+		source, err := traversal.Get(n, op.From)
+		if err != nil {
+			return nil, err
+		}
+		return traversal.FocusedTransform(n, op.Path, func(_ traversal.Progress, point datamodel.Node) (datamodel.Node, error) {
+			return source, nil // is this right?  what does FocusedTransform do re upsert?
+		}, false)
+	case "test":
+		point, err := traversal.Get(n, op.Path)
+		if err != nil {
+			return nil, err
+		}
+		if datamodel.DeepEqual(point, op.Value) {
+			return n, nil
+		}
+		return n, fmt.Errorf("test failed") // TODO real error handling and a code
+	default:
+		return nil, fmt.Errorf("misuse: invalid operation") // TODO real error handling and a code
+	}
+}

--- a/traversal/patch/patch.ipldsch
+++ b/traversal/patch/patch.ipldsch
@@ -1,0 +1,39 @@
+# Op represents the kind of operation to perfrom
+# The current set is based on the JSON Patch specification
+# We may end up adding more operations in the future
+type Op enum {
+  | add
+  | remove
+  | replace
+  | move
+  | copy
+  | test
+}
+
+# Operation and OperationSequence are the types that describe operations (but not what to apply them on).
+# See the Instruction type for describing both operations and what to apply them on.
+type Operation struct {
+  op Op
+  path String
+  value optional Any
+  from optional String
+}
+
+type OperationSequence [Operation]
+
+type Instruction struct {
+  startAt Link
+  operations OperationSequence
+  # future: optional field for adl signalling and/or other lenses
+}
+
+type InstructionResult union {
+  | Error "error"
+  | Link "result"
+} representation keyed
+
+type Error struct {
+  code String # enum forthcoming
+  message String
+  details {String:String}
+}

--- a/traversal/patch/patch_serial.go
+++ b/traversal/patch/patch_serial.go
@@ -1,0 +1,73 @@
+package patch
+
+import (
+	"io"
+	"strings"
+
+	"github.com/ipld/go-ipld-prime/node/bindnode"
+
+	"github.com/ipld/go-ipld-prime/codec/json"
+	"github.com/ipld/go-ipld-prime/datamodel"
+	"github.com/ipld/go-ipld-prime/schema"
+	schemadmt "github.com/ipld/go-ipld-prime/schema/dmt"
+	schemadsl "github.com/ipld/go-ipld-prime/schema/dsl"
+)
+
+var ts = func() schema.TypeSystem {
+	sch, err := schemadsl.Parse("", strings.NewReader(
+		// This could be more accurately modelled as an inline union,
+		// but that seems like work, given how high the overlap is.
+		`
+		type Operation struct {
+			op String
+			path String
+			value optional Any
+			from optional String
+		}
+		type OperationList [Operation]
+	`))
+	if err != nil {
+		panic(err)
+	}
+	var ts schema.TypeSystem
+	ts.Init()
+	if err := schemadmt.Compile(&ts, sch); err != nil {
+		panic(err)
+	}
+	return ts
+}()
+
+// FIXME this should surely accept a codec.Decoder parameter
+func LoadPatch(r io.Reader) ([]Operation, error) {
+	npt := bindnode.Prototype((*[]operationRaw)(nil), ts.TypeByName("OperationList"))
+	nb := npt.Representation().NewBuilder()
+	if err := json.Decode(nb, r); err != nil {
+		return nil, err
+	}
+	opsRaw := bindnode.Unwrap(nb.Build()).(*[]operationRaw)
+	var ops []Operation
+	for _, opRaw := range *opsRaw {
+		// TODO check the Op string
+		op := Operation{
+			Op:   Op(opRaw.Op),
+			Path: datamodel.ParsePath(opRaw.Path),
+		}
+		if opRaw.Value != nil {
+			op.Value = *opRaw.Value
+		}
+		if opRaw.From != nil {
+			op.From = datamodel.ParsePath(*opRaw.From)
+		}
+		ops = append(ops, op)
+	}
+	return ops, nil
+}
+
+// operationRaw is roughly the same structure as Operation, but more amenable to serialization
+// (it doesn't use high level library types that don't have a data model equivalent).
+type operationRaw struct {
+	Op    string
+	Path  string
+	Value *datamodel.Node
+	From  *string
+}

--- a/traversal/patch/patch_test.go
+++ b/traversal/patch/patch_test.go
@@ -61,7 +61,7 @@ func testOneSpecFixtureFile(t *testing.T, filename string) {
 			// Do the thing!
 			actualResult, err := Eval(initial, ops)
 			if err != nil {
-				t.Errorf("patch did not apply: %s", err)
+				t.Fatalf("patch did not apply: %s", err)
 			}
 
 			// Serialize (and pretty print) result, so that we can diff it.

--- a/traversal/patch/patch_test.go
+++ b/traversal/patch/patch_test.go
@@ -48,7 +48,7 @@ func testOneSpecFixtureFile(t *testing.T, filename string) {
 			if err != nil {
 				t.Errorf("failed to parse fixture data: %s", err)
 			}
-			ops, err := LoadPatch(bytes.NewReader(patchBlob))
+			ops, err := ParseBytes(patchBlob, dagjson.Decode)
 			if err != nil {
 				t.Errorf("failed to parse fixture patch: %s", err)
 			}
@@ -59,7 +59,7 @@ func testOneSpecFixtureFile(t *testing.T, filename string) {
 			}
 
 			// Do the thing!
-			actualResult, err := Apply(initial, ops)
+			actualResult, err := Eval(initial, ops)
 			if err != nil {
 				t.Errorf("patch did not apply: %s", err)
 			}

--- a/traversal/patch/patch_test.go
+++ b/traversal/patch/patch_test.go
@@ -46,16 +46,16 @@ func testOneSpecFixtureFile(t *testing.T, filename string) {
 			// Parse everything.
 			initial, err := ipld.Decode(initialBlob, dagjson.Decode)
 			if err != nil {
-				t.Errorf("failed to parse fixture data: %s", err)
+				t.Fatalf("failed to parse fixture data: %s", err)
 			}
 			ops, err := ParseBytes(patchBlob, dagjson.Decode)
 			if err != nil {
-				t.Errorf("failed to parse fixture patch: %s", err)
+				t.Fatalf("failed to parse fixture patch: %s", err)
 			}
 			// We don't actually keep the decoded result object.  We're just gonna serialize the result and textually diff that instead.
 			_, err = ipld.Decode(resultBlob, dagjson.Decode)
 			if err != nil {
-				t.Errorf("failed to parse fixture data: %s", err)
+				t.Fatalf("failed to parse fixture data: %s", err)
 			}
 
 			// Do the thing!

--- a/traversal/patch/patch_test.go
+++ b/traversal/patch/patch_test.go
@@ -1,0 +1,83 @@
+package patch
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/warpfork/go-testmark"
+
+	"github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/codec"
+	"github.com/ipld/go-ipld-prime/codec/dagjson"
+)
+
+func TestSpecFixtures(t *testing.T) {
+	dir := "../../.ipld/specs/patch/fixtures/"
+	testOneSpecFixtureFile(t, dir+"fixtures-1.md")
+}
+
+func testOneSpecFixtureFile(t *testing.T, filename string) {
+	doc, err := testmark.ReadFile(filename)
+	if os.IsNotExist(err) {
+		t.Skipf("not running spec suite: %s (did you clone the submodule with the data?)", err)
+	}
+	if err != nil {
+		t.Fatalf("spec file parse failed?!: %s", err)
+	}
+
+	// Data hunk in this spec file are in "directories" of a test scenario each.
+	doc.BuildDirIndex()
+	// Data hunk in this spec file are in "directories" of a test scenario each.
+	doc.BuildDirIndex()
+	for _, dir := range doc.DirEnt.ChildrenList {
+		t.Run(dir.Name, func(t *testing.T) {
+			// Grab all the data hunks.
+			//  Each "directory" contains three piece of data:
+			//   - `initial` -- this is the "block".  It's arbitrary example data.  They're all in json (or dag-json) format, for simplicity.
+			//   - `patch` -- this is a list of patch ops.  Again, as json.
+			//   - `result` -- this is the expected result object.  Again, as json.
+			initialBlob := dir.Children["initial"].Hunk.Body
+			patchBlob := dir.Children["patch"].Hunk.Body
+			resultBlob := dir.Children["result"].Hunk.Body
+
+			// Parse everything.
+			initial, err := ipld.Decode(initialBlob, dagjson.Decode)
+			if err != nil {
+				t.Errorf("failed to parse fixture data: %s", err)
+			}
+			ops, err := LoadPatch(bytes.NewReader(patchBlob))
+			if err != nil {
+				t.Errorf("failed to parse fixture patch: %s", err)
+			}
+			// We don't actually keep the decoded result object.  We're just gonna serialize the result and textually diff that instead.
+			_, err = ipld.Decode(resultBlob, dagjson.Decode)
+			if err != nil {
+				t.Errorf("failed to parse fixture data: %s", err)
+			}
+
+			// Do the thing!
+			actualResult, err := Apply(initial, ops)
+			if err != nil {
+				t.Errorf("patch did not apply: %s", err)
+			}
+
+			// Serialize (and pretty print) result, so that we can diff it.
+			actualResultBlob, err := ipld.Encode(actualResult, dagjson.EncodeOptions{
+				EncodeLinks: true,
+				EncodeBytes: true,
+				MapSortMode: codec.MapSortMode_None,
+			}.Encode)
+			if err != nil {
+				t.Errorf("failed to reserialize result: %s", err)
+			}
+			var actualResultBlobPretty bytes.Buffer
+			json.Indent(&actualResultBlobPretty, actualResultBlob, "", "\t")
+
+			// Diff!
+			qt.Assert(t, actualResultBlobPretty.String()+"\n", qt.Equals, string(resultBlob))
+		})
+	}
+}

--- a/traversal/patch/patch_test.go
+++ b/traversal/patch/patch_test.go
@@ -30,8 +30,7 @@ func testOneSpecFixtureFile(t *testing.T, filename string) {
 
 	// Data hunk in this spec file are in "directories" of a test scenario each.
 	doc.BuildDirIndex()
-	// Data hunk in this spec file are in "directories" of a test scenario each.
-	doc.BuildDirIndex()
+
 	for _, dir := range doc.DirEnt.ChildrenList {
 		t.Run(dir.Name, func(t *testing.T) {
 			// Grab all the data hunks.

--- a/traversal/patch/patch_test.go
+++ b/traversal/patch/patch_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"os"
+	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -59,8 +60,16 @@ func testOneSpecFixtureFile(t *testing.T, filename string) {
 
 			// Do the thing!
 			actualResult, err := Eval(initial, ops)
-			if err != nil {
-				t.Fatalf("patch did not apply: %s", err)
+			if strings.HasSuffix(dir.Name, "-fail") {
+				if err == nil {
+					t.Fatalf("patch was expected to fail")
+				} else {
+					return
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("patch did not apply: %s", err)
+				}
 			}
 
 			// Serialize (and pretty print) result, so that we can diff it.


### PR DESCRIPTION
(Work in progress.)

The JSON Patch specification is pretty decent; this roughly follows it.

Most of the heavy lifting is done by shelling out to the existing
traversal.FocusedTransform functions.  We're just gluing that to a more
declarative API, which is more ready to be used via a serial API.

The performance of this system in the face of multiple patch operations
on the same target is probably abysmal.  This implementation is an MVP.
It's likely that a smarter implementation could combine more than one
operation application onto the same data build process, and thus
induce a *lot* fewer copies.  This also gets much trickier to implement
(maybe you need some patricia trees for ordering operations?  or more
mutable nodes for the duration of the computation, then ideally a way
to freeze them again at the end so we don't break other consistency?),
so it's "future work".  The goal of this changeset is probably going to
be limited in scope to getting the declarative API part hammered out.

As of this first commit, there's still several TODOs, regarding validation of
the patch instructions during their parse, generalizing the API to
support more codecs, and testing around upsets and moves and etc.