### PR TITLE
Implement option to start traversals at a path

### DIFF
--- a/traversal/fns.go
+++ b/traversal/fns.go
@@ -37,7 +37,7 @@ type Progress struct {
 		Path datamodel.Path
 		Link datamodel.Link
 	}
-	PastStartAtPath bool
+	PastStartAtPath bool                        // Indicates whether the traversal has progressed passed the StartAtPath in the config -- use to avoid path checks when inside a sub portion of a DAG that is entirely inside the "not-skipped" portion of a traversal
 	Budget          *Budget                     // If present, tracks "budgets" for how many more steps we're willing to take before we should halt.
 	SeenLinks       map[datamodel.Link]struct{} // Set used to remember which links have been visited before, if Cfg.LinkVisitOnlyOnce is true.
 }

--- a/traversal/fns.go
+++ b/traversal/fns.go
@@ -47,7 +47,7 @@ type Config struct {
 	LinkSystem                     linking.LinkSystem             // LinkSystem used for automatic link loading, and also any storing if mutation features (e.g. traversal.Transform) are used.
 	LinkTargetNodePrototypeChooser LinkTargetNodePrototypeChooser // Chooser for Node implementations to produce during automatic link traversal.
 	LinkVisitOnlyOnce              bool                           // By default, we visit across links wherever we see them again, even if we've visited them before, because the reason for visiting might be different than it was before since we got to it via a different path.  If set to true, track links we've seen before in Progress.SeenLinks and do not visit them again.  Note that sufficiently complex selectors may require valid revisiting of some links, so setting this to true can change behavior noticably and should be done with care.
-	StartAtPath                    datamodel.Path                 // allows a traversal to skip execution of everything it would traverse before a given path
+	StartAtPath                    datamodel.Path                 // If set, causes a traversal to skip forward until passing this path, and only then begins calling visit functions.  Block loads will also be skipped wherever possible.
 }
 
 type Budget struct {

--- a/traversal/fns.go
+++ b/traversal/fns.go
@@ -37,8 +37,9 @@ type Progress struct {
 		Path datamodel.Path
 		Link datamodel.Link
 	}
-	Budget    *Budget                     // If present, tracks "budgets" for how many more steps we're willing to take before we should halt.
-	SeenLinks map[datamodel.Link]struct{} // Set used to remember which links have been visited before, if Cfg.LinkVisitOnlyOnce is true.
+	PastStartAtPath bool
+	Budget          *Budget                     // If present, tracks "budgets" for how many more steps we're willing to take before we should halt.
+	SeenLinks       map[datamodel.Link]struct{} // Set used to remember which links have been visited before, if Cfg.LinkVisitOnlyOnce is true.
 }
 
 type Config struct {
@@ -46,6 +47,7 @@ type Config struct {
 	LinkSystem                     linking.LinkSystem             // LinkSystem used for automatic link loading, and also any storing if mutation features (e.g. traversal.Transform) are used.
 	LinkTargetNodePrototypeChooser LinkTargetNodePrototypeChooser // Chooser for Node implementations to produce during automatic link traversal.
 	LinkVisitOnlyOnce              bool                           // By default, we visit across links wherever we see them again, even if we've visited them before, because the reason for visiting might be different than it was before since we got to it via a different path.  If set to true, track links we've seen before in Progress.SeenLinks and do not visit them again.  Note that sufficiently complex selectors may require valid revisiting of some links, so setting this to true can change behavior noticably and should be done with care.
+	StartAtPath                    datamodel.Path                 // allows a traversal to skip execution of everything it would traverse before a given path
 }
 
 type Budget struct {

--- a/traversal/walk.go
+++ b/traversal/walk.go
@@ -181,14 +181,16 @@ func (prog Progress) walkAdv(n datamodel.Node, s selector.Selector, fn AdvVisitF
 		n = rn
 	}
 
-	// Decide if this node is matched -- do callbacks as appropriate.
-	if s.Decide(n) {
-		if err := fn(prog, n, VisitReason_SelectionMatch); err != nil {
-			return err
-		}
-	} else {
-		if err := fn(prog, n, VisitReason_SelectionCandidate); err != nil {
-			return err
+	if prog.Path.Len() >= prog.Cfg.StartAtPath.Len() || !prog.PastStartAtPath {
+		// Decide if this node is matched -- do callbacks as appropriate.
+		if s.Decide(n) {
+			if err := fn(prog, n, VisitReason_SelectionMatch); err != nil {
+				return err
+			}
+		} else {
+			if err := fn(prog, n, VisitReason_SelectionCandidate); err != nil {
+				return err
+			}
 		}
 	}
 	// If we're handling scalars (e.g. not maps and lists) we can return now.
@@ -211,10 +213,22 @@ func (prog Progress) walkAdv(n datamodel.Node, s selector.Selector, fn AdvVisitF
 }
 
 func (prog Progress) walkAdv_iterateAll(n datamodel.Node, s selector.Selector, fn AdvVisitFn) error {
+	var reachedStartAtPath bool
 	for itr := selector.NewSegmentIterator(n); !itr.Done(); {
+		if reachedStartAtPath {
+			prog.PastStartAtPath = reachedStartAtPath
+		}
 		ps, v, err := itr.Next()
 		if err != nil {
 			return err
+		}
+		if prog.Path.Len() < prog.Cfg.StartAtPath.Len() && !prog.PastStartAtPath {
+			if ps.Equals(prog.Cfg.StartAtPath.Segments()[prog.Path.Len()]) {
+				reachedStartAtPath = true
+			}
+			if !reachedStartAtPath {
+				continue
+			}
 		}
 		sNext, err := s.Explore(n, ps)
 		if err != nil {
@@ -252,7 +266,16 @@ func (prog Progress) walkAdv_iterateAll(n datamodel.Node, s selector.Selector, f
 }
 
 func (prog Progress) walkAdv_iterateSelective(n datamodel.Node, attn []datamodel.PathSegment, s selector.Selector, fn AdvVisitFn) error {
+	var reachedStartAtPath bool
 	for _, ps := range attn {
+		if prog.Path.Len() < prog.Cfg.StartAtPath.Len() {
+			if ps.Equals(prog.Cfg.StartAtPath.Segments()[prog.Path.Len()]) {
+				reachedStartAtPath = true
+			}
+			if !reachedStartAtPath {
+				continue
+			}
+		}
 		v, err := n.LookupBySegment(ps)
 		if err != nil {
 			continue


### PR DESCRIPTION
# Goals

This is an alternative way to "resume selector traversals"  - similar to https://github.com/ipld/go-ipld-prime/pull/354 - but tailored to different needs. 

https://github.com/ipld/go-ipld-prime/pull/354 is ideal for someone writing a CAR file who needs to stop on a block boundary and wants to retain information about blocks traversed so they can resume writing at a point.

This is ideal for someone who wants to maintain as little state information as possible and simply execute a selector as if it started at a specific path -- even the visits will not get called before the path. It's deal for a scenario like graphsync resumption -- where transmitting a list of "do not send these blocks" has proved quite problematic in the past (cause of the network overhead on large DAGs)

# Implementation

It's really simple: you can now set a StartAtPath on the TraversalConfig

The progress keeps an additional piece of state of whether you're "past the startup path" at which point you can just not worry about checking

The code is a wee bit imperative and tricky, but it's tested and works.

# For Discussion

Why not do it in a selector itself? Selectors are stateless and I don't believe you can execute this in a selector as a result.