### PR TITLE
fix(dagcbor): don't accept trailing bytes

### DIFF
--- a/codec/dagcbor/unmarshal.go
+++ b/codec/dagcbor/unmarshal.go
@@ -59,14 +59,15 @@ func (cfg DecodeOptions) Decode(na datamodel.NodeAssembler, r io.Reader) error {
 	}
 
 	var buf [1]byte
-	count, err := r.Read(buf[:])
-	if count != 0 {
-		return ErrTrailingBytes
-	}
-	if err == io.EOF {
+	_, err = io.ReadFull(r, buf[:])
+	switch err {
+	case io.EOF:
 		return nil
+	case nil:
+		return ErrTrailingBytes
+	default:
+		return err
 	}
-	return err
 }
 
 // Future work: we would like to remove the Unmarshal function,

--- a/codec/dagcbor/unmarshal_test.go
+++ b/codec/dagcbor/unmarshal_test.go
@@ -49,4 +49,10 @@ func TestFunBlocks(t *testing.T) {
 		qt.Assert(t, err, qt.IsNil)
 		qt.Assert(t, nb.Build().Kind(), qt.Equals, datamodel.Kind_Null)
 	})
+	t.Run("extra bytes", func(t *testing.T) {
+		buf := strings.NewReader("\xa0\x00")
+		nb := basicnode.Prototype.Any.NewBuilder()
+		err := Decode(nb, buf)
+		qt.Assert(t, err, qt.Equals, ErrTrailingBytes)
+	})
 }

--- a/node/bindnode/fuzz_test.go
+++ b/node/bindnode/fuzz_test.go
@@ -238,9 +238,7 @@ func FuzzBindnodeViaDagCBOR(f *testing.F) {
 			t.Logf("decode successful: %#v", reflect.ValueOf(bindnode.Unwrap(node)).Elem().Interface())
 			reenc := marshalDagCBOR(t, node)
 			if !bytes.Equal(reenc, nodeDagCBOR) {
-				// TODO: reenable this once the dagcbor codec rejects non-canonical
-				// inputs like "00" and "a000", "0" and "a0" respectively.
-				// t.Errorf("node reencoded as %q rather than %q", reenc, nodeDagCBOR)
+				t.Errorf("node reencoded as %q rather than %q", reenc, nodeDagCBOR)
 			}
 			t.Logf("re-encode successful: %q", reenc)
 		}


### PR DESCRIPTION
Just re-using an approach that's used by the dag-json codec rather than trying to hack refmt which won't properly support this kind of inspection since it only considers complete terminal sets rather than caring about where the bytes stop.

This does mean https://github.com/ipld/go-ipld-prime/issues/374 will apply to dag-cbor too, but that's appropriate - we should be erroring here and allowing the user to opt-in (somehow!) to allowing it to go only up to the end of the terminal set and no more.

---

To try out the fuzz thing I grabbed go 1.18 and ran `go test -fuzz=FuzzBindnodeViaDagCBOR` in `node/bindnode` to make it run and the `a000` case is fixed there, but it still fails:

```
fuzz: elapsed: 0s, gathering baseline coverage: 0/25 completed
fuzz: elapsed: 0s, gathering baseline coverage: 25/25 completed, now fuzzing with 16 workers
fuzz: minimizing 112-byte failing input file
fuzz: elapsed: 0s, minimizing
--- FAIL: FuzzBindnodeViaDagCBOR (0.37s)
    --- FAIL: FuzzBindnodeViaDagCBOR (0.00s)
        fuzz_test.go:165: schema in dag-cbor: a1657479706573a164526f6f74a1636d6170a2676b65795479706566537472696e676976616c75655479706563496e74
        fuzz_test.go:166: node in dag-cbor: a2615830613030
        fuzz_test.go:167: schema in dag-json: {"types":{"Root":{"map":{"keyType":"String","valueType":"Int"}}}}
        fuzz_test.go:176: node in dag-json: {"0":-17,"X":-17}
        fuzz_test.go:219: decode and encode roundtrip with dag-cbor repr=false
        fuzz_test.go:238: decode successful: struct { Keys []string; Values map[string]int }{Keys:[]string{"X", "0"}, Values:map[string]int{"0":-17, "X":-17}}
        fuzz_test.go:241: node reencoded as "\xa2a00aX0" rather than "\xa2aX0a00"
        fuzz_test.go:243: re-encode successful: "\xa2a00aX0"
        fuzz_test.go:219: decode and encode roundtrip with dag-cbor repr=true
        fuzz_test.go:238: decode successful: struct { Keys []string; Values map[string]int }{Keys:[]string{"X", "0"}, Values:map[string]int{"0":-17, "X":-17}}
        fuzz_test.go:241: node reencoded as "\xa2a00aX0" rather than "\xa2aX0a00"
        fuzz_test.go:243: re-encode successful: "\xa2a00aX0"
    
    Failing input written to testdata/fuzz/FuzzBindnodeViaDagCBOR/11124a93392709940afb28dd60fecc9841776627a436091b4b9d09da57a97905
    To re-run:
    go test -run=FuzzBindnodeViaDagCBOR/11124a93392709940afb28dd60fecc9841776627a436091b4b9d09da57a97905
FAIL
exit status 1
FAIL    github.com/ipld/go-ipld-prime/node/bindnode     0.557s
```

is that expected?