### PR TITLE
feat: representation of full uint64 range in & out of cbor

### DIFF
--- a/codec/dagcbor/marshal.go
+++ b/codec/dagcbor/marshal.go
@@ -99,13 +99,22 @@ func marshal(n datamodel.Node, tk *tok.Token, sink shared.TokenSink, options Enc
 		_, err = sink.Step(tk)
 		return err
 	case datamodel.Kind_Int:
-		v, err := n.AsInt()
-		if err != nil {
-			return err
+		if uin, ok := n.(datamodel.UintNode); ok {
+			v, err := uin.AsUint()
+			if err != nil {
+				return err
+			}
+			tk.Type = tok.TUint
+			tk.Uint = v
+		} else {
+			v, err := n.AsInt()
+			if err != nil {
+				return err
+			}
+			tk.Type = tok.TInt
+			tk.Int = v
 		}
-		tk.Type = tok.TInt
-		tk.Int = int64(v)
-		_, err = sink.Step(tk)
+		_, err := sink.Step(tk)
 		return err
 	case datamodel.Kind_Float:
 		v, err := n.AsFloat()

--- a/datamodel/node.go
+++ b/datamodel/node.go
@@ -167,6 +167,21 @@ type Node interface {
 	Prototype() NodePrototype
 }
 
+// UintNode is an optional interface that can be used to represent an Int node
+// that provides access to the full uint64 range.
+//
+// EXPERIMENTAL: this API is experimental and may be changed or removed in a
+// future use. A future iteration may replace this with a BigInt interface to
+// access a larger range of integers that may be enabled by alternative codecs.
+type UintNode interface {
+	Node
+
+	// AsUint returns a uint64 representing the underlying integer if possible.
+	// This may return an error if the Node represents a negative integer that
+	// cannot be represented as a uint64.
+	AsUint() (uint64, error)
+}
+
 // LargeBytesNode is an optional interface extending a Bytes node that allows its
 // contents to be accessed through an io.ReadSeeker instead of a []byte slice. Use of
 // an io.Reader is encouraged, as it allows for streaming large byte slices

--- a/node/basicnode/int.go
+++ b/node/basicnode/int.go
@@ -1,26 +1,40 @@
 package basicnode
 
 import (
+	"fmt"
+	"math"
+
 	"github.com/ipld/go-ipld-prime/datamodel"
 	"github.com/ipld/go-ipld-prime/node/mixins"
 )
 
 var (
 	_ datamodel.Node          = plainInt(0)
+	_ datamodel.Node          = plainUint(0)
+	_ datamodel.UintNode      = plainUint(0)
 	_ datamodel.NodePrototype = Prototype__Int{}
 	_ datamodel.NodeBuilder   = &plainInt__Builder{}
 	_ datamodel.NodeAssembler = &plainInt__Assembler{}
 )
 
 func NewInt(value int64) datamodel.Node {
-	v := plainInt(value)
-	return &v
+	return plainInt(value)
+}
+
+// NewUint creates a new uint64-backed Node which will behave as a plain Int
+// node but also conforms to the datamodel.UintNode interface which can access
+// the full uint64 range.
+//
+// EXPERIMENTAL: this API is experimental and may be changed or removed in a
+// future release.
+func NewUint(value uint64) datamodel.Node {
+	return plainUint(value)
 }
 
 // plainInt is a simple boxed int that complies with datamodel.Node.
 type plainInt int64
 
-// -- Node interface methods -->
+// -- Node interface methods for plainInt -->
 
 func (plainInt) Kind() datamodel.Kind {
 	return datamodel.Kind_Int
@@ -72,6 +86,74 @@ func (plainInt) AsLink() (datamodel.Link, error) {
 }
 func (plainInt) Prototype() datamodel.NodePrototype {
 	return Prototype__Int{}
+}
+
+// plainUint is a simple boxed uint64 that complies with datamodel.Node,
+// allowing representation of the uint64 range above the int64 maximum via the
+// UintNode interface
+type plainUint uint64
+
+// -- Node interface methods for plainUint -->
+
+func (plainUint) Kind() datamodel.Kind {
+	return datamodel.Kind_Int
+}
+func (plainUint) LookupByString(string) (datamodel.Node, error) {
+	return mixins.Int{TypeName: "int"}.LookupByString("")
+}
+func (plainUint) LookupByNode(key datamodel.Node) (datamodel.Node, error) {
+	return mixins.Int{TypeName: "int"}.LookupByNode(nil)
+}
+func (plainUint) LookupByIndex(idx int64) (datamodel.Node, error) {
+	return mixins.Int{TypeName: "int"}.LookupByIndex(0)
+}
+func (plainUint) LookupBySegment(seg datamodel.PathSegment) (datamodel.Node, error) {
+	return mixins.Int{TypeName: "int"}.LookupBySegment(seg)
+}
+func (plainUint) MapIterator() datamodel.MapIterator {
+	return nil
+}
+func (plainUint) ListIterator() datamodel.ListIterator {
+	return nil
+}
+func (plainUint) Length() int64 {
+	return -1
+}
+func (plainUint) IsAbsent() bool {
+	return false
+}
+func (plainUint) IsNull() bool {
+	return false
+}
+func (plainUint) AsBool() (bool, error) {
+	return mixins.Int{TypeName: "int"}.AsBool()
+}
+func (n plainUint) AsInt() (int64, error) {
+	if uint64(n) > uint64(math.MaxInt64) {
+		return -1, fmt.Errorf("unsigned integer out of range of int64 type")
+	}
+	return int64(n), nil
+}
+func (plainUint) AsFloat() (float64, error) {
+	return mixins.Int{TypeName: "int"}.AsFloat()
+}
+func (plainUint) AsString() (string, error) {
+	return mixins.Int{TypeName: "int"}.AsString()
+}
+func (plainUint) AsBytes() ([]byte, error) {
+	return mixins.Int{TypeName: "int"}.AsBytes()
+}
+func (plainUint) AsLink() (datamodel.Link, error) {
+	return mixins.Int{TypeName: "int"}.AsLink()
+}
+func (plainUint) Prototype() datamodel.NodePrototype {
+	return Prototype__Int{}
+}
+
+// allows plainUint to conform to the plainUint interface
+
+func (n plainUint) AsUint() (uint64, error) {
+	return uint64(n), nil
 }
 
 // -- NodePrototype -->


### PR DESCRIPTION
I don't think I'd dare do this without Eric's OK so it's a draft for now. This _should_ allow us to access the full positive uint64 range of integers, although you can only get to it by type checking and accessing some custom methods.

I'm mainly thinking about this for bindnode, when you have a `uint64` you can actually encode and decode the full range rather than overflowing the signed bit when casting to int64 for the highest range of integers. The awkward cast to the `uintNode` shaped type wouldn't be a big deal tucked away in bindnode and it's not really something we have to advertise publicly unless folks complain and want their full range.

This doesn't handle the negative uint64 range, which cbor can do, that would require some plumbing through refmt which currently errors when it encounters a negint below int64 range.