### PR TITLE
FIXME: node/bindnode: add fuzz failure with dag-cbor floats

### DIFF
--- a/node/bindnode/testdata/fuzz/FuzzBindnodeViaDagCBOR/15d6928da0570d594343d02b06036af5319c7c19f213934e0e3610a829591dd0
+++ b/node/bindnode/testdata/fuzz/FuzzBindnodeViaDagCBOR/15d6928da0570d594343d02b06036af5319c7c19f213934e0e3610a829591dd0
@@ -1,0 +1,3 @@
+go test fuzz v1
+[]byte("\xa1etypes\xa1dRoot\xa1cint\xa0")
+[]byte("8\x00")

--- a/node/bindnode/testdata/fuzz/FuzzBindnodeViaDagCBOR/fe2623e7accd5d812c4d2c7869769788f2fc7676cd908427f33bce937be65094
+++ b/node/bindnode/testdata/fuzz/FuzzBindnodeViaDagCBOR/fe2623e7accd5d812c4d2c7869769788f2fc7676cd908427f33bce937be65094
@@ -1,0 +1,3 @@
+go test fuzz v1
+[]byte("\xa1etypes\xa1dRoot\xa1cmap\xa2gkeyTypefStringivalueTypeeFloat")
+[]byte("\xa2a0\xfb00000000a1\xf900")


### PR DESCRIPTION
(see commit message)

