### PR TITLE
Disable gen-go parallelism when testing on macos to enable macos in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
         # TODO(mvdan): fix and enable windows
         # TODO(mvdan): mac seems to timeout too often
         # os: [ubuntu-latest, macos-latest, windows-latest]
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Install Go

--- a/schema/gen/go/testLinks_test.go
+++ b/schema/gen/go/testLinks_test.go
@@ -1,13 +1,16 @@
 package gengo
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/ipld/go-ipld-prime/node/tests"
 )
 
 func TestLinks(t *testing.T) {
-	t.Parallel()
+	if runtime.GOOS != "darwin" { // TODO: enable parallelism on macos
+		t.Parallel()
+	}
 
 	engine := &genAndCompileEngine{prefix: "links"}
 	tests.SchemaTestLinks(t, engine)

--- a/schema/gen/go/testLists_test.go
+++ b/schema/gen/go/testLists_test.go
@@ -1,6 +1,7 @@
 package gengo
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/ipld/go-ipld-prime/node/tests"
@@ -8,7 +9,9 @@ import (
 )
 
 func TestListsContainingMaybe(t *testing.T) {
-	t.Parallel()
+	if runtime.GOOS != "darwin" { // TODO: enable parallelism on macos
+		t.Parallel()
+	}
 
 	for _, engine := range []*genAndCompileEngine{
 		{
@@ -34,7 +37,9 @@ func TestListsContainingMaybe(t *testing.T) {
 }
 
 func TestListsContainingLists(t *testing.T) {
-	t.Parallel()
+	if runtime.GOOS != "darwin" { // TODO: enable parallelism on macos
+		t.Parallel()
+	}
 
 	engine := &genAndCompileEngine{prefix: "lists-of-lists"}
 	tests.SchemaTestListsContainingLists(t, engine)

--- a/schema/gen/go/testMaps_test.go
+++ b/schema/gen/go/testMaps_test.go
@@ -1,6 +1,7 @@
 package gengo
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/ipld/go-ipld-prime/node/tests"
@@ -8,7 +9,9 @@ import (
 )
 
 func TestMapsContainingMaybe(t *testing.T) {
-	t.Parallel()
+	if runtime.GOOS != "darwin" { // TODO: enable parallelism on macos
+		t.Parallel()
+	}
 
 	for _, engine := range []*genAndCompileEngine{
 		{
@@ -33,14 +36,18 @@ func TestMapsContainingMaybe(t *testing.T) {
 }
 
 func TestMapsContainingMaps(t *testing.T) {
-	t.Parallel()
+	if runtime.GOOS != "darwin" { // TODO: enable parallelism on macos
+		t.Parallel()
+	}
 
 	engine := &genAndCompileEngine{prefix: "maps-recursive"}
 	tests.SchemaTestMapsContainingMaps(t, engine)
 }
 
 func TestMapsWithComplexKeys(t *testing.T) {
-	t.Parallel()
+	if runtime.GOOS != "darwin" { // TODO: enable parallelism on macos
+		t.Parallel()
+	}
 
 	engine := &genAndCompileEngine{prefix: "maps-cmplx-keys"}
 	tests.SchemaTestMapsWithComplexKeys(t, engine)

--- a/schema/gen/go/testScalars_test.go
+++ b/schema/gen/go/testScalars_test.go
@@ -1,13 +1,16 @@
 package gengo
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/ipld/go-ipld-prime/node/tests"
 )
 
 func TestScalars(t *testing.T) {
-	t.Parallel()
+	if runtime.GOOS != "darwin" { // TODO: enable parallelism on macos
+		t.Parallel()
+	}
 
 	engine := &genAndCompileEngine{prefix: "scalars"}
 	tests.SchemaTestScalars(t, engine)

--- a/schema/gen/go/testStructReprStringjoin_test.go
+++ b/schema/gen/go/testStructReprStringjoin_test.go
@@ -1,13 +1,16 @@
 package gengo
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/ipld/go-ipld-prime/node/tests"
 )
 
 func TestStructReprStringjoin(t *testing.T) {
-	t.Parallel()
+	if runtime.GOOS != "darwin" { // TODO: enable parallelism on macos
+		t.Parallel()
+	}
 
 	engine := &genAndCompileEngine{prefix: "struct-str-join"}
 	tests.SchemaTestStructReprStringjoin(t, engine)

--- a/schema/gen/go/testStructReprTuple_test.go
+++ b/schema/gen/go/testStructReprTuple_test.go
@@ -1,13 +1,16 @@
 package gengo
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/ipld/go-ipld-prime/node/tests"
 )
 
 func TestStructReprTuple(t *testing.T) {
-	t.Parallel()
+	if runtime.GOOS != "darwin" { // TODO: enable parallelism on macos
+		t.Parallel()
+	}
 
 	engine := &genAndCompileEngine{prefix: "struct-tuple"}
 	tests.SchemaTestStructReprTuple(t, engine)

--- a/schema/gen/go/testStruct_test.go
+++ b/schema/gen/go/testStruct_test.go
@@ -1,13 +1,16 @@
 package gengo
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/ipld/go-ipld-prime/node/tests"
 )
 
 func TestRequiredFields(t *testing.T) {
-	t.Parallel()
+	if runtime.GOOS != "darwin" { // TODO: enable parallelism on macos
+		t.Parallel()
+	}
 
 	engine := &genAndCompileEngine{prefix: "struct-required-fields"}
 	tests.SchemaTestRequiredFields(t, engine)

--- a/schema/gen/go/testStructsContainingMaybe_test.go
+++ b/schema/gen/go/testStructsContainingMaybe_test.go
@@ -1,6 +1,7 @@
 package gengo
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/ipld/go-ipld-prime/node/tests"
@@ -8,7 +9,9 @@ import (
 )
 
 func TestStructsContainingMaybe(t *testing.T) {
-	t.Parallel()
+	if runtime.GOOS != "darwin" { // TODO: enable parallelism on macos
+		t.Parallel()
+	}
 
 	for _, engine := range []*genAndCompileEngine{
 		{

--- a/schema/gen/go/testUnionsKinded_test.go
+++ b/schema/gen/go/testUnionsKinded_test.go
@@ -1,6 +1,7 @@
 package gengo
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/ipld/go-ipld-prime/node/tests"
@@ -8,7 +9,9 @@ import (
 )
 
 func TestUnionKinded(t *testing.T) {
-	t.Parallel()
+	if runtime.GOOS != "darwin" { // TODO: enable parallelism on macos
+		t.Parallel()
+	}
 
 	for _, engine := range []*genAndCompileEngine{
 		{

--- a/schema/gen/go/testUnionsStringprefix_test.go
+++ b/schema/gen/go/testUnionsStringprefix_test.go
@@ -1,6 +1,7 @@
 package gengo
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/ipld/go-ipld-prime/node/tests"
@@ -8,7 +9,9 @@ import (
 )
 
 func TestUnionStringprefix(t *testing.T) {
-	t.Parallel()
+	if runtime.GOOS != "darwin" { // TODO: enable parallelism on macos
+		t.Parallel()
+	}
 
 	for _, engine := range []*genAndCompileEngine{
 		{

--- a/schema/gen/go/testUnions_test.go
+++ b/schema/gen/go/testUnions_test.go
@@ -1,6 +1,7 @@
 package gengo
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/ipld/go-ipld-prime/node/tests"
@@ -8,7 +9,9 @@ import (
 )
 
 func TestUnionKeyed(t *testing.T) {
-	t.Parallel()
+	if runtime.GOOS != "darwin" { // TODO: enable parallelism on macos
+		t.Parallel()
+	}
 
 	for _, engine := range []*genAndCompileEngine{
 		{
@@ -33,7 +36,9 @@ func TestUnionKeyed(t *testing.T) {
 }
 
 func TestUnionKeyedComplexChildren(t *testing.T) {
-	t.Parallel()
+	if runtime.GOOS != "darwin" { // TODO: enable parallelism on macos
+		t.Parallel()
+	}
 
 	for _, engine := range []*genAndCompileEngine{
 		{
@@ -58,7 +63,9 @@ func TestUnionKeyedComplexChildren(t *testing.T) {
 }
 
 func TestUnionKeyedReset(t *testing.T) {
-	t.Parallel()
+	if runtime.GOOS != "darwin" { // TODO: enable parallelism on macos
+		t.Parallel()
+	}
 
 	for _, engine := range []*genAndCompileEngine{
 		{


### PR DESCRIPTION
There's an underlying bug (or set of them) here that is causing problems on macos. A temporary fix to get macos into CI is to disable the parallelism but we really need to find the real cause and fix that.

It'd be nice to be able to iterate toward being able to enable the unified-ci setup here and this is one of the main blockers I believe (Windows is another story).

Ref: https://github.com/ipld/go-ipld-prime/issues/79