### PR TITLE
Allow feature detection for `io.ReaderAt` on Bytes nodes

### DIFF
--- a/datamodel/node.go
+++ b/datamodel/node.go
@@ -168,15 +168,18 @@ type Node interface {
 }
 
 // LargeBytesNode is an optional interface extending a Bytes node that allows its
-// contents to be accessed through an io.Reader instead of a []byte slice. Use of
+// contents to be accessed through an io.ReadSeeker instead of a []byte slice. Use of
 // an io.Reader is encouraged, as it allows for streaming large byte slices
 // without allocating a large slice in memory.
 type LargeBytesNode interface {
 	Node
-	// AsLargeBytes returns an io.Reader that can be used to read the contents of the node.
+	// AsLargeBytes returns an io.ReadSeeker that can be used to read the contents of the node.
 	// Note that the presence of this method / interface does not imply that the node
 	// can always return a valid io.ReadSeeker, and the error value must also be checked
 	// for support.
+	// It is not guaranteed that all implementations will implement the full semantics of
+	// Seek, in particular, they may refuse to seek to the end of a large bytes node if
+	// it is not possible to do so efficiently.
 	AsLargeBytes() (io.ReadSeeker, error)
 }
 

--- a/datamodel/node.go
+++ b/datamodel/node.go
@@ -1,5 +1,7 @@
 package datamodel
 
+import "io"
+
 // Node represents a value in IPLD.  Any point in a tree of data is a node:
 // scalar values (like int64, string, etc) are nodes, and
 // so are recursive values (like map and list).
@@ -163,6 +165,19 @@ type Node interface {
 	//
 	// Calling this method should not cause an allocation.
 	Prototype() NodePrototype
+}
+
+// LargeBytesNode is an optional interface extending a Bytes node that allows its
+// contents to be accessed through an io.Reader instead of a []byte slice. Use of
+// an io.Reader is encouraged, as it allows for streaming large byte slices
+// without allocating a large slice in memory.
+type LargeBytesNode interface {
+	Node
+	// AsLargeBytes returns an io.Reader that can be used to read the contents of the node.
+	// Note that the presence of this method / interface does not imply that the node
+	// can always return a valid io.ReadSeeker, and the error value must also be checked
+	// for support.
+	AsLargeBytes() (io.ReadSeeker, error)
 }
 
 // NodePrototype describes a node implementation (all Node have a NodePrototype),

--- a/node/basicnode/bytes.go
+++ b/node/basicnode/bytes.go
@@ -73,6 +73,10 @@ func (plainBytes) AsLink() (datamodel.Link, error) {
 func (plainBytes) Prototype() datamodel.NodePrototype {
 	return Prototype__Bytes{}
 }
+func (pb plainBytes) ReadAt(p []byte, off int64) (n int, err error) {
+	n = copy(p, pb[off:])
+	return
+}
 
 // -- NodePrototype -->
 

--- a/node/basicnode/bytes.go
+++ b/node/basicnode/bytes.go
@@ -1,6 +1,9 @@
 package basicnode
 
 import (
+	"bytes"
+	"io"
+
 	"github.com/ipld/go-ipld-prime/datamodel"
 	"github.com/ipld/go-ipld-prime/node/mixins"
 )
@@ -73,9 +76,8 @@ func (plainBytes) AsLink() (datamodel.Link, error) {
 func (plainBytes) Prototype() datamodel.NodePrototype {
 	return Prototype__Bytes{}
 }
-func (pb plainBytes) ReadAt(p []byte, off int64) (n int, err error) {
-	n = copy(p, pb[off:])
-	return
+func (n plainBytes) AsLargeBytes() (io.ReadSeeker, error) {
+	return bytes.NewReader(n), nil
 }
 
 // -- NodePrototype -->


### PR DESCRIPTION
We can handle large bytes by allowing Bytes kinded nodes to optionally support
the `ReadAt` method thereby implementing the ReaderAt interface.

This is proposed over a distinct the reader / seeker implementation because the ReaderAt interface is stateless - it does not need the addition of a position cursor to be tracked in the node between calls, while still allowing for partial reads of the node contents.