### PR TITLE
feat(bindnode): allow custom type conversions with options

### DIFF
--- a/node/bindnode/api.go
+++ b/node/bindnode/api.go
@@ -301,7 +301,7 @@ func Wrap(ptrVal interface{}, schemaType schema.Type, options ...Option) schema.
 		// inferred.
 		verifyCompatibility(cfg, make(map[seenEntry]bool), goVal.Type(), schemaType)
 	}
-	return &_node{cfg: cfg, val: goVal, schemaType: schemaType}
+	return newNode(cfg, schemaType, goVal)
 }
 
 // TODO: consider making our own Node interface, like:

--- a/node/bindnode/api.go
+++ b/node/bindnode/api.go
@@ -145,20 +145,20 @@ type converter struct {
 
 type config map[reflect.Type]*converter
 
+// this mainly exists to short-circuit the nonPtrType() call; the `Type()` variant
+// exists for completeness
 func (c config) converterFor(val reflect.Value) *converter {
 	if len(c) == 0 {
 		return nil
 	}
-	conv, _ := c[nonPtrType(val)]
-	return conv
+	return c[nonPtrType(val)]
 }
 
 func (c config) converterForType(typ reflect.Type) *converter {
 	if len(c) == 0 {
 		return nil
 	}
-	conv, _ := c[typ]
-	return conv
+	return c[typ]
 }
 
 // Option is able to apply custom options to the bindnode API

--- a/node/bindnode/api.go
+++ b/node/bindnode/api.go
@@ -153,6 +153,14 @@ func (c config) converterFor(val reflect.Value) (converter, bool) {
 	return conv, ok
 }
 
+func (c config) converterForType(typ reflect.Type) (converter, bool) {
+	if len(c) == 0 {
+		return converter{}, false
+	}
+	conv, ok := c[typ]
+	return conv, ok
+}
+
 // Option is able to apply custom options to the bindnode API
 type Option func(config)
 

--- a/node/bindnode/api.go
+++ b/node/bindnode/api.go
@@ -174,12 +174,13 @@ type Option func(config)
 // changed in a future release.
 func TypedBoolConverter(ptrVal interface{}, from CustomFromBool, to CustomToBool) Option {
 	customType := nonPtrType(reflect.ValueOf(ptrVal))
+	converter := &converter{
+		kind:           schema.TypeKind_Bool,
+		customFromBool: from,
+		customToBool:   to,
+	}
 	return func(cfg config) {
-		cfg[customType] = &converter{
-			kind:           schema.TypeKind_Bool,
-			customFromBool: from,
-			customToBool:   to,
-		}
+		cfg[customType] = converter
 	}
 }
 
@@ -193,12 +194,13 @@ func TypedBoolConverter(ptrVal interface{}, from CustomFromBool, to CustomToBool
 // changed in a future release.
 func TypedIntConverter(ptrVal interface{}, from CustomFromInt, to CustomToInt) Option {
 	customType := nonPtrType(reflect.ValueOf(ptrVal))
+	converter := &converter{
+		kind:          schema.TypeKind_Int,
+		customFromInt: from,
+		customToInt:   to,
+	}
 	return func(cfg config) {
-		cfg[customType] = &converter{
-			kind:          schema.TypeKind_Int,
-			customFromInt: from,
-			customToInt:   to,
-		}
+		cfg[customType] = converter
 	}
 }
 
@@ -212,12 +214,13 @@ func TypedIntConverter(ptrVal interface{}, from CustomFromInt, to CustomToInt) O
 // changed in a future release.
 func TypedFloatConverter(ptrVal interface{}, from CustomFromFloat, to CustomToFloat) Option {
 	customType := nonPtrType(reflect.ValueOf(ptrVal))
+	converter := &converter{
+		kind:            schema.TypeKind_Float,
+		customFromFloat: from,
+		customToFloat:   to,
+	}
 	return func(cfg config) {
-		cfg[customType] = &converter{
-			kind:            schema.TypeKind_Float,
-			customFromFloat: from,
-			customToFloat:   to,
-		}
+		cfg[customType] = converter
 	}
 }
 
@@ -231,12 +234,13 @@ func TypedFloatConverter(ptrVal interface{}, from CustomFromFloat, to CustomToFl
 // changed in a future release.
 func TypedStringConverter(ptrVal interface{}, from CustomFromString, to CustomToString) Option {
 	customType := nonPtrType(reflect.ValueOf(ptrVal))
+	converter := &converter{
+		kind:             schema.TypeKind_String,
+		customFromString: from,
+		customToString:   to,
+	}
 	return func(cfg config) {
-		cfg[customType] = &converter{
-			kind:             schema.TypeKind_String,
-			customFromString: from,
-			customToString:   to,
-		}
+		cfg[customType] = converter
 	}
 }
 
@@ -250,12 +254,13 @@ func TypedStringConverter(ptrVal interface{}, from CustomFromString, to CustomTo
 // changed in a future release.
 func TypedBytesConverter(ptrVal interface{}, from CustomFromBytes, to CustomToBytes) Option {
 	customType := nonPtrType(reflect.ValueOf(ptrVal))
+	converter := &converter{
+		kind:            schema.TypeKind_Bytes,
+		customFromBytes: from,
+		customToBytes:   to,
+	}
 	return func(cfg config) {
-		cfg[customType] = &converter{
-			kind:            schema.TypeKind_Bytes,
-			customFromBytes: from,
-			customToBytes:   to,
-		}
+		cfg[customType] = converter
 	}
 }
 
@@ -273,12 +278,13 @@ func TypedBytesConverter(ptrVal interface{}, from CustomFromBytes, to CustomToBy
 // changed in a future release.
 func TypedLinkConverter(ptrVal interface{}, from CustomFromLink, to CustomToLink) Option {
 	customType := nonPtrType(reflect.ValueOf(ptrVal))
+	converter := &converter{
+		kind:           schema.TypeKind_Link,
+		customFromLink: from,
+		customToLink:   to,
+	}
 	return func(cfg config) {
-		cfg[customType] = &converter{
-			kind:           schema.TypeKind_Link,
-			customFromLink: from,
-			customToLink:   to,
-		}
+		cfg[customType] = converter
 	}
 }
 
@@ -295,16 +301,22 @@ func TypedLinkConverter(ptrVal interface{}, from CustomFromLink, to CustomToLink
 // changed in a future release.
 func TypedAnyConverter(ptrVal interface{}, from CustomFromAny, to CustomToAny) Option {
 	customType := nonPtrType(reflect.ValueOf(ptrVal))
+	converter := &converter{
+		kind:          schema.TypeKind_Any,
+		customFromAny: from,
+		customToAny:   to,
+	}
 	return func(cfg config) {
-		cfg[customType] = &converter{
-			kind:          schema.TypeKind_Any,
-			customFromAny: from,
-			customToAny:   to,
-		}
+		cfg[customType] = converter
 	}
 }
 
 func applyOptions(opt ...Option) config {
+	if len(opt) == 0 {
+		// no need to allocate, we access it via converterFor and converterForType
+		// which are safe for nil maps
+		return nil
+	}
 	cfg := make(map[reflect.Type]*converter)
 	for _, o := range opt {
 		o(cfg)
@@ -340,6 +352,11 @@ func Wrap(ptrVal interface{}, schemaType schema.Type, options ...Option) schema.
 	if schemaType == nil {
 		schemaType = inferSchema(goVal.Type(), 0)
 	} else {
+		// TODO(rvagg): explore ways to make this skippable by caching in the schema.Type
+		// passed in to this function; e.g. if you call Prototype(), then you've gone through
+		// this already, then calling .Type() on that could return a bindnode version of
+		// schema.Type that has the config cached and can be assumed to have been checked or
+		// inferred.
 		verifyCompatibility(cfg, make(map[seenEntry]bool), goVal.Type(), schemaType)
 	}
 	return &_node{cfg: cfg, val: goVal, schemaType: schemaType}

--- a/node/bindnode/api.go
+++ b/node/bindnode/api.go
@@ -143,39 +143,39 @@ type converter struct {
 	customToAny   CustomToAny
 }
 
-type config map[reflect.Type]converter
+type config map[reflect.Type]*converter
 
-func (c config) converterFor(val reflect.Value) (converter, bool) {
+func (c config) converterFor(val reflect.Value) *converter {
 	if len(c) == 0 {
-		return converter{}, false
+		return nil
 	}
-	conv, ok := c[nonPtrType(val)]
-	return conv, ok
+	conv, _ := c[nonPtrType(val)]
+	return conv
 }
 
-func (c config) converterForType(typ reflect.Type) (converter, bool) {
+func (c config) converterForType(typ reflect.Type) *converter {
 	if len(c) == 0 {
-		return converter{}, false
+		return nil
 	}
-	conv, ok := c[typ]
-	return conv, ok
+	conv, _ := c[typ]
+	return conv
 }
 
 // Option is able to apply custom options to the bindnode API
 type Option func(config)
 
-// AddCustomTypeBoolConverter adds custom converter functions for a particular
+// TypedBoolConverter adds custom converter functions for a particular
 // type as identified by a pointer in the first argument.
 // The fromFunc is of the form: func(bool) (interface{}, error)
 // and toFunc is of the form: func(interface{}) (bool, error)
 // where interface{} is a pointer form of the type we are converting.
 //
-// AddCustomTypeBoolConverter is an EXPERIMENTAL API and may be removed or
+// TypedBoolConverter is an EXPERIMENTAL API and may be removed or
 // changed in a future release.
-func AddCustomTypeBoolConverter(ptrVal interface{}, from CustomFromBool, to CustomToBool) Option {
+func TypedBoolConverter(ptrVal interface{}, from CustomFromBool, to CustomToBool) Option {
 	customType := nonPtrType(reflect.ValueOf(ptrVal))
 	return func(cfg config) {
-		cfg[customType] = converter{
+		cfg[customType] = &converter{
 			kind:           schema.TypeKind_Bool,
 			customFromBool: from,
 			customToBool:   to,
@@ -183,18 +183,18 @@ func AddCustomTypeBoolConverter(ptrVal interface{}, from CustomFromBool, to Cust
 	}
 }
 
-// AddCustomTypeIntConverter adds custom converter functions for a particular
+// TypedIntConverter adds custom converter functions for a particular
 // type as identified by a pointer in the first argument.
 // The fromFunc is of the form: func(int64) (interface{}, error)
 // and toFunc is of the form: func(interface{}) (int64, error)
 // where interface{} is a pointer form of the type we are converting.
 //
-// AddCustomTypeIntConverter is an EXPERIMENTAL API and may be removed or
+// TypedIntConverter is an EXPERIMENTAL API and may be removed or
 // changed in a future release.
-func AddCustomTypeIntConverter(ptrVal interface{}, from CustomFromInt, to CustomToInt) Option {
+func TypedIntConverter(ptrVal interface{}, from CustomFromInt, to CustomToInt) Option {
 	customType := nonPtrType(reflect.ValueOf(ptrVal))
 	return func(cfg config) {
-		cfg[customType] = converter{
+		cfg[customType] = &converter{
 			kind:          schema.TypeKind_Int,
 			customFromInt: from,
 			customToInt:   to,
@@ -202,18 +202,18 @@ func AddCustomTypeIntConverter(ptrVal interface{}, from CustomFromInt, to Custom
 	}
 }
 
-// AddCustomTypeFloatConverter adds custom converter functions for a particular
+// TypedFloatConverter adds custom converter functions for a particular
 // type as identified by a pointer in the first argument.
 // The fromFunc is of the form: func(float64) (interface{}, error)
 // and toFunc is of the form: func(interface{}) (float64, error)
 // where interface{} is a pointer form of the type we are converting.
 //
-// AddCustomTypeFloatConverter is an EXPERIMENTAL API and may be removed or
+// TypedFloatConverter is an EXPERIMENTAL API and may be removed or
 // changed in a future release.
-func AddCustomTypeFloatConverter(ptrVal interface{}, from CustomFromFloat, to CustomToFloat) Option {
+func TypedFloatConverter(ptrVal interface{}, from CustomFromFloat, to CustomToFloat) Option {
 	customType := nonPtrType(reflect.ValueOf(ptrVal))
 	return func(cfg config) {
-		cfg[customType] = converter{
+		cfg[customType] = &converter{
 			kind:            schema.TypeKind_Float,
 			customFromFloat: from,
 			customToFloat:   to,
@@ -221,18 +221,18 @@ func AddCustomTypeFloatConverter(ptrVal interface{}, from CustomFromFloat, to Cu
 	}
 }
 
-// AddCustomTypeStringConverter adds custom converter functions for a particular
+// TypedStringConverter adds custom converter functions for a particular
 // type as identified by a pointer in the first argument.
 // The fromFunc is of the form: func(string) (interface{}, error)
 // and toFunc is of the form: func(interface{}) (string, error)
 // where interface{} is a pointer form of the type we are converting.
 //
-// AddCustomTypeStringConverter is an EXPERIMENTAL API and may be removed or
+// TypedStringConverter is an EXPERIMENTAL API and may be removed or
 // changed in a future release.
-func AddCustomTypeStringConverter(ptrVal interface{}, from CustomFromString, to CustomToString) Option {
+func TypedStringConverter(ptrVal interface{}, from CustomFromString, to CustomToString) Option {
 	customType := nonPtrType(reflect.ValueOf(ptrVal))
 	return func(cfg config) {
-		cfg[customType] = converter{
+		cfg[customType] = &converter{
 			kind:             schema.TypeKind_String,
 			customFromString: from,
 			customToString:   to,
@@ -240,18 +240,18 @@ func AddCustomTypeStringConverter(ptrVal interface{}, from CustomFromString, to 
 	}
 }
 
-// AddCustomTypeBytesConverter adds custom converter functions for a particular
+// TypedBytesConverter adds custom converter functions for a particular
 // type as identified by a pointer in the first argument.
 // The fromFunc is of the form: func([]byte) (interface{}, error)
 // and toFunc is of the form: func(interface{}) ([]byte, error)
 // where interface{} is a pointer form of the type we are converting.
 //
-// AddCustomTypeBytesConverter is an EXPERIMENTAL API and may be removed or
+// TypedBytesConverter is an EXPERIMENTAL API and may be removed or
 // changed in a future release.
-func AddCustomTypeBytesConverter(ptrVal interface{}, from CustomFromBytes, to CustomToBytes) Option {
+func TypedBytesConverter(ptrVal interface{}, from CustomFromBytes, to CustomToBytes) Option {
 	customType := nonPtrType(reflect.ValueOf(ptrVal))
 	return func(cfg config) {
-		cfg[customType] = converter{
+		cfg[customType] = &converter{
 			kind:            schema.TypeKind_Bytes,
 			customFromBytes: from,
 			customToBytes:   to,
@@ -259,7 +259,7 @@ func AddCustomTypeBytesConverter(ptrVal interface{}, from CustomFromBytes, to Cu
 	}
 }
 
-// AddCustomTypeLinkConverter adds custom converter functions for a particular
+// TypedLinkConverter adds custom converter functions for a particular
 // type as identified by a pointer in the first argument.
 // The fromFunc is of the form: func([]byte) (interface{}, error)
 // and toFunc is of the form: func(interface{}) ([]byte, error)
@@ -269,12 +269,12 @@ func AddCustomTypeBytesConverter(ptrVal interface{}, from CustomFromBytes, to Cu
 // model and may result in errors if attempting to convert from other
 // datamodel.Link types.
 //
-// AddCustomTypeLinkConverter is an EXPERIMENTAL API and may be removed or
+// TypedLinkConverter is an EXPERIMENTAL API and may be removed or
 // changed in a future release.
-func AddCustomTypeLinkConverter(ptrVal interface{}, from CustomFromLink, to CustomToLink) Option {
+func TypedLinkConverter(ptrVal interface{}, from CustomFromLink, to CustomToLink) Option {
 	customType := nonPtrType(reflect.ValueOf(ptrVal))
 	return func(cfg config) {
-		cfg[customType] = converter{
+		cfg[customType] = &converter{
 			kind:           schema.TypeKind_Link,
 			customFromLink: from,
 			customToLink:   to,
@@ -282,7 +282,7 @@ func AddCustomTypeLinkConverter(ptrVal interface{}, from CustomFromLink, to Cust
 	}
 }
 
-// AddCustomTypeAnyConverter adds custom converter functions for a particular
+// TypedAnyConverter adds custom converter functions for a particular
 // type as identified by a pointer in the first argument.
 // The fromFunc is of the form: func(datamodel.Node) (interface{}, error)
 // and toFunc is of the form: func(interface{}) (datamodel.Node, error)
@@ -291,12 +291,12 @@ func AddCustomTypeLinkConverter(ptrVal interface{}, from CustomFromLink, to Cust
 // This method should be able to deal with all forms of Any and return an error
 // if the expected data forms don't match the expected.
 //
-// AddCustomTypeAnyConverter is an EXPERIMENTAL API and may be removed or
+// TypedAnyConverter is an EXPERIMENTAL API and may be removed or
 // changed in a future release.
-func AddCustomTypeAnyConverter(ptrVal interface{}, from CustomFromAny, to CustomToAny) Option {
+func TypedAnyConverter(ptrVal interface{}, from CustomFromAny, to CustomToAny) Option {
 	customType := nonPtrType(reflect.ValueOf(ptrVal))
 	return func(cfg config) {
-		cfg[customType] = converter{
+		cfg[customType] = &converter{
 			kind:          schema.TypeKind_Any,
 			customFromAny: from,
 			customToAny:   to,
@@ -305,7 +305,7 @@ func AddCustomTypeAnyConverter(ptrVal interface{}, from CustomFromAny, to Custom
 }
 
 func applyOptions(opt ...Option) config {
-	cfg := make(map[reflect.Type]converter)
+	cfg := make(map[reflect.Type]*converter)
 	for _, o := range opt {
 		o(cfg)
 	}

--- a/node/bindnode/api.go
+++ b/node/bindnode/api.go
@@ -60,87 +60,29 @@ func Prototype(ptrType interface{}, schemaType schema.Type, options ...Option) s
 	return &_prototype{cfg: cfg, schemaType: schemaType, goType: goType}
 }
 
-// scalar kinds excluding Null
-
-// CustomFromBool is a custom converter function that takes a bool and returns a
-// custom type
-type CustomFromBool func(bool) (interface{}, error)
-
-// CustomToBool is a custom converter function that takes a custom type and
-// returns a bool
-type CustomToBool func(interface{}) (bool, error)
-
-// CustomFromInt is a custom converter function that takes an int and returns a
-// custom type
-type CustomFromInt func(int64) (interface{}, error)
-
-// CustomToInt is a custom converter function that takes a custom type and
-// returns an int
-type CustomToInt func(interface{}) (int64, error)
-
-// CustomFromFloat is a custom converter function that takes a float and returns
-// a custom type
-type CustomFromFloat func(float64) (interface{}, error)
-
-// CustomToFloat is a custom converter function that takes a custom type and
-// returns a float
-type CustomToFloat func(interface{}) (float64, error)
-
-// CustomFromString is a custom converter function that takes a string and
-// returns custom type
-type CustomFromString func(string) (interface{}, error)
-
-// CustomToString is a custom converter function that takes a custom type and
-// returns a string
-type CustomToString func(interface{}) (string, error)
-
-// CustomFromBytes is a custom converter function that takes a byte slice and
-// returns a custom type
-type CustomFromBytes func([]byte) (interface{}, error)
-
-// CustomToBytes is a custom converter function that takes a custom type and
-// returns a byte slice
-type CustomToBytes func(interface{}) ([]byte, error)
-
-// CustomFromLink is a custom converter function that takes a cid.Cid and
-// returns a custom type
-type CustomFromLink func(cid.Cid) (interface{}, error)
-
-// CustomToLink is a custom converter function that takes a custom type and
-// returns a cid.Cid
-type CustomToLink func(interface{}) (cid.Cid, error)
-
-// CustomFromAny is a custom converter function that takes a datamodel.Node and
-// returns a custom type
-type CustomFromAny func(datamodel.Node) (interface{}, error)
-
-// CustomToAny is a custom converter function that takes a custom type and
-// returns a datamodel.Node
-type CustomToAny func(interface{}) (datamodel.Node, error)
-
 type converter struct {
 	kind schema.TypeKind
 
-	customFromBool CustomFromBool
-	customToBool   CustomToBool
+	customFromBool func(bool) (interface{}, error)
+	customToBool   func(interface{}) (bool, error)
 
-	customFromInt CustomFromInt
-	customToInt   CustomToInt
+	customFromInt func(int64) (interface{}, error)
+	customToInt   func(interface{}) (int64, error)
 
-	customFromFloat CustomFromFloat
-	customToFloat   CustomToFloat
+	customFromFloat func(float64) (interface{}, error)
+	customToFloat   func(interface{}) (float64, error)
 
-	customFromString CustomFromString
-	customToString   CustomToString
+	customFromString func(string) (interface{}, error)
+	customToString   func(interface{}) (string, error)
 
-	customFromBytes CustomFromBytes
-	customToBytes   CustomToBytes
+	customFromBytes func([]byte) (interface{}, error)
+	customToBytes   func(interface{}) ([]byte, error)
 
-	customFromLink CustomFromLink
-	customToLink   CustomToLink
+	customFromLink func(cid.Cid) (interface{}, error)
+	customToLink   func(interface{}) (cid.Cid, error)
 
-	customFromAny CustomFromAny
-	customToAny   CustomToAny
+	customFromAny func(datamodel.Node) (interface{}, error)
+	customToAny   func(interface{}) (datamodel.Node, error)
 }
 
 type config map[reflect.Type]*converter
@@ -172,7 +114,7 @@ type Option func(config)
 //
 // TypedBoolConverter is an EXPERIMENTAL API and may be removed or
 // changed in a future release.
-func TypedBoolConverter(ptrVal interface{}, from CustomFromBool, to CustomToBool) Option {
+func TypedBoolConverter(ptrVal interface{}, from func(bool) (interface{}, error), to func(interface{}) (bool, error)) Option {
 	customType := nonPtrType(reflect.ValueOf(ptrVal))
 	converter := &converter{
 		kind:           schema.TypeKind_Bool,
@@ -192,7 +134,7 @@ func TypedBoolConverter(ptrVal interface{}, from CustomFromBool, to CustomToBool
 //
 // TypedIntConverter is an EXPERIMENTAL API and may be removed or
 // changed in a future release.
-func TypedIntConverter(ptrVal interface{}, from CustomFromInt, to CustomToInt) Option {
+func TypedIntConverter(ptrVal interface{}, from func(int64) (interface{}, error), to func(interface{}) (int64, error)) Option {
 	customType := nonPtrType(reflect.ValueOf(ptrVal))
 	converter := &converter{
 		kind:          schema.TypeKind_Int,
@@ -212,7 +154,7 @@ func TypedIntConverter(ptrVal interface{}, from CustomFromInt, to CustomToInt) O
 //
 // TypedFloatConverter is an EXPERIMENTAL API and may be removed or
 // changed in a future release.
-func TypedFloatConverter(ptrVal interface{}, from CustomFromFloat, to CustomToFloat) Option {
+func TypedFloatConverter(ptrVal interface{}, from func(float64) (interface{}, error), to func(interface{}) (float64, error)) Option {
 	customType := nonPtrType(reflect.ValueOf(ptrVal))
 	converter := &converter{
 		kind:            schema.TypeKind_Float,
@@ -232,7 +174,7 @@ func TypedFloatConverter(ptrVal interface{}, from CustomFromFloat, to CustomToFl
 //
 // TypedStringConverter is an EXPERIMENTAL API and may be removed or
 // changed in a future release.
-func TypedStringConverter(ptrVal interface{}, from CustomFromString, to CustomToString) Option {
+func TypedStringConverter(ptrVal interface{}, from func(string) (interface{}, error), to func(interface{}) (string, error)) Option {
 	customType := nonPtrType(reflect.ValueOf(ptrVal))
 	converter := &converter{
 		kind:             schema.TypeKind_String,
@@ -252,7 +194,7 @@ func TypedStringConverter(ptrVal interface{}, from CustomFromString, to CustomTo
 //
 // TypedBytesConverter is an EXPERIMENTAL API and may be removed or
 // changed in a future release.
-func TypedBytesConverter(ptrVal interface{}, from CustomFromBytes, to CustomToBytes) Option {
+func TypedBytesConverter(ptrVal interface{}, from func([]byte) (interface{}, error), to func(interface{}) ([]byte, error)) Option {
 	customType := nonPtrType(reflect.ValueOf(ptrVal))
 	converter := &converter{
 		kind:            schema.TypeKind_Bytes,
@@ -276,7 +218,7 @@ func TypedBytesConverter(ptrVal interface{}, from CustomFromBytes, to CustomToBy
 //
 // TypedLinkConverter is an EXPERIMENTAL API and may be removed or
 // changed in a future release.
-func TypedLinkConverter(ptrVal interface{}, from CustomFromLink, to CustomToLink) Option {
+func TypedLinkConverter(ptrVal interface{}, from func(cid.Cid) (interface{}, error), to func(interface{}) (cid.Cid, error)) Option {
 	customType := nonPtrType(reflect.ValueOf(ptrVal))
 	converter := &converter{
 		kind:           schema.TypeKind_Link,
@@ -299,7 +241,7 @@ func TypedLinkConverter(ptrVal interface{}, from CustomFromLink, to CustomToLink
 //
 // TypedAnyConverter is an EXPERIMENTAL API and may be removed or
 // changed in a future release.
-func TypedAnyConverter(ptrVal interface{}, from CustomFromAny, to CustomToAny) Option {
+func TypedAnyConverter(ptrVal interface{}, from func(datamodel.Node) (interface{}, error), to func(interface{}) (datamodel.Node, error)) Option {
 	customType := nonPtrType(reflect.ValueOf(ptrVal))
 	converter := &converter{
 		kind:          schema.TypeKind_Any,

--- a/node/bindnode/api.go
+++ b/node/bindnode/api.go
@@ -145,6 +145,14 @@ type converter struct {
 
 type config map[reflect.Type]converter
 
+func (c config) converterFor(val reflect.Value) (converter, bool) {
+	if len(c) == 0 {
+		return converter{}, false
+	}
+	conv, ok := c[nonPtrType(val)]
+	return conv, ok
+}
+
 // Option is able to apply custom options to the bindnode API
 type Option func(config)
 

--- a/node/bindnode/api.go
+++ b/node/bindnode/api.go
@@ -7,6 +7,7 @@ package bindnode
 import (
 	"reflect"
 
+	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime/datamodel"
 	"github.com/ipld/go-ipld-prime/schema"
 )
@@ -59,10 +60,47 @@ func Prototype(ptrType interface{}, schemaType schema.Type, options ...Option) s
 	return &_prototype{cfg: cfg, schemaType: schemaType, goType: goType}
 }
 
+// scalar kinds excluding Null
+
+type CustomBool struct {
+	From func(bool) (interface{}, error)
+	To   func(interface{}) (bool, error)
+}
+
+type CustomInt struct {
+	From func(int64) (interface{}, error)
+	To   func(interface{}) (int64, error)
+}
+
+type CustomFloat struct {
+	From func(float64) (interface{}, error)
+	To   func(interface{}) (float64, error)
+}
+
+type CustomString struct {
+	From func(string) (interface{}, error)
+	To   func(interface{}) (string, error)
+}
+
+type CustomBytes struct {
+	From func([]byte) (interface{}, error)
+	To   func(interface{}) ([]byte, error)
+}
+
+type CustomLink struct {
+	From func(cid.Cid) (interface{}, error)
+	To   func(interface{}) (cid.Cid, error)
+}
+
 type converter struct {
-	kindType reflect.Type
-	fromFunc reflect.Value // func(Kind) (*Custom, error)
-	toFunc   reflect.Value // func(*Custom) (Kind, error)
+	kind datamodel.Kind
+
+	customBool   *CustomBool
+	customInt    *CustomInt
+	customFloat  *CustomFloat
+	customString *CustomString
+	customBytes  *CustomBytes
+	customLink   *CustomLink
 }
 
 type config map[reflect.Type]converter
@@ -70,47 +108,64 @@ type config map[reflect.Type]converter
 // Option is able to apply custom options to the bindnode API
 type Option func(config)
 
-var byteSliceType = reflect.TypeOf([]byte{})
-var errorType = reflect.TypeOf((*error)(nil)).Elem()
-
-// AddCustomTypeBytesConverter adds custom converter functions for a particular
-// type. The fromBytesFunc is of the form: func([]byte) (interface{}, error)
-// and toBytesFunc is of the form: func(interface{}) ([]byte, error)
-// where interface{} is a pointer form of the type we are converting.
+// AddCustomTypeConverter adds custom converter functions for a particular
+// type as identified by a pointer in the first argument.
+// The fromFunc is of the form: func(kind) (interface{}, error)
+// and toFunc is of the form: func(interface{}) (kind, error)
+// where interface{} is a pointer form of the type we are converting and "kind"
+// is a Go form of the kind being converted (bool, int64, float64, string,
+// []byte, cid.Cid).
 //
-// AddCustomTypeBytesConverter is an EXPERIMENTAL API and may be removed or
+// AddCustomTypeConverter is an EXPERIMENTAL API and may be removed or
 // changed in a future release.
-func AddCustomTypeBytesConverter(fromBytesFunc interface{}, toBytesFunc interface{}) Option {
-	fbfVal := reflect.ValueOf(fromBytesFunc)
-	fbfType := fbfVal.Type()
-	if fbfType == nil || fbfType.Kind() != reflect.Func || fbfType.IsVariadic() {
-		panic("fromBytesFunc must be a (non-varadic) function")
-	}
-	ni, no := fbfType.NumIn(), fbfType.NumOut()
-	if ni != 1 || no != 2 || fbfType.In(0) != byteSliceType || fbfType.Out(1) != errorType {
-		panic("fromBytesFunc must be of the form func([]byte) (interface{}, error)")
-	}
+func AddCustomTypeConverter(ptrValue interface{}, customConverter interface{}) Option {
+	customType := reflect.ValueOf(ptrValue).Elem().Type()
 
-	tbfVal := reflect.ValueOf(toBytesFunc)
-	tbfType := tbfVal.Type()
-	if tbfType == nil || tbfType.Kind() != reflect.Func || tbfType.IsVariadic() {
-		panic("toBytesFunc must be a (non-varadic) function")
-	}
-	ni, no = tbfType.NumIn(), tbfType.NumOut()
-	if ni != 1 || no != 2 || tbfType.Out(0) != byteSliceType || tbfType.Out(1) != errorType {
-		panic("toBytesFunc must be of the form func(interface{}) ([]byte, error)")
-	}
-
-	if fbfType.Out(0) != tbfType.In(0) {
-		panic("toBytesFunc must be of the form func(interface{}) ([]byte, error)")
-	}
-
-	customType := fbfType.Out(0)
-	if customType.Kind() == reflect.Ptr {
-		customType = customType.Elem()
-	}
-	return func(cfg config) {
-		cfg[customType] = converter{byteSliceType, fbfVal, tbfVal}
+	switch typedCustomConverter := customConverter.(type) {
+	case CustomBool:
+		return func(cfg config) {
+			cfg[customType] = converter{
+				kind:       datamodel.Kind_Bool,
+				customBool: &typedCustomConverter,
+			}
+		}
+	case CustomInt:
+		return func(cfg config) {
+			cfg[customType] = converter{
+				kind:      datamodel.Kind_Int,
+				customInt: &typedCustomConverter,
+			}
+		}
+	case CustomFloat:
+		return func(cfg config) {
+			cfg[customType] = converter{
+				kind:        datamodel.Kind_Float,
+				customFloat: &typedCustomConverter,
+			}
+		}
+	case CustomString:
+		return func(cfg config) {
+			cfg[customType] = converter{
+				kind:         datamodel.Kind_String,
+				customString: &typedCustomConverter,
+			}
+		}
+	case CustomBytes:
+		return func(cfg config) {
+			cfg[customType] = converter{
+				kind:        datamodel.Kind_Bytes,
+				customBytes: &typedCustomConverter,
+			}
+		}
+	case CustomLink:
+		return func(cfg config) {
+			cfg[customType] = converter{
+				kind:       datamodel.Kind_Link,
+				customLink: &typedCustomConverter,
+			}
+		}
+	default:
+		panic("bindnode: fromFunc for Link must match one of the CustomFromX types")
 	}
 }
 

--- a/node/bindnode/api.go
+++ b/node/bindnode/api.go
@@ -110,8 +110,16 @@ type CustomFromLink func(cid.Cid) (interface{}, error)
 // returns a cid.Cid
 type CustomToLink func(interface{}) (cid.Cid, error)
 
+// CustomFromAny is a custom converter function that takes a datamodel.Node and
+// returns a custom type
+type CustomFromAny func(datamodel.Node) (interface{}, error)
+
+// CustomToAny is a custom converter function that takes a custom type and
+// returns a datamodel.Node
+type CustomToAny func(interface{}) (datamodel.Node, error)
+
 type converter struct {
-	kind datamodel.Kind
+	kind schema.TypeKind
 
 	customFromBool CustomFromBool
 	customToBool   CustomToBool
@@ -130,6 +138,9 @@ type converter struct {
 
 	customFromLink CustomFromLink
 	customToLink   CustomToLink
+
+	customFromAny CustomFromAny
+	customToAny   CustomToAny
 }
 
 type config map[reflect.Type]converter
@@ -149,7 +160,7 @@ func AddCustomTypeBoolConverter(ptrVal interface{}, from CustomFromBool, to Cust
 	customType := nonPtrType(reflect.ValueOf(ptrVal))
 	return func(cfg config) {
 		cfg[customType] = converter{
-			kind:           datamodel.Kind_Bool,
+			kind:           schema.TypeKind_Bool,
 			customFromBool: from,
 			customToBool:   to,
 		}
@@ -168,7 +179,7 @@ func AddCustomTypeIntConverter(ptrVal interface{}, from CustomFromInt, to Custom
 	customType := nonPtrType(reflect.ValueOf(ptrVal))
 	return func(cfg config) {
 		cfg[customType] = converter{
-			kind:          datamodel.Kind_Int,
+			kind:          schema.TypeKind_Int,
 			customFromInt: from,
 			customToInt:   to,
 		}
@@ -187,7 +198,7 @@ func AddCustomTypeFloatConverter(ptrVal interface{}, from CustomFromFloat, to Cu
 	customType := nonPtrType(reflect.ValueOf(ptrVal))
 	return func(cfg config) {
 		cfg[customType] = converter{
-			kind:            datamodel.Kind_Float,
+			kind:            schema.TypeKind_Float,
 			customFromFloat: from,
 			customToFloat:   to,
 		}
@@ -206,7 +217,7 @@ func AddCustomTypeStringConverter(ptrVal interface{}, from CustomFromString, to 
 	customType := nonPtrType(reflect.ValueOf(ptrVal))
 	return func(cfg config) {
 		cfg[customType] = converter{
-			kind:             datamodel.Kind_String,
+			kind:             schema.TypeKind_String,
 			customFromString: from,
 			customToString:   to,
 		}
@@ -225,7 +236,7 @@ func AddCustomTypeBytesConverter(ptrVal interface{}, from CustomFromBytes, to Cu
 	customType := nonPtrType(reflect.ValueOf(ptrVal))
 	return func(cfg config) {
 		cfg[customType] = converter{
-			kind:            datamodel.Kind_Bytes,
+			kind:            schema.TypeKind_Bytes,
 			customFromBytes: from,
 			customToBytes:   to,
 		}
@@ -248,9 +259,31 @@ func AddCustomTypeLinkConverter(ptrVal interface{}, from CustomFromLink, to Cust
 	customType := nonPtrType(reflect.ValueOf(ptrVal))
 	return func(cfg config) {
 		cfg[customType] = converter{
-			kind:           datamodel.Kind_Link,
+			kind:           schema.TypeKind_Link,
 			customFromLink: from,
 			customToLink:   to,
+		}
+	}
+}
+
+// AddCustomTypeAnyConverter adds custom converter functions for a particular
+// type as identified by a pointer in the first argument.
+// The fromFunc is of the form: func(datamodel.Node) (interface{}, error)
+// and toFunc is of the form: func(interface{}) (datamodel.Node, error)
+// where interface{} is a pointer form of the type we are converting.
+//
+// This method should be able to deal with all forms of Any and return an error
+// if the expected data forms don't match the expected.
+//
+// AddCustomTypeAnyConverter is an EXPERIMENTAL API and may be removed or
+// changed in a future release.
+func AddCustomTypeAnyConverter(ptrVal interface{}, from CustomFromAny, to CustomToAny) Option {
+	customType := nonPtrType(reflect.ValueOf(ptrVal))
+	return func(cfg config) {
+		cfg[customType] = converter{
+			kind:          schema.TypeKind_Any,
+			customFromAny: from,
+			customToAny:   to,
 		}
 	}
 }

--- a/node/bindnode/api_test.go
+++ b/node/bindnode/api_test.go
@@ -2,6 +2,7 @@ package bindnode_test
 
 import (
 	"encoding/hex"
+	"math"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -195,5 +196,79 @@ func TestSubNodeWalkAndUnwrap(t *testing.T) {
 		qt.Assert(t, hex.EncodeToString(byts), qt.Equals, encodedHex)
 
 		verifyMap(node)
+	})
+}
+
+func TestUint64Struct(t *testing.T) {
+	t.Run("in struct", func(t *testing.T) {
+		type IntHolder struct {
+			Int32  int32
+			Int64  int64
+			Uint64 uint64
+		}
+		schema := `
+			type IntHolder struct {
+				Int32 Int
+				Int64 Int
+				Uint64 Int
+			}
+		`
+
+		maxExpectedHex := "a365496e7433321a7fffffff65496e7436341b7fffffffffffffff6655696e7436341bffffffffffffffff"
+		maxExpected, err := hex.DecodeString(maxExpectedHex)
+		qt.Assert(t, err, qt.IsNil)
+
+		typeSystem, err := ipld.LoadSchemaBytes([]byte(schema))
+		qt.Assert(t, err, qt.IsNil)
+		schemaType := typeSystem.TypeByName("IntHolder")
+		proto := bindnode.Prototype(&IntHolder{}, schemaType)
+
+		node, err := ipld.DecodeUsingPrototype([]byte(maxExpected), dagcbor.Decode, proto)
+		qt.Assert(t, err, qt.IsNil)
+
+		typ := bindnode.Unwrap(node)
+		inst, ok := typ.(*IntHolder)
+		qt.Assert(t, ok, qt.IsTrue)
+
+		qt.Assert(t, *inst, qt.DeepEquals, IntHolder{
+			Int32:  math.MaxInt32,
+			Int64:  math.MaxInt64,
+			Uint64: math.MaxUint64,
+		})
+
+		node = bindnode.Wrap(inst, schemaType).Representation()
+		byt, err := ipld.Encode(node, dagcbor.Encode)
+		qt.Assert(t, err, qt.IsNil)
+
+		qt.Assert(t, hex.EncodeToString(byt), qt.Equals, maxExpectedHex)
+	})
+
+	t.Run("plain", func(t *testing.T) {
+		type IntHolder uint64
+		schema := `type IntHolder int`
+
+		maxExpectedHex := "1bffffffffffffffff"
+		maxExpected, err := hex.DecodeString(maxExpectedHex)
+		qt.Assert(t, err, qt.IsNil)
+
+		typeSystem, err := ipld.LoadSchemaBytes([]byte(schema))
+		qt.Assert(t, err, qt.IsNil)
+		schemaType := typeSystem.TypeByName("IntHolder")
+		proto := bindnode.Prototype((*IntHolder)(nil), schemaType)
+
+		node, err := ipld.DecodeUsingPrototype([]byte(maxExpected), dagcbor.Decode, proto)
+		qt.Assert(t, err, qt.IsNil)
+
+		typ := bindnode.Unwrap(node)
+		inst, ok := typ.(*IntHolder)
+		qt.Assert(t, ok, qt.IsTrue)
+
+		qt.Assert(t, *inst, qt.Equals, IntHolder(math.MaxUint64))
+
+		node = bindnode.Wrap(inst, schemaType).Representation()
+		byt, err := ipld.Encode(node, dagcbor.Encode)
+		qt.Assert(t, err, qt.IsNil)
+
+		qt.Assert(t, hex.EncodeToString(byt), qt.Equals, maxExpectedHex)
 	})
 }

--- a/node/bindnode/custom_test.go
+++ b/node/bindnode/custom_test.go
@@ -279,13 +279,13 @@ var boomFixtureInstance = Boom{
 
 func TestCustom(t *testing.T) {
 	opts := []bindnode.Option{
-		bindnode.AddCustomTypeBytesConverter(&Boop{}, BoopFromBytes, BoopToBytes),
-		bindnode.AddCustomTypeBytesConverter(&Frop{}, FropFromBytes, FropToBytes),
-		bindnode.AddCustomTypeBoolConverter(BoolSubst(0), BoolSubstFromBool, BoolToBoolSubst),
-		bindnode.AddCustomTypeIntConverter(IntSubst(""), IntSubstFromInt, IntToIntSubst),
-		bindnode.AddCustomTypeFloatConverter(&BigFloat{}, BigFloatFromFloat, FloatFromBigFloat),
-		bindnode.AddCustomTypeStringConverter(&ByteArray{}, ByteArrayFromString, StringFromByteArray),
-		bindnode.AddCustomTypeLinkConverter(BtcId(""), FromCidToBtcId, FromBtcIdToCid),
+		bindnode.TypedBytesConverter(&Boop{}, BoopFromBytes, BoopToBytes),
+		bindnode.TypedBytesConverter(&Frop{}, FropFromBytes, FropToBytes),
+		bindnode.TypedBoolConverter(BoolSubst(0), BoolSubstFromBool, BoolToBoolSubst),
+		bindnode.TypedIntConverter(IntSubst(""), IntSubstFromInt, IntToIntSubst),
+		bindnode.TypedFloatConverter(&BigFloat{}, BigFloatFromFloat, FloatFromBigFloat),
+		bindnode.TypedStringConverter(&ByteArray{}, ByteArrayFromString, StringFromByteArray),
+		bindnode.TypedLinkConverter(BtcId(""), FromCidToBtcId, FromBtcIdToCid),
 	}
 
 	typeSystem, err := ipld.LoadSchemaBytes([]byte(boomSchema))
@@ -472,9 +472,9 @@ var anyExtendFixtureInstance = AnyExtend{
 
 func TestCustomAny(t *testing.T) {
 	opts := []bindnode.Option{
-		bindnode.AddCustomTypeAnyConverter(&AnyExtendBlob{}, AnyExtendBlobFromNode, AnyExtendBlobToNode),
-		bindnode.AddCustomTypeAnyConverter(&AnyCborEncoded{}, AnyCborEncodedFromNode, AnyCborEncodedToNode),
-		bindnode.AddCustomTypeBoolConverter(BoolSubst(0), BoolSubstFromBool, BoolToBoolSubst),
+		bindnode.TypedAnyConverter(&AnyExtendBlob{}, AnyExtendBlobFromNode, AnyExtendBlobToNode),
+		bindnode.TypedAnyConverter(&AnyCborEncoded{}, AnyCborEncodedFromNode, AnyCborEncodedToNode),
+		bindnode.TypedBoolConverter(BoolSubst(0), BoolSubstFromBool, BoolToBoolSubst),
 	}
 
 	typeSystem, err := ipld.LoadSchemaBytes([]byte(anyExtendSchema))

--- a/node/bindnode/custom_test.go
+++ b/node/bindnode/custom_test.go
@@ -2,17 +2,118 @@ package bindnode_test
 
 import (
 	"bytes"
+	"encoding/hex"
 	"fmt"
 	"math/big"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime"
 	"github.com/ipld/go-ipld-prime/codec/dagjson"
 	"github.com/ipld/go-ipld-prime/node/bindnode"
+	"github.com/multiformats/go-multihash"
 
 	qt "github.com/frankban/quicktest"
 )
+
+type BoolSubst int
+
+const (
+	BoolSubst_Yes = 100
+	BoolSubst_No  = -100
+)
+
+func BoolSubstFromBool(b bool) (interface{}, error) {
+	if b {
+		return BoolSubst_Yes, nil
+	}
+	return BoolSubst_No, nil
+}
+
+func BoolToBoolSubst(b interface{}) (bool, error) {
+	bp, ok := b.(*BoolSubst)
+	if !ok {
+		return true, fmt.Errorf("expected *BoolSubst value")
+	}
+	switch *bp {
+	case BoolSubst_Yes:
+		return true, nil
+	case BoolSubst_No:
+		return false, nil
+	default:
+		return true, fmt.Errorf("bad BoolSubst")
+	}
+}
+
+type IntSubst string
+
+func IntSubstFromInt(i int64) (interface{}, error) {
+	if i == 1000 {
+		return "one thousand", nil
+	} else if i == 2000 {
+		return "two thousand", nil
+	}
+	return nil, fmt.Errorf("unexpected value of IntSubst")
+}
+
+func IntToIntSubst(i interface{}) (int64, error) {
+	ip, ok := i.(*IntSubst)
+	if !ok {
+		return 0, fmt.Errorf("expected *IntSubst value")
+	}
+	switch *ip {
+	case "one thousand":
+		return 1000, nil
+	case "two thousand":
+		return 2000, nil
+	default:
+		return 0, fmt.Errorf("bad IntSubst")
+	}
+}
+
+type BigFloat struct{ *big.Float }
+
+func BigFloatFromFloat(f float64) (interface{}, error) {
+	bf := big.NewFloat(f)
+	return &BigFloat{bf}, nil
+}
+
+func FloatFromBigFloat(f interface{}) (float64, error) {
+	fp, ok := f.(*BigFloat)
+	if !ok {
+		return 0, fmt.Errorf("expected *BigFloat value")
+	}
+	f64, _ := fp.Float64()
+	return f64, nil
+}
+
+type ByteArray [][]byte
+
+func ByteArrayFromString(s string) (interface{}, error) {
+	sa := strings.Split(s, "|")
+	ba := make([][]byte, 0)
+	for _, a := range sa {
+		ba = append(ba, []byte(a))
+	}
+	return ba, nil
+}
+
+func StringFromByteArray(b interface{}) (string, error) {
+	bap, ok := b.(*ByteArray)
+	if !ok {
+		return "", fmt.Errorf("expected *ByteArray value")
+	}
+	sb := strings.Builder{}
+	for i, b := range *bap {
+		sb.WriteString(string(b))
+		if i != len(*bap)-1 {
+			sb.WriteString("|")
+		}
+	}
+	return sb.String(), nil
+}
 
 // similar to cid/Cid, go-address/Address, go-graphsync/RequestID
 type Boop struct{ str string }
@@ -67,34 +168,6 @@ func (b *Frop) Bytes() []byte {
 	}
 }
 
-type Boom struct {
-	S    string
-	B    Boop
-	Bptr *Boop
-	F    Frop
-	I    int
-}
-
-const boomSchema = `
-type Boom struct {
-	S String
-	B Bytes
-	Bptr nullable Bytes
-	F Bytes
-	I Int
-} representation map
-`
-
-const boomFixtureDagJson = `{"B":{"/":{"bytes":"dGhlc2UgYXJlIGJ5dGVz"}},"Bptr":{"/":{"bytes":"dGhlc2UgYXJlIHBvaW50ZXIgYnl0ZXM"}},"F":{"/":{"bytes":"AAH3fubjrGlwOMpClAkh/ro13L5Uls4/CtI"}},"I":10101,"S":"a string here"}`
-
-var boomFixtureInstance = Boom{
-	S:    "a string here",
-	B:    *NewBoop([]byte("these are bytes")),
-	Bptr: NewBoop([]byte("these are pointer bytes")),
-	F:    NewFropFromString("12345678901234567891234567890123456789012345678901234567890"),
-	I:    10101,
-}
-
 func BoopFromBytes(b []byte) (interface{}, error) {
 	return NewBoop(b), nil
 }
@@ -117,10 +190,97 @@ func FropToBytes(iface interface{}) ([]byte, error) {
 	return nil, fmt.Errorf("did not get expected type")
 }
 
+// Bitcoin's version of "links" is a hex form of the dbl-sha2-256 digest reversed
+type BtcId string
+
+func FromCidToBtcId(c cid.Cid) (interface{}, error) {
+	if c.Prefix().Codec != cid.BitcoinBlock { // should be able to do BitcoinTx too .. but ..
+		return nil, fmt.Errorf("can only convert IDs for BitcoinBlock codecs")
+	}
+	// and multihash must be dbl-sha2-256
+	dig, err := multihash.Decode(c.Hash())
+	if err != nil {
+		return nil, err
+	}
+	hid := make([]byte, 0)
+	for i := len(dig.Digest) - 1; i >= 0; i-- {
+		hid = append(hid, dig.Digest[i])
+	}
+	return BtcId(hex.EncodeToString(hid)), nil
+}
+
+func FromBtcIdToCid(iface interface{}) (cid.Cid, error) {
+	bid, ok := iface.(*BtcId)
+	if !ok {
+		return cid.Undef, fmt.Errorf("expected *BtcId value")
+	}
+	dig := make([]byte, 0)
+	hid, err := hex.DecodeString(string(*bid))
+	if err != nil {
+		return cid.Undef, err
+	}
+	for i := len(hid) - 1; i >= 0; i-- {
+		dig = append(dig, hid[i])
+	}
+	mh, err := multihash.Encode(dig, multihash.DBL_SHA2_256)
+	if err != nil {
+		return cid.Undef, err
+	}
+	return cid.NewCidV1(cid.BitcoinBlock, mh), nil
+}
+
+type Boom struct {
+	S    string
+	St   ByteArray
+	B    Boop
+	Bo   BoolSubst
+	Bptr *Boop
+	F    Frop
+	Fl   BigFloat
+	I    int
+	In   IntSubst
+	L    BtcId
+}
+
+const boomSchema = `
+type Boom struct {
+	S String
+	St String
+	B Bytes
+	Bo Bool
+	Bptr nullable Bytes
+	F Bytes
+	Fl Float
+	I Int
+	In Int
+	L &Any
+} representation map
+`
+
+const boomFixtureDagJson = `{"B":{"/":{"bytes":"dGhlc2UgYXJlIGJ5dGVz"}},"Bo":false,"Bptr":{"/":{"bytes":"dGhlc2UgYXJlIHBvaW50ZXIgYnl0ZXM"}},"F":{"/":{"bytes":"AAH3fubjrGlwOMpClAkh/ro13L5Uls4/CtI"}},"Fl":1.12,"I":10101,"In":2000,"L":{"/":"bagyacvra2e6qt2fohajauxceox55t3gedsyqap2phmv7q2qaaaaaaaaaaaaa"},"S":"a string here","St":"a|byte|array"}`
+
+var boomFixtureInstance = Boom{
+	B:    *NewBoop([]byte("these are bytes")),
+	Bo:   BoolSubst_No,
+	Bptr: NewBoop([]byte("these are pointer bytes")),
+	F:    NewFropFromString("12345678901234567891234567890123456789012345678901234567890"),
+	Fl:   BigFloat{big.NewFloat(1.12)},
+	I:    10101,
+	In:   IntSubst("two thousand"),
+	S:    "a string here",
+	St:   ByteArray([][]byte{[]byte("a"), []byte("byte"), []byte("array")}),
+	L:    BtcId("00000000000000006af82b3b4f3f00b11cc4ecd9fb75445c0a1238aee8093dd1"),
+}
+
 func TestCustom(t *testing.T) {
 	opts := []bindnode.Option{
-		bindnode.AddCustomTypeConverter(&Boop{}, bindnode.CustomBytes{From: BoopFromBytes, To: BoopToBytes}),
-		bindnode.AddCustomTypeConverter(&Frop{}, bindnode.CustomBytes{From: FropFromBytes, To: FropToBytes}),
+		bindnode.AddCustomTypeBytesConverter(&Boop{}, BoopFromBytes, BoopToBytes),
+		bindnode.AddCustomTypeBytesConverter(&Frop{}, FropFromBytes, FropToBytes),
+		bindnode.AddCustomTypeBoolConverter(BoolSubst(0), BoolSubstFromBool, BoolToBoolSubst),
+		bindnode.AddCustomTypeIntConverter(IntSubst(""), IntSubstFromInt, IntToIntSubst),
+		bindnode.AddCustomTypeFloatConverter(&BigFloat{}, BigFloatFromFloat, FloatFromBigFloat),
+		bindnode.AddCustomTypeStringConverter(&ByteArray{}, ByteArrayFromString, StringFromByteArray),
+		bindnode.AddCustomTypeLinkConverter(BtcId(""), FromCidToBtcId, FromBtcIdToCid),
 	}
 
 	typeSystem, err := ipld.LoadSchemaBytes([]byte(boomSchema))
@@ -139,6 +299,7 @@ func TestCustom(t *testing.T) {
 	cmpr := qt.CmpEquals(
 		cmp.Comparer(func(x, y Boop) bool { return x.String() == y.String() }),
 		cmp.Comparer(func(x, y Frop) bool { return x.String() == y.String() }),
+		cmp.Comparer(func(x, y BigFloat) bool { return x.String() == y.String() }),
 	)
 	qt.Assert(t, *inst, cmpr, boomFixtureInstance)
 

--- a/node/bindnode/custom_test.go
+++ b/node/bindnode/custom_test.go
@@ -1,0 +1,168 @@
+package bindnode_test
+
+import (
+	"bytes"
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/codec/dagjson"
+	"github.com/ipld/go-ipld-prime/node/basicnode"
+	"github.com/ipld/go-ipld-prime/node/bindnode"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// similar to cid/Cid, go-address/Address, go-graphsync/RequestID
+type Boop struct{ str string }
+
+func NewBoop(b []byte) *Boop {
+	return &Boop{string(b)}
+}
+
+func (b Boop) Bytes() []byte {
+	return []byte(b.str)
+}
+
+func (b Boop) String() string {
+	return b.str
+}
+
+// similar to go-state-types/big/Int
+type Blop struct{ *big.Int }
+
+func NewBlopFromString(str string) Blop {
+	v, _ := big.NewInt(0).SetString(str, 10)
+	return Blop{v}
+}
+
+func NewBlopFromBytes(buf []byte) Blop {
+	var negative bool
+	switch buf[0] {
+	case 0:
+		negative = false
+	case 1:
+		negative = true
+	default:
+		panic("can't handle this")
+	}
+
+	i := big.NewInt(0).SetBytes(buf[1:])
+	if negative {
+		i.Neg(i)
+	}
+
+	return Blop{i}
+}
+
+func (b *Blop) Bytes() []byte {
+	switch {
+	case b.Sign() > 0:
+		return append([]byte{0}, b.Int.Bytes()...)
+	case b.Sign() < 0:
+		return append([]byte{1}, b.Int.Bytes()...)
+	default:
+		return []byte{}
+	}
+}
+
+type Boom struct {
+	S    string
+	B    Boop
+	Bptr *Boop
+	BI   Blop
+	I    int
+}
+
+const boomSchema = `
+type Boom struct {
+	S String
+	B Bytes
+	Bptr nullable Bytes
+	BI Bytes
+	I Int
+} representation map
+`
+
+const boomFixtureDagJson = `{"B":{"/":{"bytes":"dGhlc2UgYXJlIGJ5dGVz"}},"BI":{"/":{"bytes":"AAH3fubjrGlwOMpClAkh/ro13L5Uls4/CtI"}},"Bptr":{"/":{"bytes":"dGhlc2UgYXJlIHBvaW50ZXIgYnl0ZXM"}},"I":10101,"S":"a string here"}`
+
+var boomFixtureInstance = Boom{
+	S:    "a string here",
+	B:    *NewBoop([]byte("these are bytes")),
+	BI:   NewBlopFromString("12345678901234567891234567890123456789012345678901234567890"),
+	Bptr: NewBoop([]byte("these are pointer bytes")),
+	I:    10101,
+}
+
+type BoopConverter struct {
+}
+
+func (bc BoopConverter) FromBytes(b []byte) (interface{}, error) {
+	return NewBoop(b), nil
+}
+
+func (bc BoopConverter) ToBytes(typ interface{}) ([]byte, error) {
+	if boop, ok := typ.(*Boop); ok {
+		return boop.Bytes(), nil
+	}
+	return nil, fmt.Errorf("did not get a Boop type")
+}
+
+type BlopConverter struct {
+}
+
+func (bc BlopConverter) FromBytes(b []byte) (interface{}, error) {
+	return NewBlopFromBytes(b), nil
+}
+
+func (bc BlopConverter) ToBytes(typ interface{}) ([]byte, error) {
+	if blop, ok := typ.(*Blop); ok {
+		return blop.Bytes(), nil
+	}
+	return nil, fmt.Errorf("did not get a Blop type")
+}
+
+var (
+	_ bindnode.CustomTypeBytesConverter = (*BoopConverter)(nil)
+	_ bindnode.CustomTypeBytesConverter = (*BlopConverter)(nil)
+)
+
+func TestCustom(t *testing.T) {
+	opts := []bindnode.Option{
+		bindnode.AddCustomTypeBytesConverter(Boop{}, BoopConverter{}),
+		bindnode.AddCustomTypeBytesConverter(Blop{}, BlopConverter{}),
+	}
+
+	nb := basicnode.Prototype.Any.NewBuilder()
+	err := dagjson.Decode(nb, bytes.NewReader([]byte(boomFixtureDagJson)))
+	qt.Assert(t, err, qt.IsNil)
+
+	typeSystem, err := ipld.LoadSchemaBytes([]byte(boomSchema))
+	qt.Assert(t, err, qt.IsNil)
+	schemaType := typeSystem.TypeByName("Boom")
+	proto := bindnode.Prototype(&Boom{}, schemaType, opts...)
+
+	node := nb.Build()
+	builder := proto.Representation().NewBuilder()
+	err = builder.AssignNode(node)
+	qt.Assert(t, err, qt.IsNil)
+
+	typ := bindnode.Unwrap(builder.Build())
+	inst, ok := typ.(*Boom)
+	qt.Assert(t, ok, qt.IsTrue)
+
+	cmpr := qt.CmpEquals(
+		cmp.Comparer(func(x, y Boop) bool { return x.String() == y.String() }),
+		cmp.Comparer(func(x, y Blop) bool { return x.String() == y.String() }),
+	)
+	qt.Assert(t, *inst, cmpr, boomFixtureInstance)
+
+	tn := bindnode.Wrap(&boomFixtureInstance, schemaType, opts...)
+	var buf bytes.Buffer
+	err = dagjson.Encode(tn.Representation(), &buf)
+	qt.Assert(t, err, qt.IsNil)
+
+	qt.Assert(t, buf.String(), qt.Equals, boomFixtureDagJson)
+}

--- a/node/bindnode/custom_test.go
+++ b/node/bindnode/custom_test.go
@@ -332,6 +332,13 @@ type AnyExtend struct {
 	Map          AnyCborEncoded
 	List         AnyCborEncoded
 	BoolPtr      *BoolSubst // included to test that a null entry won't call a non-Any converter
+	XListAny     []AnyCborEncoded
+	XMapAny      anyMap
+}
+
+type anyMap struct {
+	Keys   []string
+	Values map[string]*AnyCborEncoded
 }
 
 const anyExtendSchema = `
@@ -351,6 +358,8 @@ type AnyExtend struct {
 	Map Any
 	List Any
 	BoolPtr nullable Bool
+	XListAny [Any]
+	XMapAny {String:Any}
 }
 `
 
@@ -450,7 +459,7 @@ func AnyCborEncodedToNode(ptr interface{}) (datamodel.Node, error) {
 	return na.Build(), nil
 }
 
-const anyExtendDagJson = `{"Blob":{"baz":[2,3,4],"foo":"bar"},"Bool":false,"BoolPtr":null,"Bytes":{"/":{"bytes":"AgMEBQYHCA"}},"Count":101,"Float":2.34,"Int":123456789,"Link":{"/":"bagyacvra2e6qt2fohajauxceox55t3gedsyqap2phmv7q2qaaaaaaaaaaaaa"},"List":[null,"one","two","three",1,2,3,true],"Map":{"foo":"bar","one":1,"three":3,"two":2},"Name":"Any extend test","Null":null,"NullPtr":null,"NullableWith":123456789,"String":"this is a string"}`
+const anyExtendDagJson = `{"Blob":{"baz":[2,3,4],"foo":"bar"},"Bool":false,"BoolPtr":null,"Bytes":{"/":{"bytes":"AgMEBQYHCA"}},"Count":101,"Float":2.34,"Int":123456789,"Link":{"/":"bagyacvra2e6qt2fohajauxceox55t3gedsyqap2phmv7q2qaaaaaaaaaaaaa"},"List":[null,"one","two","three",1,2,3,true],"Map":{"foo":"bar","one":1,"three":3,"two":2},"Name":"Any extend test","Null":null,"NullPtr":null,"NullableWith":123456789,"String":"this is a string","XListAny":[1,2,true,null,"bop"],"XMapAny":{"a":1,"b":2,"c":true,"d":null,"e":"bop"}}`
 
 var anyExtendFixtureInstance = AnyExtend{
 	Name:         "Any extend test",
@@ -460,14 +469,23 @@ var anyExtendFixtureInstance = AnyExtend{
 	NullPtr:      &AnyCborEncoded{mustFromHex("f6")},
 	NullableWith: &AnyCborEncoded{mustFromHex("1a075bcd15")},
 	Bool:         AnyCborEncoded{mustFromHex("f4")},
-	Int:          AnyCborEncoded{mustFromHex("1a075bcd15")},                                                                           // cbor encoded form of 123456789
-	Float:        AnyCborEncoded{mustFromHex("fb4002b851eb851eb8")},                                                                   // cbor encoded form of 2.34
-	String:       AnyCborEncoded{mustFromHex("7074686973206973206120737472696e67")},                                                   // cbor encoded form of "this is a string"
-	Bytes:        AnyCborEncoded{mustFromHex("4702030405060708")},                                                                     // cbor encoded form of [2,3,4,5,6,7,8]
-	Link:         AnyCborEncoded{mustFromHex("d82a58260001b0015620d13d09e8ae38120a5c4475fbd9ecc41cb1003f4f3b2bf86a0000000000000000")}, // dag-cbor encoded CID bagyacvra2e6qt2fohajauxceox55t3gedsyqap2phmv7q2qaaaaaaaaaaaaa
-	Map:          AnyCborEncoded{mustFromHex("a463666f6f63626172636f6e65016374776f0265746872656503")},                                 // cbor encoded form of {"one":1,"two":2,"three":3,"foo":"bar"}
-	List:         AnyCborEncoded{mustFromHex("88f6636f6e656374776f657468726565010203f5")},                                             // cbor encoded form of [null,'one','two','three',1,2,3,true]
+	Int:          AnyCborEncoded{mustFromHex("1a075bcd15")},                                                                           // 123456789
+	Float:        AnyCborEncoded{mustFromHex("fb4002b851eb851eb8")},                                                                   // 2.34
+	String:       AnyCborEncoded{mustFromHex("7074686973206973206120737472696e67")},                                                   // "this is a string"
+	Bytes:        AnyCborEncoded{mustFromHex("4702030405060708")},                                                                     // [2,3,4,5,6,7,8]
+	Link:         AnyCborEncoded{mustFromHex("d82a58260001b0015620d13d09e8ae38120a5c4475fbd9ecc41cb1003f4f3b2bf86a0000000000000000")}, // bagyacvra2e6qt2fohajauxceox55t3gedsyqap2phmv7q2qaaaaaaaaaaaaa
+	Map:          AnyCborEncoded{mustFromHex("a463666f6f63626172636f6e65016374776f0265746872656503")},                                 // {"one":1,"two":2,"three":3,"foo":"bar"}
+	List:         AnyCborEncoded{mustFromHex("88f6636f6e656374776f657468726565010203f5")},                                             // [null,'one','two','three',1,2,3,true]
 	BoolPtr:      nil,
+	XListAny:     []AnyCborEncoded{{mustFromHex("01")}, {mustFromHex("02")}, {mustFromHex("f5")}, {mustFromHex("f6")}, {mustFromHex("63626f70")}}, // [1,2,true,null,"bop"]
+	XMapAny: anyMap{
+		Keys: []string{"a", "b", "c", "d", "e"},
+		Values: map[string]*AnyCborEncoded{
+			"a": {mustFromHex("01")},
+			"b": {mustFromHex("02")},
+			"c": {mustFromHex("f5")},
+			"d": {mustFromHex("f6")},
+			"e": {mustFromHex("63626f70")}}}, // {"a":1,"b":2,"c":true,"d":null,"e":"bop"}
 }
 
 func TestCustomAny(t *testing.T) {

--- a/node/bindnode/custom_test.go
+++ b/node/bindnode/custom_test.go
@@ -2,6 +2,7 @@ package bindnode_test
 
 import (
 	"bytes"
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -94,26 +95,32 @@ var boomFixtureInstance = Boom{
 	I:    10101,
 }
 
-func BoopFromBytes(b []byte) (*Boop, error) {
+func BoopFromBytes(b []byte) (interface{}, error) {
 	return NewBoop(b), nil
 }
 
-func BoopToBytes(boop *Boop) ([]byte, error) {
-	return boop.Bytes(), nil
+func BoopToBytes(iface interface{}) ([]byte, error) {
+	if boop, ok := iface.(*Boop); ok {
+		return boop.Bytes(), nil
+	}
+	return nil, fmt.Errorf("did not get expected type")
 }
 
-func FropFromBytes(b []byte) (*Frop, error) {
+func FropFromBytes(b []byte) (interface{}, error) {
 	return NewFropFromBytes(b), nil
 }
 
-func FropToBytes(frop *Frop) ([]byte, error) {
-	return frop.Bytes(), nil
+func FropToBytes(iface interface{}) ([]byte, error) {
+	if frop, ok := iface.(*Frop); ok {
+		return frop.Bytes(), nil
+	}
+	return nil, fmt.Errorf("did not get expected type")
 }
 
 func TestCustom(t *testing.T) {
 	opts := []bindnode.Option{
-		bindnode.AddCustomTypeBytesConverter(BoopFromBytes, BoopToBytes),
-		bindnode.AddCustomTypeBytesConverter(FropFromBytes, FropToBytes),
+		bindnode.AddCustomTypeConverter(&Boop{}, bindnode.CustomBytes{From: BoopFromBytes, To: BoopToBytes}),
+		bindnode.AddCustomTypeConverter(&Frop{}, bindnode.CustomBytes{From: FropFromBytes, To: FropToBytes}),
 	}
 
 	typeSystem, err := ipld.LoadSchemaBytes([]byte(boomSchema))

--- a/node/bindnode/infer.go
+++ b/node/bindnode/infer.go
@@ -67,7 +67,7 @@ func verifyCompatibility(cfg config, seen map[seenEntry]bool, goType reflect.Typ
 	switch schemaType := schemaType.(type) {
 	case *schema.TypeBool:
 		if customConverter, ok := cfg[goType]; ok {
-			if customConverter.kind != datamodel.Kind_Bool {
+			if customConverter.kind != schema.TypeKind_Bool {
 				doPanic("kind mismatch; custom converter for type is not for Bool")
 			}
 		} else if goType.Kind() != reflect.Bool {
@@ -75,7 +75,7 @@ func verifyCompatibility(cfg config, seen map[seenEntry]bool, goType reflect.Typ
 		}
 	case *schema.TypeInt:
 		if customConverter, ok := cfg[goType]; ok {
-			if customConverter.kind != datamodel.Kind_Int {
+			if customConverter.kind != schema.TypeKind_Int {
 				doPanic("kind mismatch; custom converter for type is not for Int")
 			}
 		} else if kind := goType.Kind(); !kindInt[kind] && !kindUint[kind] {
@@ -83,7 +83,7 @@ func verifyCompatibility(cfg config, seen map[seenEntry]bool, goType reflect.Typ
 		}
 	case *schema.TypeFloat:
 		if customConverter, ok := cfg[goType]; ok {
-			if customConverter.kind != datamodel.Kind_Float {
+			if customConverter.kind != schema.TypeKind_Float {
 				doPanic("kind mismatch; custom converter for type is not for Float")
 			}
 		} else {
@@ -96,7 +96,7 @@ func verifyCompatibility(cfg config, seen map[seenEntry]bool, goType reflect.Typ
 	case *schema.TypeString:
 		// TODO: allow []byte?
 		if customConverter, ok := cfg[goType]; ok {
-			if customConverter.kind != datamodel.Kind_String {
+			if customConverter.kind != schema.TypeKind_String {
 				doPanic("kind mismatch; custom converter for type is not for String")
 			}
 		} else if goType.Kind() != reflect.String {
@@ -105,7 +105,7 @@ func verifyCompatibility(cfg config, seen map[seenEntry]bool, goType reflect.Typ
 	case *schema.TypeBytes:
 		// TODO: allow string?
 		if customConverter, ok := cfg[goType]; ok {
-			if customConverter.kind != datamodel.Kind_Bytes {
+			if customConverter.kind != schema.TypeKind_Bytes {
 				doPanic("kind mismatch; custom converter for type is not for Bytes")
 			}
 		} else if goType.Kind() != reflect.Slice {
@@ -231,15 +231,18 @@ func verifyCompatibility(cfg config, seen map[seenEntry]bool, goType reflect.Typ
 		}
 	case *schema.TypeLink:
 		if customConverter, ok := cfg[goType]; ok {
-			if customConverter.kind != datamodel.Kind_Link {
+			if customConverter.kind != schema.TypeKind_Link {
 				doPanic("kind mismatch; custom converter for type is not for Link")
 			}
 		} else if goType != goTypeLink && goType != goTypeCidLink && goType != goTypeCid {
 			doPanic("links in Go must be datamodel.Link, cidlink.Link, or cid.Cid")
 		}
 	case *schema.TypeAny:
-		// TODO: support some other option for Any, such as deferred decode
-		if goType != goTypeNode {
+		if customConverter, ok := cfg[goType]; ok {
+			if customConverter.kind != schema.TypeKind_Any {
+				doPanic("kind mismatch; custom converter for type is not for Any")
+			}
+		} else if goType != goTypeNode {
 			doPanic("Any in Go must be datamodel.Node")
 		}
 	default:

--- a/node/bindnode/infer.go
+++ b/node/bindnode/infer.go
@@ -88,7 +88,7 @@ func verifyCompatibility(cfg config, seen map[seenEntry]bool, goType reflect.Typ
 		// TODO: allow string?
 		customConverter, ok := cfg[goType]
 		if ok {
-			if customConverter.kindType != byteSliceType {
+			if customConverter.kind != datamodel.Kind_Bytes {
 				doPanic("kind mismatch; custom converter for type is not for Bytes")
 			}
 		} else {

--- a/node/bindnode/infer.go
+++ b/node/bindnode/infer.go
@@ -86,10 +86,10 @@ func verifyCompatibility(cfg config, seen map[seenEntry]bool, goType reflect.Typ
 		}
 	case *schema.TypeBytes:
 		// TODO: allow string?
-		customConverter, ok := cfg.customConverters[goType]
+		customConverter, ok := cfg[goType]
 		if ok {
-			if _, ok := customConverter.(CustomTypeBytesConverter); !ok {
-				doPanic("kind mismatch; custom converter for type is not a CustomTypeBytesConverter")
+			if customConverter.kindType != byteSliceType {
+				doPanic("kind mismatch; custom converter for type is not for Bytes")
 			}
 		} else {
 			if goType.Kind() != reflect.Slice {

--- a/node/bindnode/infer.go
+++ b/node/bindnode/infer.go
@@ -66,7 +66,7 @@ func verifyCompatibility(cfg config, seen map[seenEntry]bool, goType reflect.Typ
 	}
 	switch schemaType := schemaType.(type) {
 	case *schema.TypeBool:
-		if customConverter, ok := cfg.converterForType(goType); ok {
+		if customConverter := cfg.converterForType(goType); customConverter != nil {
 			if customConverter.kind != schema.TypeKind_Bool {
 				doPanic("kind mismatch; custom converter for type is not for Bool")
 			}
@@ -74,7 +74,7 @@ func verifyCompatibility(cfg config, seen map[seenEntry]bool, goType reflect.Typ
 			doPanic("kind mismatch; need boolean")
 		}
 	case *schema.TypeInt:
-		if customConverter, ok := cfg.converterForType(goType); ok {
+		if customConverter := cfg.converterForType(goType); customConverter != nil {
 			if customConverter.kind != schema.TypeKind_Int {
 				doPanic("kind mismatch; custom converter for type is not for Int")
 			}
@@ -82,7 +82,7 @@ func verifyCompatibility(cfg config, seen map[seenEntry]bool, goType reflect.Typ
 			doPanic("kind mismatch; need integer")
 		}
 	case *schema.TypeFloat:
-		if customConverter, ok := cfg.converterForType(goType); ok {
+		if customConverter := cfg.converterForType(goType); customConverter != nil {
 			if customConverter.kind != schema.TypeKind_Float {
 				doPanic("kind mismatch; custom converter for type is not for Float")
 			}
@@ -95,7 +95,7 @@ func verifyCompatibility(cfg config, seen map[seenEntry]bool, goType reflect.Typ
 		}
 	case *schema.TypeString:
 		// TODO: allow []byte?
-		if customConverter, ok := cfg.converterForType(goType); ok {
+		if customConverter := cfg.converterForType(goType); customConverter != nil {
 			if customConverter.kind != schema.TypeKind_String {
 				doPanic("kind mismatch; custom converter for type is not for String")
 			}
@@ -104,7 +104,7 @@ func verifyCompatibility(cfg config, seen map[seenEntry]bool, goType reflect.Typ
 		}
 	case *schema.TypeBytes:
 		// TODO: allow string?
-		if customConverter, ok := cfg.converterForType(goType); ok {
+		if customConverter := cfg.converterForType(goType); customConverter != nil {
 			if customConverter.kind != schema.TypeKind_Bytes {
 				doPanic("kind mismatch; custom converter for type is not for Bytes")
 			}
@@ -204,7 +204,7 @@ func verifyCompatibility(cfg config, seen map[seenEntry]bool, goType reflect.Typ
 				}
 			case schemaField.IsNullable():
 				if ptr, nilable := ptrOrNilable(goType.Kind()); !nilable {
-					if _, hasConverter := cfg.converterForType(goType); !hasConverter {
+					if customConverter := cfg.converterForType(goType); customConverter == nil {
 						doPanic("nullable fields must be nilable")
 					}
 				} else if ptr {
@@ -233,7 +233,7 @@ func verifyCompatibility(cfg config, seen map[seenEntry]bool, goType reflect.Typ
 			verifyCompatibility(cfg, seen, goType, schemaType)
 		}
 	case *schema.TypeLink:
-		if customConverter, ok := cfg.converterForType(goType); ok {
+		if customConverter := cfg.converterForType(goType); customConverter != nil {
 			if customConverter.kind != schema.TypeKind_Link {
 				doPanic("kind mismatch; custom converter for type is not for Link")
 			}
@@ -241,7 +241,7 @@ func verifyCompatibility(cfg config, seen map[seenEntry]bool, goType reflect.Typ
 			doPanic("links in Go must be datamodel.Link, cidlink.Link, or cid.Cid")
 		}
 	case *schema.TypeAny:
-		if customConverter, ok := cfg.converterForType(goType); ok {
+		if customConverter := cfg.converterForType(goType); customConverter != nil {
 			if customConverter.kind != schema.TypeKind_Any {
 				doPanic("kind mismatch; custom converter for type is not for Any")
 			}

--- a/node/bindnode/infer.go
+++ b/node/bindnode/infer.go
@@ -39,6 +39,11 @@ type seenEntry struct {
 	schemaType schema.Type
 }
 
+// verifyCompatibility is the primary way we check that the schema type(s)
+// matches the Go type(s); so we do this before we can proceed operating on it.
+// verifyCompatibility doesn't return an error, it panics—the errors here are
+// not runtime errors, they're programmer errors because your schema doesn't
+// match your Go type
 func verifyCompatibility(cfg config, seen map[seenEntry]bool, goType reflect.Type, schemaType schema.Type) {
 	// TODO(mvdan): support **T as well?
 	if goType.Kind() == reflect.Ptr {
@@ -278,6 +283,7 @@ const (
 	inferringDone
 )
 
+// inferGoType can build a Go type given a schema
 func inferGoType(typ schema.Type, status map[schema.TypeName]inferredStatus, level int) reflect.Type {
 	if level > maxRecursionLevel {
 		panic(fmt.Sprintf("inferGoType: refusing to recurse past %d levels", maxRecursionLevel))
@@ -407,6 +413,7 @@ func init() {
 // TODO: we should probably avoid re-spawning the same types if the TypeSystem
 // has them, and test that that works as expected
 
+// inferSchema can build a schema from a Go type
 func inferSchema(typ reflect.Type, level int) schema.Type {
 	if level > maxRecursionLevel {
 		panic(fmt.Sprintf("inferSchema: refusing to recurse past %d levels", maxRecursionLevel))

--- a/node/bindnode/node.go
+++ b/node/bindnode/node.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ipld/go-ipld-prime/datamodel"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/ipld/go-ipld-prime/node/basicnode"
+	"github.com/ipld/go-ipld-prime/node/mixins"
 	"github.com/ipld/go-ipld-prime/schema"
 )
 
@@ -24,6 +25,12 @@ var (
 	_ datamodel.Node   = (*_node)(nil)
 	_ schema.TypedNode = (*_node)(nil)
 	_ datamodel.Node   = (*_nodeRepr)(nil)
+
+	_ datamodel.Node     = (*_uintNode)(nil)
+	_ schema.TypedNode   = (*_uintNode)(nil)
+	_ datamodel.UintNode = (*_uintNode)(nil)
+	_ datamodel.Node     = (*_uintNodeRepr)(nil)
+	_ datamodel.UintNode = (*_uintNodeRepr)(nil)
 
 	_ datamodel.NodeBuilder   = (*_builder)(nil)
 	_ datamodel.NodeBuilder   = (*_builderRepr)(nil)
@@ -79,6 +86,20 @@ type _node struct {
 // type _typedNode struct {
 // 	_node
 // }
+
+func newNode(cfg config, schemaType schema.Type, val reflect.Value) schema.TypedNode {
+	if schemaType.TypeKind() == schema.TypeKind_Int && nonPtrVal(val).Kind() == reflect.Uint64 {
+		// special case for uint64 values so we can handle the >int64 range
+		// we give this treatment to all uint64s, regardless of current value
+		// because we have no guarantees the value won't change underneath us
+		return &_uintNode{
+			cfg:        cfg,
+			schemaType: schemaType,
+			val:        val,
+		}
+	}
+	return &_node{cfg, schemaType, val}
+}
 
 func (w *_node) Type() schema.Type {
 	return w.schemaType
@@ -201,12 +222,7 @@ func (w *_node) LookupByString(key string) (datamodel.Node, error) {
 			// field is an Any, safely assume a Node in fval
 			return nonPtrVal(fval).Interface().(datamodel.Node), nil
 		}
-		node := &_node{
-			cfg:        w.cfg,
-			schemaType: field.Type(),
-			val:        fval,
-		}
-		return node, nil
+		return newNode(w.cfg, field.Type(), fval), nil
 	case *schema.TypeMap:
 		// maps can only be structs with a Values map
 		var kval reflect.Value
@@ -251,12 +267,7 @@ func (w *_node) LookupByString(key string) (datamodel.Node, error) {
 			// value is an Any, safely assume a Node in fval
 			return nonPtrVal(fval).Interface().(datamodel.Node), nil
 		}
-		node := &_node{
-			cfg:        w.cfg,
-			schemaType: typ.ValueType(),
-			val:        fval,
-		}
-		return node, nil
+		return newNode(w.cfg, typ.ValueType(), fval), nil
 	case *schema.TypeUnion:
 		// treat a union similar to a struct, but we have the member names more
 		// easily accessible to match to 'key'
@@ -277,12 +288,7 @@ func (w *_node) LookupByString(key string) (datamodel.Node, error) {
 		if haveIdx != idx { // mismatching type
 			return nil, datamodel.ErrNotExists{Segment: datamodel.PathSegmentOfString(key)}
 		}
-		node := &_node{
-			cfg:        w.cfg,
-			schemaType: mtyp,
-			val:        mval,
-		}
-		return node, nil
+		return newNode(w.cfg, mtyp, mval), nil
 	}
 	return nil, datamodel.ErrWrongKind{
 		TypeName:        w.schemaType.Name(),
@@ -346,7 +352,7 @@ func (w *_node) LookupByIndex(idx int64) (datamodel.Node, error) {
 			// Any always yields a plain datamodel.Node
 			return nonPtrVal(val).Interface().(datamodel.Node), nil
 		}
-		return &_node{cfg: w.cfg, schemaType: typ.ValueType(), val: val}, nil
+		return newNode(w.cfg, typ.ValueType(), val), nil
 	}
 	return nil, datamodel.ErrWrongKind{
 		TypeName:        w.schemaType.Name(),
@@ -566,7 +572,7 @@ type _builder struct {
 
 func (w *_builder) Build() datamodel.Node {
 	// TODO: should we panic if no Assign call was made, just like codegen?
-	return &_node{cfg: w.cfg, schemaType: w.schemaType, val: w.val}
+	return newNode(w.cfg, w.schemaType, w.val)
 }
 
 func (w *_builder) Reset() {
@@ -836,6 +842,35 @@ func (w *_assembler) AssignBool(b bool) error {
 	return nil
 }
 
+func (w *_assembler) assignUInt(uin datamodel.UintNode) error {
+	if err := compatibleKind(w.schemaType, datamodel.Kind_Int); err != nil {
+		return err
+	}
+	_, isAny := w.schemaType.(*schema.TypeAny)
+	// TODO: customConverter for uint??
+	if isAny {
+		// Any means the Go type must receive a datamodel.Node
+		w.createNonPtrVal().Set(reflect.ValueOf(uin))
+	} else {
+		i, err := uin.AsUint()
+		if err != nil {
+			return err
+		}
+		if kindUint[w.val.Kind()] {
+			w.createNonPtrVal().SetUint(i)
+		} else {
+			// TODO: check for overflow
+			w.createNonPtrVal().SetInt(int64(i))
+		}
+	}
+	if w.finish != nil {
+		if err := w.finish(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (w *_assembler) AssignInt(i int64) error {
 	if err := compatibleKind(w.schemaType, datamodel.Kind_Int); err != nil {
 		return err
@@ -1064,6 +1099,9 @@ func (w *_assembler) AssignNode(node datamodel.Node) error {
 	// 	w.val.Set(newVal)
 	// 	return nil
 	// }
+	if uintNode, ok := node.(datamodel.UintNode); ok {
+		return w.assignUInt(uintNode)
+	}
 	return datamodel.Copy(node, w)
 }
 
@@ -1441,12 +1479,7 @@ func (w *_structIterator) Next() (key, value datamodel.Node, _ error) {
 		// field holds a datamodel.Node
 		return key, nonPtrVal(val).Interface().(datamodel.Node), nil
 	}
-	node := &_node{
-		cfg:        w.cfg,
-		schemaType: field.Type(),
-		val:        val,
-	}
-	return key, node, nil
+	return key, newNode(w.cfg, field.Type(), val), nil
 }
 
 func (w *_structIterator) Done() bool {
@@ -1471,11 +1504,7 @@ func (w *_mapIterator) Next() (key, value datamodel.Node, _ error) {
 	val := w.valuesVal.MapIndex(goKey)
 	w.nextIndex++
 
-	key = &_node{
-		cfg:        w.cfg,
-		schemaType: w.schemaType.KeyType(),
-		val:        goKey,
-	}
+	key = newNode(w.cfg, w.schemaType.KeyType(), goKey)
 	_, isAny := w.schemaType.ValueType().(*schema.TypeAny)
 	if isAny {
 		if customConverter := w.cfg.converterFor(val); customConverter != nil {
@@ -1499,12 +1528,7 @@ func (w *_mapIterator) Next() (key, value datamodel.Node, _ error) {
 		// Values holds datamodel.Nodes
 		return key, nonPtrVal(val).Interface().(datamodel.Node), nil
 	}
-	node := &_node{
-		cfg:        w.cfg,
-		schemaType: w.schemaType.ValueType(),
-		val:        val,
-	}
-	return key, node, nil
+	return key, newNode(w.cfg, w.schemaType.ValueType(), val), nil
 }
 
 func (w *_mapIterator) Done() bool {
@@ -1542,7 +1566,7 @@ func (w *_listIterator) Next() (index int64, value datamodel.Node, _ error) {
 		// values are Any, assume that they are datamodel.Nodes
 		return idx, nonPtrVal(val).Interface().(datamodel.Node), nil
 	}
-	return idx, &_node{cfg: w.cfg, schemaType: w.schemaType.ValueType(), val: val}, nil
+	return idx, newNode(w.cfg, w.schemaType.ValueType(), val), nil
 }
 
 func (w *_listIterator) Done() bool {
@@ -1573,15 +1597,158 @@ func (w *_unionIterator) Next() (key, value datamodel.Node, _ error) {
 	}
 	mtyp := w.members[haveIdx]
 
-	node := &_node{
-		cfg:        w.cfg,
-		schemaType: mtyp,
-		val:        mval,
-	}
+	node := newNode(w.cfg, mtyp, mval)
 	key = basicnode.NewString(mtyp.Name())
 	return key, node, nil
 }
 
 func (w *_unionIterator) Done() bool {
 	return w.done
+}
+
+// --- uint64 special case handling
+
+type _uintNode struct {
+	cfg        config
+	schemaType schema.Type
+
+	val reflect.Value // non-pointer
+}
+
+func (tu *_uintNode) Type() schema.Type {
+	return tu.schemaType
+}
+func (tu *_uintNode) Representation() datamodel.Node {
+	return (*_uintNodeRepr)(tu)
+}
+func (_uintNode) Kind() datamodel.Kind {
+	return datamodel.Kind_Int
+}
+func (_uintNode) LookupByString(string) (datamodel.Node, error) {
+	return mixins.Int{TypeName: "int"}.LookupByString("")
+}
+func (_uintNode) LookupByNode(key datamodel.Node) (datamodel.Node, error) {
+	return mixins.Int{TypeName: "int"}.LookupByNode(nil)
+}
+func (_uintNode) LookupByIndex(idx int64) (datamodel.Node, error) {
+	return mixins.Int{TypeName: "int"}.LookupByIndex(0)
+}
+func (_uintNode) LookupBySegment(seg datamodel.PathSegment) (datamodel.Node, error) {
+	return mixins.Int{TypeName: "int"}.LookupBySegment(seg)
+}
+func (_uintNode) MapIterator() datamodel.MapIterator {
+	return nil
+}
+func (_uintNode) ListIterator() datamodel.ListIterator {
+	return nil
+}
+func (_uintNode) Length() int64 {
+	return -1
+}
+func (_uintNode) IsAbsent() bool {
+	return false
+}
+func (_uintNode) IsNull() bool {
+	return false
+}
+func (_uintNode) AsBool() (bool, error) {
+	return mixins.Int{TypeName: "int"}.AsBool()
+}
+func (tu *_uintNode) AsInt() (int64, error) {
+	return (*_uintNodeRepr)(tu).AsInt()
+}
+func (tu *_uintNode) AsUint() (uint64, error) {
+	return (*_uintNodeRepr)(tu).AsUint()
+}
+func (_uintNode) AsFloat() (float64, error) {
+	return mixins.Int{TypeName: "int"}.AsFloat()
+}
+func (_uintNode) AsString() (string, error) {
+	return mixins.Int{TypeName: "int"}.AsString()
+}
+func (_uintNode) AsBytes() ([]byte, error) {
+	return mixins.Int{TypeName: "int"}.AsBytes()
+}
+func (_uintNode) AsLink() (datamodel.Link, error) {
+	return mixins.Int{TypeName: "int"}.AsLink()
+}
+func (_uintNode) Prototype() datamodel.NodePrototype {
+	return basicnode.Prototype__Int{}
+}
+
+// we need this for _uintNode#Representation() so we don't return a TypeNode
+type _uintNodeRepr _uintNode
+
+func (_uintNodeRepr) Kind() datamodel.Kind {
+	return datamodel.Kind_Int
+}
+func (_uintNodeRepr) LookupByString(string) (datamodel.Node, error) {
+	return mixins.Int{TypeName: "int"}.LookupByString("")
+}
+func (_uintNodeRepr) LookupByNode(key datamodel.Node) (datamodel.Node, error) {
+	return mixins.Int{TypeName: "int"}.LookupByNode(nil)
+}
+func (_uintNodeRepr) LookupByIndex(idx int64) (datamodel.Node, error) {
+	return mixins.Int{TypeName: "int"}.LookupByIndex(0)
+}
+func (_uintNodeRepr) LookupBySegment(seg datamodel.PathSegment) (datamodel.Node, error) {
+	return mixins.Int{TypeName: "int"}.LookupBySegment(seg)
+}
+func (_uintNodeRepr) MapIterator() datamodel.MapIterator {
+	return nil
+}
+func (_uintNodeRepr) ListIterator() datamodel.ListIterator {
+	return nil
+}
+func (_uintNodeRepr) Length() int64 {
+	return -1
+}
+func (_uintNodeRepr) IsAbsent() bool {
+	return false
+}
+func (_uintNodeRepr) IsNull() bool {
+	return false
+}
+func (_uintNodeRepr) AsBool() (bool, error) {
+	return mixins.Int{TypeName: "int"}.AsBool()
+}
+func (tu *_uintNodeRepr) AsInt() (int64, error) {
+	if err := compatibleKind(tu.schemaType, datamodel.Kind_Int); err != nil {
+		return 0, err
+	}
+	if customConverter := tu.cfg.converterFor(tu.val); customConverter != nil {
+		// user has registered a converter that takes the underlying type and returns an int
+		return customConverter.customToInt(ptrVal(tu.val).Interface())
+	}
+	val := nonPtrVal(tu.val)
+	// we can assume it's a uint64 at this point
+	u := val.Uint()
+	if u > math.MaxInt64 {
+		return 0, fmt.Errorf("bindnode: integer overflow, %d is too large for an int64", u)
+	}
+	return int64(u), nil
+}
+func (tu *_uintNodeRepr) AsUint() (uint64, error) {
+	if err := compatibleKind(tu.schemaType, datamodel.Kind_Int); err != nil {
+		return 0, err
+	}
+	// TODO(rvagg): do we want a converter option for uint values? do we combine it
+	// with int converters?
+	// we can assume it's a uint64 at this point
+	return nonPtrVal(tu.val).Uint(), nil
+}
+func (_uintNodeRepr) AsFloat() (float64, error) {
+	return mixins.Int{TypeName: "int"}.AsFloat()
+}
+func (_uintNodeRepr) AsString() (string, error) {
+	return mixins.Int{TypeName: "int"}.AsString()
+}
+func (_uintNodeRepr) AsBytes() ([]byte, error) {
+	return mixins.Int{TypeName: "int"}.AsBytes()
+}
+func (_uintNodeRepr) AsLink() (datamodel.Link, error) {
+	return mixins.Int{TypeName: "int"}.AsLink()
+}
+func (_uintNodeRepr) Prototype() datamodel.NodePrototype {
+	return basicnode.Prototype__Int{}
 }

--- a/node/bindnode/node.go
+++ b/node/bindnode/node.go
@@ -432,7 +432,7 @@ func (w *_node) AsBool() (bool, error) {
 	if err := compatibleKind(w.schemaType, datamodel.Kind_Bool); err != nil {
 		return false, err
 	}
-	if customConverter, ok := w.cfg[nonPtrType(w.val)]; ok {
+	if customConverter, ok := w.cfg.converterFor(w.val); ok {
 		return customConverter.customToBool(ptrVal(w.val).Interface())
 	}
 	return nonPtrVal(w.val).Bool(), nil
@@ -442,7 +442,7 @@ func (w *_node) AsInt() (int64, error) {
 	if err := compatibleKind(w.schemaType, datamodel.Kind_Int); err != nil {
 		return 0, err
 	}
-	if customConverter, ok := w.cfg[nonPtrType(w.val)]; ok {
+	if customConverter, ok := w.cfg.converterFor(w.val); ok {
 		return customConverter.customToInt(ptrVal(w.val).Interface())
 	}
 	val := nonPtrVal(w.val)
@@ -457,7 +457,7 @@ func (w *_node) AsFloat() (float64, error) {
 	if err := compatibleKind(w.schemaType, datamodel.Kind_Float); err != nil {
 		return 0, err
 	}
-	if customConverter, ok := w.cfg[nonPtrType(w.val)]; ok {
+	if customConverter, ok := w.cfg.converterFor(w.val); ok {
 		return customConverter.customToFloat(ptrVal(w.val).Interface())
 	}
 	return nonPtrVal(w.val).Float(), nil
@@ -467,7 +467,7 @@ func (w *_node) AsString() (string, error) {
 	if err := compatibleKind(w.schemaType, datamodel.Kind_String); err != nil {
 		return "", err
 	}
-	if customConverter, ok := w.cfg[nonPtrType(w.val)]; ok {
+	if customConverter, ok := w.cfg.converterFor(w.val); ok {
 		return customConverter.customToString(ptrVal(w.val).Interface())
 	}
 	return nonPtrVal(w.val).String(), nil
@@ -477,7 +477,7 @@ func (w *_node) AsBytes() ([]byte, error) {
 	if err := compatibleKind(w.schemaType, datamodel.Kind_Bytes); err != nil {
 		return nil, err
 	}
-	if customConverter, ok := w.cfg[nonPtrType(w.val)]; ok {
+	if customConverter, ok := w.cfg.converterFor(w.val); ok {
 		return customConverter.customToBytes(ptrVal(w.val).Interface())
 	}
 	return nonPtrVal(w.val).Bytes(), nil
@@ -487,7 +487,7 @@ func (w *_node) AsLink() (datamodel.Link, error) {
 	if err := compatibleKind(w.schemaType, datamodel.Kind_Link); err != nil {
 		return nil, err
 	}
-	if customConverter, ok := w.cfg[nonPtrType(w.val)]; ok {
+	if customConverter, ok := w.cfg.converterFor(w.val); ok {
 		cid, err := customConverter.customToLink(ptrVal(w.val).Interface())
 		if err != nil {
 			return nil, err
@@ -596,7 +596,7 @@ func (w *_assembler) BeginMap(sizeHint int64) (datamodel.MapAssembler, error) {
 			return nil, err
 		}
 		var conv *converter = nil
-		if customConverter, ok := w.cfg[nonPtrType(w.val)]; ok {
+		if customConverter, ok := w.cfg.converterFor(w.val); ok {
 			conv = &customConverter
 		}
 		return &basicMapAssembler{MapAssembler: mapAsm, builder: basicBuilder, parent: w, converter: conv}, nil
@@ -680,7 +680,7 @@ func (w *_assembler) BeginList(sizeHint int64) (datamodel.ListAssembler, error) 
 			return nil, err
 		}
 		var conv *converter = nil
-		if customConverter, ok := w.cfg[nonPtrType(w.val)]; ok {
+		if customConverter, ok := w.cfg.converterFor(w.val); ok {
 			conv = &customConverter
 		}
 		return &basicListAssembler{ListAssembler: listAsm, builder: basicBuilder, parent: w, converter: conv}, nil
@@ -709,7 +709,7 @@ func (w *_assembler) AssignNull() error {
 			// TODO
 		}
 	}
-	if customConverter, ok := w.cfg[nonPtrType(w.val)]; ok {
+	if customConverter, ok := w.cfg.converterFor(w.val); ok {
 		typ, err := customConverter.customFromAny(datamodel.Null)
 		if err != nil {
 			return err
@@ -730,7 +730,7 @@ func (w *_assembler) AssignBool(b bool) error {
 	if err := compatibleKind(w.schemaType, datamodel.Kind_Bool); err != nil {
 		return err
 	}
-	customConverter, hasCustomConverter := w.cfg[nonPtrType(w.val)]
+	customConverter, hasCustomConverter := w.cfg.converterFor(w.val)
 	_, isAny := w.schemaType.(*schema.TypeAny)
 	if hasCustomConverter {
 		var typ interface{}
@@ -765,7 +765,7 @@ func (w *_assembler) AssignInt(i int64) error {
 		return err
 	}
 	// TODO: check for overflow
-	customConverter, hasCustomConverter := w.cfg[nonPtrType(w.val)]
+	customConverter, hasCustomConverter := w.cfg.converterFor(w.val)
 	_, isAny := w.schemaType.(*schema.TypeAny)
 	if hasCustomConverter {
 		var typ interface{}
@@ -805,7 +805,7 @@ func (w *_assembler) AssignFloat(f float64) error {
 	if err := compatibleKind(w.schemaType, datamodel.Kind_Float); err != nil {
 		return err
 	}
-	customConverter, hasCustomConverter := w.cfg[nonPtrType(w.val)]
+	customConverter, hasCustomConverter := w.cfg.converterFor(w.val)
 	_, isAny := w.schemaType.(*schema.TypeAny)
 	if hasCustomConverter {
 		var typ interface{}
@@ -839,7 +839,7 @@ func (w *_assembler) AssignString(s string) error {
 	if err := compatibleKind(w.schemaType, datamodel.Kind_String); err != nil {
 		return err
 	}
-	customConverter, hasCustomConverter := w.cfg[nonPtrType(w.val)]
+	customConverter, hasCustomConverter := w.cfg.converterFor(w.val)
 	_, isAny := w.schemaType.(*schema.TypeAny)
 	if hasCustomConverter {
 		var typ interface{}
@@ -873,7 +873,7 @@ func (w *_assembler) AssignBytes(p []byte) error {
 	if err := compatibleKind(w.schemaType, datamodel.Kind_Bytes); err != nil {
 		return err
 	}
-	customConverter, hasCustomConverter := w.cfg[nonPtrType(w.val)]
+	customConverter, hasCustomConverter := w.cfg.converterFor(w.val)
 	_, isAny := w.schemaType.(*schema.TypeAny)
 	if hasCustomConverter {
 		var typ interface{}
@@ -907,7 +907,7 @@ func (w *_assembler) AssignLink(link datamodel.Link) error {
 	val := w.createNonPtrVal()
 	// TODO: newVal.Type() panics if link==nil; add a test and fix.
 	if _, ok := w.schemaType.(*schema.TypeAny); ok {
-		if customConverter, ok := w.cfg[nonPtrType(w.val)]; ok {
+		if customConverter, ok := w.cfg.converterFor(w.val); ok {
 			typ, err := customConverter.customFromAny(basicnode.NewLink(link))
 			if err != nil {
 				return err
@@ -916,7 +916,7 @@ func (w *_assembler) AssignLink(link datamodel.Link) error {
 		} else {
 			val.Set(reflect.ValueOf(basicnode.NewLink(link)))
 		}
-	} else if customConverter, ok := w.cfg[nonPtrType(w.val)]; ok {
+	} else if customConverter, ok := w.cfg.converterFor(w.val); ok {
 		if cl, ok := link.(cidlink.Link); ok {
 			typ, err := customConverter.customFromLink(cl.Cid)
 			if err != nil {
@@ -1317,7 +1317,7 @@ func (w *_structIterator) Next() (key, value datamodel.Node, _ error) {
 		}
 	}
 	if _, ok := field.Type().(*schema.TypeAny); ok {
-		if customConverter, ok := w.cfg[nonPtrType(val)]; ok {
+		if customConverter, ok := w.cfg.converterFor(val); ok {
 			v, err := customConverter.customToAny(ptrVal(val).Interface())
 			if err != nil {
 				return nil, nil, err

--- a/node/bindnode/node.go
+++ b/node/bindnode/node.go
@@ -702,7 +702,8 @@ func (w *_assembler) BeginList(sizeHint int64) (datamodel.ListAssembler, error) 
 }
 
 func (w *_assembler) AssignNull() error {
-	if customConverter, ok := w.cfg.converterFor(w.val); ok {
+	_, isAny := w.schemaType.(*schema.TypeAny)
+	if customConverter, ok := w.cfg.converterFor(w.val); ok && isAny {
 		typ, err := customConverter.customFromAny(datamodel.Null)
 		if err != nil {
 			return err

--- a/node/bindnode/repr.go
+++ b/node/bindnode/repr.go
@@ -39,6 +39,7 @@ type _prototypeRepr _prototype
 
 func (w *_prototypeRepr) NewBuilder() datamodel.NodeBuilder {
 	return &_builderRepr{_assemblerRepr{
+		cfg:        w.cfg,
 		schemaType: w.schemaType,
 		val:        reflect.New(w.goType).Elem(),
 	}}
@@ -268,7 +269,7 @@ func (w *_nodeRepr) ListIterator() datamodel.ListIterator {
 	switch reprStrategy(w.schemaType).(type) {
 	case schema.StructRepresentation_Tuple:
 		typ := w.schemaType.(*schema.TypeStruct)
-		iter := _tupleIteratorRepr{schemaType: typ, fields: typ.Fields(), val: w.val}
+		iter := _tupleIteratorRepr{cfg: w.cfg, schemaType: typ, fields: typ.Fields(), val: w.val}
 		iter.reprEnd = int(w.lengthMinusTrailingAbsents())
 		return &iter
 	default:
@@ -307,6 +308,7 @@ func (w *_nodeRepr) lengthMinusAbsents() int64 {
 
 type _tupleIteratorRepr struct {
 	// TODO: support embedded fields?
+	cfg        config
 	schemaType *schema.TypeStruct
 	fields     []schema.StructField
 	val        reflect.Value // non-pointer
@@ -535,7 +537,7 @@ type _builderRepr struct {
 func (w *_builderRepr) Build() datamodel.Node {
 	// TODO: see the notes above.
 	// return &_nodeRepr{schemaType: w.schemaType, val: w.val}
-	return &_node{schemaType: w.schemaType, val: w.val}
+	return &_node{cfg: w.cfg, schemaType: w.schemaType, val: w.val}
 }
 
 func (w *_builderRepr) Reset() {
@@ -543,6 +545,7 @@ func (w *_builderRepr) Reset() {
 }
 
 type _assemblerRepr struct {
+	cfg        config
 	schemaType schema.Type
 	val        reflect.Value // non-pointer
 	finish     func() error

--- a/node/bindnode/repr.go
+++ b/node/bindnode/repr.go
@@ -656,6 +656,21 @@ func (w *_assemblerRepr) AssignBool(b bool) error {
 	}
 }
 
+func (w *_assemblerRepr) assignUInt(uin datamodel.UintNode) error {
+	switch stg := reprStrategy(w.schemaType).(type) {
+	case schema.UnionRepresentation_Kinded:
+		return w.asKinded(stg, datamodel.Kind_Int).(*_assemblerRepr).assignUInt(uin)
+	case schema.EnumRepresentation_Int:
+		uin, err := uin.AsUint()
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("AssignInt: %d is not a valid member of enum %s", uin, w.schemaType.Name())
+	default:
+		return (*_assembler)(w).assignUInt(uin)
+	}
+}
+
 func (w *_assemblerRepr) AssignInt(i int64) error {
 	switch stg := reprStrategy(w.schemaType).(type) {
 	case schema.UnionRepresentation_Kinded:
@@ -820,6 +835,9 @@ func (w *_assemblerRepr) AssignLink(link datamodel.Link) error {
 
 func (w *_assemblerRepr) AssignNode(node datamodel.Node) error {
 	// TODO: attempt to take a shortcut, like assembler.AssignNode
+	if uintNode, ok := node.(datamodel.UintNode); ok {
+		return w.assignUInt(uintNode)
+	}
 	return datamodel.Copy(node, w)
 }
 


### PR DESCRIPTION
This arises out of the attempts to push bindnode down into go-fil-markets for go-data-transfer vouchers. There are some types that are difficult to handle without just replacing them and having a conversion layer.

(Skip to custom_test.go for the code TL;DR)

To give some idea of the challenges, here's the list of types in their hierarchies that become difficult:

- `retrievalmarket.DealResponse`
    - `go-state-types/abi/TokenAmount` - `go-state-types/big/Int` - `struct{*big.Int}`
- `retrievalmarket.DealProposal`
    - `retrievalmarket.Params`
      - `go-state-types/abi/TokenAmount` - `go-state-types/big/Int` - `struct{*big.Int}`
- `retrievalmarket.DealPayment`
    - `go-address/Address` - `struct{string}`
    - `specs-actors/actors/builtin/paych/SignedVoucher`
      - `go-address/Address` - `struct{string}`
      - `specs-actors/actors/builtin/paych/ModVerifyParams`
        - `go-address/Address` - `struct{string}`
      - `go-state-types/big/Int` - `struct{*big.Int}`
      - `go-state-types/crypto/crypto.Signature`
        - this is a `byteprefix` union, `SigType` is first byte, `Data` is remainder, it could be read as `Bytes` and converted internally rather than implementing `byteprefix`

All of these types currently have their own custom, hand-rolled, `UnmarshalCBOR()` and `MarshalCBOR()` methods for cbor-gen. They're also not in go-fil-markets, so attempting to do anything direct with them (like adding custom methods) means chasing through lots of repos.

The approach I'm taking here is to add some options when calling bindnode, with these you can register converters for your custom types. In all of the above instances it's `Bytes` that we're dealing with, I think it's going to be the most common so I've only implemented that for now but I think a complete version of this would do it for all scalar kinds. Your schema still has to say that the field is `Bytes` / `bytes` but when traversing the Go type, if it encounters that type you registered for and it has the right kind then it'll run through your converter, either way.

The current version requires you supply two functions, a `to` and a `from` and they are checked for types. A previous iteration which you can see in 12a0ca48 had a converter type interface which had two functions and it'd need one for each kind we're allowing to register. I switched to supplying functions and validating with reflection for a slightly cleaner API. Plus, if you have existing functions like `NewFromBytes()` (which `Address` has) that matches the converter signature then you can just pass that in.