### PR TITLE
node/bindnode: enforce pointer requirement for nullable maps

### DIFF
--- a/node/bindnode/infer.go
+++ b/node/bindnode/infer.go
@@ -135,8 +135,17 @@ func verifyCompatibility(seen map[seenEntry]bool, goType reflect.Type, schemaTyp
 		if fieldValues.Type.Kind() != reflect.Map {
 			doPanic("kind mismatch; need struct{Keys []K; Values map[K]V}")
 		}
-		verifyCompatibility(seen, fieldValues.Type.Key(), schemaType.KeyType())
-		verifyCompatibility(seen, fieldValues.Type.Elem(), schemaType.ValueType())
+		keyType := fieldValues.Type.Key()
+		verifyCompatibility(seen, keyType, schemaType.KeyType())
+
+		elemType := fieldValues.Type.Elem()
+		if schemaType.ValueIsNullable() {
+			if elemType.Kind() != reflect.Ptr {
+				doPanic("nullable types must be pointers")
+			}
+			elemType = elemType.Elem()
+		}
+		verifyCompatibility(seen, elemType, schemaType.ValueType())
 	case *schema.TypeStruct:
 		if goType.Kind() != reflect.Struct {
 			doPanic("kind mismatch; need struct")

--- a/node/bindnode/infer_test.go
+++ b/node/bindnode/infer_test.go
@@ -322,6 +322,12 @@ func TestPrototypePointerCombinations(t *testing.T) {
 		{"Link_Generic", "Link", (*datamodel.Link)(nil), `{"/": "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi"}`},
 		{"List_String", "[String]", (*[]string)(nil), `["foo", "bar"]`},
 		{"Any_Node_Int", "Any", (*datamodel.Node)(nil), `23`},
+		// TODO: reenable once we don't require pointers for nullable
+		// {"Any_Pointer_Int", "{String: nullable Any}",
+		// 	(*struct {
+		// 		Keys   []string
+		// 		Values map[string]datamodel.Node
+		// 	})(nil), `{"x":3,"y":"bar","z":[2.3,4.5]}`},
 		{"Map_String_Int", "{String:Int}", (*struct {
 			Keys   []string
 			Values map[string]int64
@@ -879,6 +885,23 @@ var verifyTests = []struct {
 				Keys   []string
 				Values string
 			})(nil), `.*type Root .*: kind mismatch;.*`},
+		},
+	},
+	{
+		name:      "MapNullableAny",
+		schemaSrc: `type Root {String:nullable Any}`,
+		goodTypes: []interface{}{
+			(*struct {
+				Keys   []string
+				Values map[string]*datamodel.Node
+			})(nil),
+		},
+		badTypes: []verifyBadType{
+			{(*string)(nil), `.*type Root .* type string: kind mismatch;.*`},
+			{(*struct {
+				Keys   []string
+				Values map[string]datamodel.Node
+			})(nil), `.*type Root .*: nullable types must be pointers`},
 		},
 	},
 	{


### PR DESCRIPTION
(see commit message)

Fixes #377.