### PR TITLE
schema: enable inline types through dsl parser & compiler

### DIFF
--- a/schema/dmt/compile.go
+++ b/schema/dmt/compile.go
@@ -78,9 +78,18 @@ func todoAnonTypeName(nameOrDefn TypeNameOrInlineDefn) string {
 	case defn.TypeDefnList != nil:
 		defn := defn.TypeDefnList
 		return fmt.Sprintf("List__%s", todoAnonTypeName(defn.ValueType))
+	case defn.TypeDefnLink != nil:
+		return todoAnonLinkName(*defn.TypeDefnLink)
 	default:
 		panic(fmt.Errorf("%#v", defn))
 	}
+}
+
+func todoAnonLinkName(defn TypeDefnLink) string {
+	if defn.ExpectedType != nil {
+		return fmt.Sprintf("Link__%s", *defn.ExpectedType)
+	}
+	return "Link__Link"
 }
 
 func parseKind(s string) datamodel.Kind {
@@ -124,8 +133,20 @@ func spawnType(ts *schema.TypeSystem, name schema.TypeName, defn TypeDefn) (sche
 
 	case defn.TypeDefnList != nil:
 		typ := defn.TypeDefnList
-		if typ.ValueType.InlineDefn != nil {
-			return nil, fmt.Errorf("TODO: support anonymous types in schema package")
+		tname := ""
+		if typ.ValueType.TypeName != nil {
+			tname = *typ.ValueType.TypeName
+		} else if tname = todoAnonTypeName(typ.ValueType); ts.TypeByName(tname) == nil {
+			anonDefn := TypeDefn{
+				TypeDefnMap:  typ.ValueType.InlineDefn.TypeDefnMap,
+				TypeDefnList: typ.ValueType.InlineDefn.TypeDefnList,
+				TypeDefnLink: typ.ValueType.InlineDefn.TypeDefnLink,
+			}
+			anonType, err := spawnType(ts, tname, anonDefn)
+			if err != nil {
+				return nil, err
+			}
+			ts.Accumulate(anonType)
 		}
 		switch {
 		case typ.Representation == nil ||
@@ -135,13 +156,25 @@ func spawnType(ts *schema.TypeSystem, name schema.TypeName, defn TypeDefn) (sche
 			return nil, fmt.Errorf("TODO: support other list repr in schema package")
 		}
 		return schema.SpawnList(name,
-			*typ.ValueType.TypeName,
+			tname,
 			todoFromImplicitlyFalseBool(typ.ValueNullable),
 		), nil
 	case defn.TypeDefnMap != nil:
 		typ := defn.TypeDefnMap
-		if typ.ValueType.InlineDefn != nil {
-			return nil, fmt.Errorf("TODO: support anonymous types in schema package")
+		tname := ""
+		if typ.ValueType.TypeName != nil {
+			tname = *typ.ValueType.TypeName
+		} else if tname = todoAnonTypeName(typ.ValueType); ts.TypeByName(tname) == nil {
+			anonDefn := TypeDefn{
+				TypeDefnMap:  typ.ValueType.InlineDefn.TypeDefnMap,
+				TypeDefnList: typ.ValueType.InlineDefn.TypeDefnList,
+				TypeDefnLink: typ.ValueType.InlineDefn.TypeDefnLink,
+			}
+			anonType, err := spawnType(ts, tname, anonDefn)
+			if err != nil {
+				return nil, err
+			}
+			ts.Accumulate(anonType)
 		}
 		switch {
 		case typ.Representation == nil ||
@@ -154,7 +187,7 @@ func spawnType(ts *schema.TypeSystem, name schema.TypeName, defn TypeDefn) (sche
 		}
 		return schema.SpawnMap(name,
 			typ.KeyType,
-			*typ.ValueType.TypeName,
+			tname,
 			todoFromImplicitlyFalseBool(typ.ValueNullable),
 		), nil
 	case defn.TypeDefnStruct != nil:
@@ -243,7 +276,18 @@ func spawnType(ts *schema.TypeSystem, name schema.TypeName, defn TypeDefn) (sche
 			if member.TypeName != nil {
 				members = append(members, *member.TypeName)
 			} else {
-				panic("TODO: inline union members")
+				tname := todoAnonLinkName(*member.UnionMemberInlineDefn.TypeDefnLink)
+				members = append(members, tname)
+				if ts.TypeByName(tname) == nil {
+					anonDefn := TypeDefn{
+						TypeDefnLink: member.UnionMemberInlineDefn.TypeDefnLink,
+					}
+					anonType, err := spawnType(ts, tname, anonDefn)
+					if err != nil {
+						return nil, err
+					}
+					ts.Accumulate(anonType)
+				}
 			}
 		}
 		remainingMembers := make(map[string]bool)
@@ -276,7 +320,9 @@ func spawnType(ts *schema.TypeSystem, name schema.TypeName, defn TypeDefn) (sche
 					validMember(memberName)
 					table[kind] = memberName
 				case member.UnionMemberInlineDefn != nil:
-					panic("TODO: inline defn support")
+					tname := todoAnonLinkName(*member.UnionMemberInlineDefn.TypeDefnLink)
+					validMember(tname)
+					table[kind] = tname
 				}
 			}
 			repr = schema.SpawnUnionRepresentationKinded(table)
@@ -291,7 +337,9 @@ func spawnType(ts *schema.TypeSystem, name schema.TypeName, defn TypeDefn) (sche
 					validMember(memberName)
 					table[key] = memberName
 				case member.UnionMemberInlineDefn != nil:
-					panic("TODO: inline defn support")
+					tname := todoAnonLinkName(*member.UnionMemberInlineDefn.TypeDefnLink)
+					validMember(tname)
+					table[key] = tname
 				}
 			}
 			repr = schema.SpawnUnionRepresentationKeyed(table)

--- a/schema/dmt/compile.go
+++ b/schema/dmt/compile.go
@@ -66,7 +66,7 @@ func todoFromImplicitlyFalseBool(b *bool) bool {
 	return *b
 }
 
-func todoAnonTypeName(nameOrDefn TypeNameOrInlineDefn) string {
+func anonTypeName(nameOrDefn TypeNameOrInlineDefn) string {
 	if nameOrDefn.TypeName != nil {
 		return *nameOrDefn.TypeName
 	}
@@ -74,18 +74,18 @@ func todoAnonTypeName(nameOrDefn TypeNameOrInlineDefn) string {
 	switch {
 	case defn.TypeDefnMap != nil:
 		defn := defn.TypeDefnMap
-		return fmt.Sprintf("Map__%s__%s", defn.KeyType, todoAnonTypeName(defn.ValueType))
+		return fmt.Sprintf("Map__%s__%s", defn.KeyType, anonTypeName(defn.ValueType))
 	case defn.TypeDefnList != nil:
 		defn := defn.TypeDefnList
-		return fmt.Sprintf("List__%s", todoAnonTypeName(defn.ValueType))
+		return fmt.Sprintf("List__%s", anonTypeName(defn.ValueType))
 	case defn.TypeDefnLink != nil:
-		return todoAnonLinkName(*defn.TypeDefnLink)
+		return anonLinkName(*defn.TypeDefnLink)
 	default:
 		panic(fmt.Errorf("%#v", defn))
 	}
 }
 
-func todoAnonLinkName(defn TypeDefnLink) string {
+func anonLinkName(defn TypeDefnLink) string {
 	if defn.ExpectedType != nil {
 		return fmt.Sprintf("Link__%s", *defn.ExpectedType)
 	}
@@ -136,7 +136,7 @@ func spawnType(ts *schema.TypeSystem, name schema.TypeName, defn TypeDefn) (sche
 		tname := ""
 		if typ.ValueType.TypeName != nil {
 			tname = *typ.ValueType.TypeName
-		} else if tname = todoAnonTypeName(typ.ValueType); ts.TypeByName(tname) == nil {
+		} else if tname = anonTypeName(typ.ValueType); ts.TypeByName(tname) == nil {
 			anonDefn := TypeDefn{
 				TypeDefnMap:  typ.ValueType.InlineDefn.TypeDefnMap,
 				TypeDefnList: typ.ValueType.InlineDefn.TypeDefnList,
@@ -164,7 +164,7 @@ func spawnType(ts *schema.TypeSystem, name schema.TypeName, defn TypeDefn) (sche
 		tname := ""
 		if typ.ValueType.TypeName != nil {
 			tname = *typ.ValueType.TypeName
-		} else if tname = todoAnonTypeName(typ.ValueType); ts.TypeByName(tname) == nil {
+		} else if tname = anonTypeName(typ.ValueType); ts.TypeByName(tname) == nil {
 			anonDefn := TypeDefn{
 				TypeDefnMap:  typ.ValueType.InlineDefn.TypeDefnMap,
 				TypeDefnList: typ.ValueType.InlineDefn.TypeDefnList,
@@ -198,7 +198,7 @@ func spawnType(ts *schema.TypeSystem, name schema.TypeName, defn TypeDefn) (sche
 			tname := ""
 			if field.Type.TypeName != nil {
 				tname = *field.Type.TypeName
-			} else if tname = todoAnonTypeName(field.Type); ts.TypeByName(tname) == nil {
+			} else if tname = anonTypeName(field.Type); ts.TypeByName(tname) == nil {
 				// Note that TypeDefn and InlineDefn aren't the same enum.
 				anonDefn := TypeDefn{
 					TypeDefnMap:  field.Type.InlineDefn.TypeDefnMap,
@@ -276,7 +276,7 @@ func spawnType(ts *schema.TypeSystem, name schema.TypeName, defn TypeDefn) (sche
 			if member.TypeName != nil {
 				members = append(members, *member.TypeName)
 			} else {
-				tname := todoAnonLinkName(*member.UnionMemberInlineDefn.TypeDefnLink)
+				tname := anonLinkName(*member.UnionMemberInlineDefn.TypeDefnLink)
 				members = append(members, tname)
 				if ts.TypeByName(tname) == nil {
 					anonDefn := TypeDefn{
@@ -320,7 +320,7 @@ func spawnType(ts *schema.TypeSystem, name schema.TypeName, defn TypeDefn) (sche
 					validMember(memberName)
 					table[kind] = memberName
 				case member.UnionMemberInlineDefn != nil:
-					tname := todoAnonLinkName(*member.UnionMemberInlineDefn.TypeDefnLink)
+					tname := anonLinkName(*member.UnionMemberInlineDefn.TypeDefnLink)
 					validMember(tname)
 					table[kind] = tname
 				}
@@ -337,7 +337,7 @@ func spawnType(ts *schema.TypeSystem, name schema.TypeName, defn TypeDefn) (sche
 					validMember(memberName)
 					table[key] = memberName
 				case member.UnionMemberInlineDefn != nil:
-					tname := todoAnonLinkName(*member.UnionMemberInlineDefn.TypeDefnLink)
+					tname := anonLinkName(*member.UnionMemberInlineDefn.TypeDefnLink)
 					validMember(tname)
 					table[key] = tname
 				}

--- a/schema/gen/go/generate.go
+++ b/schema/gen/go/generate.go
@@ -82,7 +82,7 @@ func Generate(pth string, pkgName string, ts schema.TypeSystem, adjCfg *AdjunctC
 					panic("unrecognized union representation strategy")
 				}
 			default:
-				panic("add more type switches here :)")
+				panic(fmt.Sprintf("add more type switches here :), failed at type %s", tn))
 			}
 		}
 	}


### PR DESCRIPTION
PR to ipld/ipld coming up after this for fixtures

This lets the schema parser parse things like:

```
  type LinkMap {String:&Boom}
  type MapMap {String:{String:Boom}}
  type ListMap {String:[Boom]}
```

enabled for links, maps, structs, keyed and kinded unions, for inline maps, lists and links (which have their own awkwardness)