### PR TITLE
feat(bindnode): add AddCustomTypeAnyConverter() to handle `Any` fields

### DIFF
--- a/node/bindnode/api.go
+++ b/node/bindnode/api.go
@@ -57,87 +57,29 @@ func Prototype(ptrType interface{}, schemaType schema.Type, options ...Option) s
 	return &_prototype{cfg: cfg, schemaType: schemaType, goType: goType}
 }
 
-// scalar kinds excluding Null
-
-// CustomFromBool is a custom converter function that takes a bool and returns a
-// custom type
-type CustomFromBool func(bool) (interface{}, error)
-
-// CustomToBool is a custom converter function that takes a custom type and
-// returns a bool
-type CustomToBool func(interface{}) (bool, error)
-
-// CustomFromInt is a custom converter function that takes an int and returns a
-// custom type
-type CustomFromInt func(int64) (interface{}, error)
-
-// CustomToInt is a custom converter function that takes a custom type and
-// returns an int
-type CustomToInt func(interface{}) (int64, error)
-
-// CustomFromFloat is a custom converter function that takes a float and returns
-// a custom type
-type CustomFromFloat func(float64) (interface{}, error)
-
-// CustomToFloat is a custom converter function that takes a custom type and
-// returns a float
-type CustomToFloat func(interface{}) (float64, error)
-
-// CustomFromString is a custom converter function that takes a string and
-// returns custom type
-type CustomFromString func(string) (interface{}, error)
-
-// CustomToString is a custom converter function that takes a custom type and
-// returns a string
-type CustomToString func(interface{}) (string, error)
-
-// CustomFromBytes is a custom converter function that takes a byte slice and
-// returns a custom type
-type CustomFromBytes func([]byte) (interface{}, error)
-
-// CustomToBytes is a custom converter function that takes a custom type and
-// returns a byte slice
-type CustomToBytes func(interface{}) ([]byte, error)
-
-// CustomFromLink is a custom converter function that takes a cid.Cid and
-// returns a custom type
-type CustomFromLink func(cid.Cid) (interface{}, error)
-
-// CustomToLink is a custom converter function that takes a custom type and
-// returns a cid.Cid
-type CustomToLink func(interface{}) (cid.Cid, error)
-
-// CustomFromAny is a custom converter function that takes a datamodel.Node and
-// returns a custom type
-type CustomFromAny func(datamodel.Node) (interface{}, error)
-
-// CustomToAny is a custom converter function that takes a custom type and
-// returns a datamodel.Node
-type CustomToAny func(interface{}) (datamodel.Node, error)
-
 type converter struct {
 	kind schema.TypeKind
 
-	customFromBool CustomFromBool
-	customToBool   CustomToBool
+	customFromBool func(bool) (interface{}, error)
+	customToBool   func(interface{}) (bool, error)
 
-	customFromInt CustomFromInt
-	customToInt   CustomToInt
+	customFromInt func(int64) (interface{}, error)
+	customToInt   func(interface{}) (int64, error)
 
-	customFromFloat CustomFromFloat
-	customToFloat   CustomToFloat
+	customFromFloat func(float64) (interface{}, error)
+	customToFloat   func(interface{}) (float64, error)
 
-	customFromString CustomFromString
-	customToString   CustomToString
+	customFromString func(string) (interface{}, error)
+	customToString   func(interface{}) (string, error)
 
-	customFromBytes CustomFromBytes
-	customToBytes   CustomToBytes
+	customFromBytes func([]byte) (interface{}, error)
+	customToBytes   func(interface{}) ([]byte, error)
 
-	customFromLink CustomFromLink
-	customToLink   CustomToLink
+	customFromLink func(cid.Cid) (interface{}, error)
+	customToLink   func(interface{}) (cid.Cid, error)
 
-	customFromAny CustomFromAny
-	customToAny   CustomToAny
+	customFromAny func(datamodel.Node) (interface{}, error)
+	customToAny   func(interface{}) (datamodel.Node, error)
 }
 
 type config map[reflect.Type]*converter
@@ -169,7 +111,7 @@ type Option func(config)
 //
 // TypedBoolConverter is an EXPERIMENTAL API and may be removed or
 // changed in a future release.
-func TypedBoolConverter(ptrVal interface{}, from CustomFromBool, to CustomToBool) Option {
+func TypedBoolConverter(ptrVal interface{}, from func(bool) (interface{}, error), to func(interface{}) (bool, error)) Option {
 	customType := nonPtrType(reflect.ValueOf(ptrVal))
 	converter := &converter{
 		kind:           schema.TypeKind_Bool,
@@ -189,7 +131,7 @@ func TypedBoolConverter(ptrVal interface{}, from CustomFromBool, to CustomToBool
 //
 // TypedIntConverter is an EXPERIMENTAL API and may be removed or
 // changed in a future release.
-func TypedIntConverter(ptrVal interface{}, from CustomFromInt, to CustomToInt) Option {
+func TypedIntConverter(ptrVal interface{}, from func(int64) (interface{}, error), to func(interface{}) (int64, error)) Option {
 	customType := nonPtrType(reflect.ValueOf(ptrVal))
 	converter := &converter{
 		kind:          schema.TypeKind_Int,
@@ -209,7 +151,7 @@ func TypedIntConverter(ptrVal interface{}, from CustomFromInt, to CustomToInt) O
 //
 // TypedFloatConverter is an EXPERIMENTAL API and may be removed or
 // changed in a future release.
-func TypedFloatConverter(ptrVal interface{}, from CustomFromFloat, to CustomToFloat) Option {
+func TypedFloatConverter(ptrVal interface{}, from func(float64) (interface{}, error), to func(interface{}) (float64, error)) Option {
 	customType := nonPtrType(reflect.ValueOf(ptrVal))
 	converter := &converter{
 		kind:            schema.TypeKind_Float,
@@ -229,7 +171,7 @@ func TypedFloatConverter(ptrVal interface{}, from CustomFromFloat, to CustomToFl
 //
 // TypedStringConverter is an EXPERIMENTAL API and may be removed or
 // changed in a future release.
-func TypedStringConverter(ptrVal interface{}, from CustomFromString, to CustomToString) Option {
+func TypedStringConverter(ptrVal interface{}, from func(string) (interface{}, error), to func(interface{}) (string, error)) Option {
 	customType := nonPtrType(reflect.ValueOf(ptrVal))
 	converter := &converter{
 		kind:             schema.TypeKind_String,
@@ -249,7 +191,7 @@ func TypedStringConverter(ptrVal interface{}, from CustomFromString, to CustomTo
 //
 // TypedBytesConverter is an EXPERIMENTAL API and may be removed or
 // changed in a future release.
-func TypedBytesConverter(ptrVal interface{}, from CustomFromBytes, to CustomToBytes) Option {
+func TypedBytesConverter(ptrVal interface{}, from func([]byte) (interface{}, error), to func(interface{}) ([]byte, error)) Option {
 	customType := nonPtrType(reflect.ValueOf(ptrVal))
 	converter := &converter{
 		kind:            schema.TypeKind_Bytes,
@@ -273,7 +215,7 @@ func TypedBytesConverter(ptrVal interface{}, from CustomFromBytes, to CustomToBy
 //
 // TypedLinkConverter is an EXPERIMENTAL API and may be removed or
 // changed in a future release.
-func TypedLinkConverter(ptrVal interface{}, from CustomFromLink, to CustomToLink) Option {
+func TypedLinkConverter(ptrVal interface{}, from func(cid.Cid) (interface{}, error), to func(interface{}) (cid.Cid, error)) Option {
 	customType := nonPtrType(reflect.ValueOf(ptrVal))
 	converter := &converter{
 		kind:           schema.TypeKind_Link,
@@ -296,7 +238,7 @@ func TypedLinkConverter(ptrVal interface{}, from CustomFromLink, to CustomToLink
 //
 // TypedAnyConverter is an EXPERIMENTAL API and may be removed or
 // changed in a future release.
-func TypedAnyConverter(ptrVal interface{}, from CustomFromAny, to CustomToAny) Option {
+func TypedAnyConverter(ptrVal interface{}, from func(datamodel.Node) (interface{}, error), to func(interface{}) (datamodel.Node, error)) Option {
 	customType := nonPtrType(reflect.ValueOf(ptrVal))
 	converter := &converter{
 		kind:          schema.TypeKind_Any,

--- a/node/bindnode/api.go
+++ b/node/bindnode/api.go
@@ -142,6 +142,14 @@ type converter struct {
 
 type config map[reflect.Type]converter
 
+func (c config) converterFor(val reflect.Value) (converter, bool) {
+	if len(c) == 0 {
+		return converter{}, false
+	}
+	conv, ok := c[nonPtrType(val)]
+	return conv, ok
+}
+
 // Option is able to apply custom options to the bindnode API
 type Option func(config)
 

--- a/node/bindnode/api.go
+++ b/node/bindnode/api.go
@@ -140,39 +140,39 @@ type converter struct {
 	customToAny   CustomToAny
 }
 
-type config map[reflect.Type]converter
+type config map[reflect.Type]*converter
 
-func (c config) converterFor(val reflect.Value) (converter, bool) {
+func (c config) converterFor(val reflect.Value) *converter {
 	if len(c) == 0 {
-		return converter{}, false
+		return nil
 	}
-	conv, ok := c[nonPtrType(val)]
-	return conv, ok
+	conv, _ := c[nonPtrType(val)]
+	return conv
 }
 
-func (c config) converterForType(typ reflect.Type) (converter, bool) {
+func (c config) converterForType(typ reflect.Type) *converter {
 	if len(c) == 0 {
-		return converter{}, false
+		return nil
 	}
-	conv, ok := c[typ]
-	return conv, ok
+	conv, _ := c[typ]
+	return conv
 }
 
 // Option is able to apply custom options to the bindnode API
 type Option func(config)
 
-// AddCustomTypeBoolConverter adds custom converter functions for a particular
+// TypedBoolConverter adds custom converter functions for a particular
 // type as identified by a pointer in the first argument.
 // The fromFunc is of the form: func(bool) (interface{}, error)
 // and toFunc is of the form: func(interface{}) (bool, error)
 // where interface{} is a pointer form of the type we are converting.
 //
-// AddCustomTypeBoolConverter is an EXPERIMENTAL API and may be removed or
+// TypedBoolConverter is an EXPERIMENTAL API and may be removed or
 // changed in a future release.
-func AddCustomTypeBoolConverter(ptrVal interface{}, from CustomFromBool, to CustomToBool) Option {
+func TypedBoolConverter(ptrVal interface{}, from CustomFromBool, to CustomToBool) Option {
 	customType := nonPtrType(reflect.ValueOf(ptrVal))
 	return func(cfg config) {
-		cfg[customType] = converter{
+		cfg[customType] = &converter{
 			kind:           schema.TypeKind_Bool,
 			customFromBool: from,
 			customToBool:   to,
@@ -180,18 +180,18 @@ func AddCustomTypeBoolConverter(ptrVal interface{}, from CustomFromBool, to Cust
 	}
 }
 
-// AddCustomTypeIntConverter adds custom converter functions for a particular
+// TypedIntConverter adds custom converter functions for a particular
 // type as identified by a pointer in the first argument.
 // The fromFunc is of the form: func(int64) (interface{}, error)
 // and toFunc is of the form: func(interface{}) (int64, error)
 // where interface{} is a pointer form of the type we are converting.
 //
-// AddCustomTypeIntConverter is an EXPERIMENTAL API and may be removed or
+// TypedIntConverter is an EXPERIMENTAL API and may be removed or
 // changed in a future release.
-func AddCustomTypeIntConverter(ptrVal interface{}, from CustomFromInt, to CustomToInt) Option {
+func TypedIntConverter(ptrVal interface{}, from CustomFromInt, to CustomToInt) Option {
 	customType := nonPtrType(reflect.ValueOf(ptrVal))
 	return func(cfg config) {
-		cfg[customType] = converter{
+		cfg[customType] = &converter{
 			kind:          schema.TypeKind_Int,
 			customFromInt: from,
 			customToInt:   to,
@@ -199,18 +199,18 @@ func AddCustomTypeIntConverter(ptrVal interface{}, from CustomFromInt, to Custom
 	}
 }
 
-// AddCustomTypeFloatConverter adds custom converter functions for a particular
+// TypedFloatConverter adds custom converter functions for a particular
 // type as identified by a pointer in the first argument.
 // The fromFunc is of the form: func(float64) (interface{}, error)
 // and toFunc is of the form: func(interface{}) (float64, error)
 // where interface{} is a pointer form of the type we are converting.
 //
-// AddCustomTypeFloatConverter is an EXPERIMENTAL API and may be removed or
+// TypedFloatConverter is an EXPERIMENTAL API and may be removed or
 // changed in a future release.
-func AddCustomTypeFloatConverter(ptrVal interface{}, from CustomFromFloat, to CustomToFloat) Option {
+func TypedFloatConverter(ptrVal interface{}, from CustomFromFloat, to CustomToFloat) Option {
 	customType := nonPtrType(reflect.ValueOf(ptrVal))
 	return func(cfg config) {
-		cfg[customType] = converter{
+		cfg[customType] = &converter{
 			kind:            schema.TypeKind_Float,
 			customFromFloat: from,
 			customToFloat:   to,
@@ -218,18 +218,18 @@ func AddCustomTypeFloatConverter(ptrVal interface{}, from CustomFromFloat, to Cu
 	}
 }
 
-// AddCustomTypeStringConverter adds custom converter functions for a particular
+// TypedStringConverter adds custom converter functions for a particular
 // type as identified by a pointer in the first argument.
 // The fromFunc is of the form: func(string) (interface{}, error)
 // and toFunc is of the form: func(interface{}) (string, error)
 // where interface{} is a pointer form of the type we are converting.
 //
-// AddCustomTypeStringConverter is an EXPERIMENTAL API and may be removed or
+// TypedStringConverter is an EXPERIMENTAL API and may be removed or
 // changed in a future release.
-func AddCustomTypeStringConverter(ptrVal interface{}, from CustomFromString, to CustomToString) Option {
+func TypedStringConverter(ptrVal interface{}, from CustomFromString, to CustomToString) Option {
 	customType := nonPtrType(reflect.ValueOf(ptrVal))
 	return func(cfg config) {
-		cfg[customType] = converter{
+		cfg[customType] = &converter{
 			kind:             schema.TypeKind_String,
 			customFromString: from,
 			customToString:   to,
@@ -237,18 +237,18 @@ func AddCustomTypeStringConverter(ptrVal interface{}, from CustomFromString, to 
 	}
 }
 
-// AddCustomTypeBytesConverter adds custom converter functions for a particular
+// TypedBytesConverter adds custom converter functions for a particular
 // type as identified by a pointer in the first argument.
 // The fromFunc is of the form: func([]byte) (interface{}, error)
 // and toFunc is of the form: func(interface{}) ([]byte, error)
 // where interface{} is a pointer form of the type we are converting.
 //
-// AddCustomTypeBytesConverter is an EXPERIMENTAL API and may be removed or
+// TypedBytesConverter is an EXPERIMENTAL API and may be removed or
 // changed in a future release.
-func AddCustomTypeBytesConverter(ptrVal interface{}, from CustomFromBytes, to CustomToBytes) Option {
+func TypedBytesConverter(ptrVal interface{}, from CustomFromBytes, to CustomToBytes) Option {
 	customType := nonPtrType(reflect.ValueOf(ptrVal))
 	return func(cfg config) {
-		cfg[customType] = converter{
+		cfg[customType] = &converter{
 			kind:            schema.TypeKind_Bytes,
 			customFromBytes: from,
 			customToBytes:   to,
@@ -256,7 +256,7 @@ func AddCustomTypeBytesConverter(ptrVal interface{}, from CustomFromBytes, to Cu
 	}
 }
 
-// AddCustomTypeLinkConverter adds custom converter functions for a particular
+// TypedLinkConverter adds custom converter functions for a particular
 // type as identified by a pointer in the first argument.
 // The fromFunc is of the form: func([]byte) (interface{}, error)
 // and toFunc is of the form: func(interface{}) ([]byte, error)
@@ -266,12 +266,12 @@ func AddCustomTypeBytesConverter(ptrVal interface{}, from CustomFromBytes, to Cu
 // model and may result in errors if attempting to convert from other
 // datamodel.Link types.
 //
-// AddCustomTypeLinkConverter is an EXPERIMENTAL API and may be removed or
+// TypedLinkConverter is an EXPERIMENTAL API and may be removed or
 // changed in a future release.
-func AddCustomTypeLinkConverter(ptrVal interface{}, from CustomFromLink, to CustomToLink) Option {
+func TypedLinkConverter(ptrVal interface{}, from CustomFromLink, to CustomToLink) Option {
 	customType := nonPtrType(reflect.ValueOf(ptrVal))
 	return func(cfg config) {
-		cfg[customType] = converter{
+		cfg[customType] = &converter{
 			kind:           schema.TypeKind_Link,
 			customFromLink: from,
 			customToLink:   to,
@@ -279,7 +279,7 @@ func AddCustomTypeLinkConverter(ptrVal interface{}, from CustomFromLink, to Cust
 	}
 }
 
-// AddCustomTypeAnyConverter adds custom converter functions for a particular
+// TypedAnyConverter adds custom converter functions for a particular
 // type as identified by a pointer in the first argument.
 // The fromFunc is of the form: func(datamodel.Node) (interface{}, error)
 // and toFunc is of the form: func(interface{}) (datamodel.Node, error)
@@ -288,12 +288,12 @@ func AddCustomTypeLinkConverter(ptrVal interface{}, from CustomFromLink, to Cust
 // This method should be able to deal with all forms of Any and return an error
 // if the expected data forms don't match the expected.
 //
-// AddCustomTypeAnyConverter is an EXPERIMENTAL API and may be removed or
+// TypedAnyConverter is an EXPERIMENTAL API and may be removed or
 // changed in a future release.
-func AddCustomTypeAnyConverter(ptrVal interface{}, from CustomFromAny, to CustomToAny) Option {
+func TypedAnyConverter(ptrVal interface{}, from CustomFromAny, to CustomToAny) Option {
 	customType := nonPtrType(reflect.ValueOf(ptrVal))
 	return func(cfg config) {
-		cfg[customType] = converter{
+		cfg[customType] = &converter{
 			kind:          schema.TypeKind_Any,
 			customFromAny: from,
 			customToAny:   to,
@@ -302,7 +302,7 @@ func AddCustomTypeAnyConverter(ptrVal interface{}, from CustomFromAny, to Custom
 }
 
 func applyOptions(opt ...Option) config {
-	cfg := make(map[reflect.Type]converter)
+	cfg := make(map[reflect.Type]*converter)
 	for _, o := range opt {
 		o(cfg)
 	}

--- a/node/bindnode/api.go
+++ b/node/bindnode/api.go
@@ -150,6 +150,14 @@ func (c config) converterFor(val reflect.Value) (converter, bool) {
 	return conv, ok
 }
 
+func (c config) converterForType(typ reflect.Type) (converter, bool) {
+	if len(c) == 0 {
+		return converter{}, false
+	}
+	conv, ok := c[typ]
+	return conv, ok
+}
+
 // Option is able to apply custom options to the bindnode API
 type Option func(config)
 

--- a/node/bindnode/api.go
+++ b/node/bindnode/api.go
@@ -142,20 +142,20 @@ type converter struct {
 
 type config map[reflect.Type]*converter
 
+// this mainly exists to short-circuit the nonPtrType() call; the `Type()` variant
+// exists for completeness
 func (c config) converterFor(val reflect.Value) *converter {
 	if len(c) == 0 {
 		return nil
 	}
-	conv, _ := c[nonPtrType(val)]
-	return conv
+	return c[nonPtrType(val)]
 }
 
 func (c config) converterForType(typ reflect.Type) *converter {
 	if len(c) == 0 {
 		return nil
 	}
-	conv, _ := c[typ]
-	return conv
+	return c[typ]
 }
 
 // Option is able to apply custom options to the bindnode API

--- a/node/bindnode/custom_test.go
+++ b/node/bindnode/custom_test.go
@@ -279,13 +279,13 @@ var boomFixtureInstance = Boom{
 
 func TestCustom(t *testing.T) {
 	opts := []bindnode.Option{
-		bindnode.AddCustomTypeBytesConverter(&Boop{}, BoopFromBytes, BoopToBytes),
-		bindnode.AddCustomTypeBytesConverter(&Frop{}, FropFromBytes, FropToBytes),
-		bindnode.AddCustomTypeBoolConverter(BoolSubst(0), BoolSubstFromBool, BoolToBoolSubst),
-		bindnode.AddCustomTypeIntConverter(IntSubst(""), IntSubstFromInt, IntToIntSubst),
-		bindnode.AddCustomTypeFloatConverter(&BigFloat{}, BigFloatFromFloat, FloatFromBigFloat),
-		bindnode.AddCustomTypeStringConverter(&ByteArray{}, ByteArrayFromString, StringFromByteArray),
-		bindnode.AddCustomTypeLinkConverter(BtcId(""), FromCidToBtcId, FromBtcIdToCid),
+		bindnode.TypedBytesConverter(&Boop{}, BoopFromBytes, BoopToBytes),
+		bindnode.TypedBytesConverter(&Frop{}, FropFromBytes, FropToBytes),
+		bindnode.TypedBoolConverter(BoolSubst(0), BoolSubstFromBool, BoolToBoolSubst),
+		bindnode.TypedIntConverter(IntSubst(""), IntSubstFromInt, IntToIntSubst),
+		bindnode.TypedFloatConverter(&BigFloat{}, BigFloatFromFloat, FloatFromBigFloat),
+		bindnode.TypedStringConverter(&ByteArray{}, ByteArrayFromString, StringFromByteArray),
+		bindnode.TypedLinkConverter(BtcId(""), FromCidToBtcId, FromBtcIdToCid),
 	}
 
 	typeSystem, err := ipld.LoadSchemaBytes([]byte(boomSchema))
@@ -472,9 +472,9 @@ var anyExtendFixtureInstance = AnyExtend{
 
 func TestCustomAny(t *testing.T) {
 	opts := []bindnode.Option{
-		bindnode.AddCustomTypeAnyConverter(&AnyExtendBlob{}, AnyExtendBlobFromNode, AnyExtendBlobToNode),
-		bindnode.AddCustomTypeAnyConverter(&AnyCborEncoded{}, AnyCborEncodedFromNode, AnyCborEncodedToNode),
-		bindnode.AddCustomTypeBoolConverter(BoolSubst(0), BoolSubstFromBool, BoolToBoolSubst),
+		bindnode.TypedAnyConverter(&AnyExtendBlob{}, AnyExtendBlobFromNode, AnyExtendBlobToNode),
+		bindnode.TypedAnyConverter(&AnyCborEncoded{}, AnyCborEncodedFromNode, AnyCborEncodedToNode),
+		bindnode.TypedBoolConverter(BoolSubst(0), BoolSubstFromBool, BoolToBoolSubst),
 	}
 
 	typeSystem, err := ipld.LoadSchemaBytes([]byte(anyExtendSchema))

--- a/node/bindnode/custom_test.go
+++ b/node/bindnode/custom_test.go
@@ -332,6 +332,13 @@ type AnyExtend struct {
 	Map          AnyCborEncoded
 	List         AnyCborEncoded
 	BoolPtr      *BoolSubst // included to test that a null entry won't call a non-Any converter
+	XListAny     []AnyCborEncoded
+	XMapAny      anyMap
+}
+
+type anyMap struct {
+	Keys   []string
+	Values map[string]*AnyCborEncoded
 }
 
 const anyExtendSchema = `
@@ -351,6 +358,8 @@ type AnyExtend struct {
 	Map Any
 	List Any
 	BoolPtr nullable Bool
+	XListAny [Any]
+	XMapAny {String:Any}
 }
 `
 
@@ -450,7 +459,7 @@ func AnyCborEncodedToNode(ptr interface{}) (datamodel.Node, error) {
 	return na.Build(), nil
 }
 
-const anyExtendDagJson = `{"Blob":{"baz":[2,3,4],"foo":"bar"},"Bool":false,"BoolPtr":null,"Bytes":{"/":{"bytes":"AgMEBQYHCA"}},"Count":101,"Float":2.34,"Int":123456789,"Link":{"/":"bagyacvra2e6qt2fohajauxceox55t3gedsyqap2phmv7q2qaaaaaaaaaaaaa"},"List":[null,"one","two","three",1,2,3,true],"Map":{"foo":"bar","one":1,"three":3,"two":2},"Name":"Any extend test","Null":null,"NullPtr":null,"NullableWith":123456789,"String":"this is a string"}`
+const anyExtendDagJson = `{"Blob":{"baz":[2,3,4],"foo":"bar"},"Bool":false,"BoolPtr":null,"Bytes":{"/":{"bytes":"AgMEBQYHCA"}},"Count":101,"Float":2.34,"Int":123456789,"Link":{"/":"bagyacvra2e6qt2fohajauxceox55t3gedsyqap2phmv7q2qaaaaaaaaaaaaa"},"List":[null,"one","two","three",1,2,3,true],"Map":{"foo":"bar","one":1,"three":3,"two":2},"Name":"Any extend test","Null":null,"NullPtr":null,"NullableWith":123456789,"String":"this is a string","XListAny":[1,2,true,null,"bop"],"XMapAny":{"a":1,"b":2,"c":true,"d":null,"e":"bop"}}`
 
 var anyExtendFixtureInstance = AnyExtend{
 	Name:         "Any extend test",
@@ -460,14 +469,23 @@ var anyExtendFixtureInstance = AnyExtend{
 	NullPtr:      &AnyCborEncoded{mustFromHex("f6")},
 	NullableWith: &AnyCborEncoded{mustFromHex("1a075bcd15")},
 	Bool:         AnyCborEncoded{mustFromHex("f4")},
-	Int:          AnyCborEncoded{mustFromHex("1a075bcd15")},                                                                           // cbor encoded form of 123456789
-	Float:        AnyCborEncoded{mustFromHex("fb4002b851eb851eb8")},                                                                   // cbor encoded form of 2.34
-	String:       AnyCborEncoded{mustFromHex("7074686973206973206120737472696e67")},                                                   // cbor encoded form of "this is a string"
-	Bytes:        AnyCborEncoded{mustFromHex("4702030405060708")},                                                                     // cbor encoded form of [2,3,4,5,6,7,8]
-	Link:         AnyCborEncoded{mustFromHex("d82a58260001b0015620d13d09e8ae38120a5c4475fbd9ecc41cb1003f4f3b2bf86a0000000000000000")}, // dag-cbor encoded CID bagyacvra2e6qt2fohajauxceox55t3gedsyqap2phmv7q2qaaaaaaaaaaaaa
-	Map:          AnyCborEncoded{mustFromHex("a463666f6f63626172636f6e65016374776f0265746872656503")},                                 // cbor encoded form of {"one":1,"two":2,"three":3,"foo":"bar"}
-	List:         AnyCborEncoded{mustFromHex("88f6636f6e656374776f657468726565010203f5")},                                             // cbor encoded form of [null,'one','two','three',1,2,3,true]
+	Int:          AnyCborEncoded{mustFromHex("1a075bcd15")},                                                                           // 123456789
+	Float:        AnyCborEncoded{mustFromHex("fb4002b851eb851eb8")},                                                                   // 2.34
+	String:       AnyCborEncoded{mustFromHex("7074686973206973206120737472696e67")},                                                   // "this is a string"
+	Bytes:        AnyCborEncoded{mustFromHex("4702030405060708")},                                                                     // [2,3,4,5,6,7,8]
+	Link:         AnyCborEncoded{mustFromHex("d82a58260001b0015620d13d09e8ae38120a5c4475fbd9ecc41cb1003f4f3b2bf86a0000000000000000")}, // bagyacvra2e6qt2fohajauxceox55t3gedsyqap2phmv7q2qaaaaaaaaaaaaa
+	Map:          AnyCborEncoded{mustFromHex("a463666f6f63626172636f6e65016374776f0265746872656503")},                                 // {"one":1,"two":2,"three":3,"foo":"bar"}
+	List:         AnyCborEncoded{mustFromHex("88f6636f6e656374776f657468726565010203f5")},                                             // [null,'one','two','three',1,2,3,true]
 	BoolPtr:      nil,
+	XListAny:     []AnyCborEncoded{{mustFromHex("01")}, {mustFromHex("02")}, {mustFromHex("f5")}, {mustFromHex("f6")}, {mustFromHex("63626f70")}}, // [1,2,true,null,"bop"]
+	XMapAny: anyMap{
+		Keys: []string{"a", "b", "c", "d", "e"},
+		Values: map[string]*AnyCborEncoded{
+			"a": {mustFromHex("01")},
+			"b": {mustFromHex("02")},
+			"c": {mustFromHex("f5")},
+			"d": {mustFromHex("f6")},
+			"e": {mustFromHex("63626f70")}}}, // {"a":1,"b":2,"c":true,"d":null,"e":"bop"}
 }
 
 func TestCustomAny(t *testing.T) {

--- a/node/bindnode/infer.go
+++ b/node/bindnode/infer.go
@@ -67,7 +67,7 @@ func verifyCompatibility(cfg config, seen map[seenEntry]bool, goType reflect.Typ
 	switch schemaType := schemaType.(type) {
 	case *schema.TypeBool:
 		if customConverter, ok := cfg[goType]; ok {
-			if customConverter.kind != datamodel.Kind_Bool {
+			if customConverter.kind != schema.TypeKind_Bool {
 				doPanic("kind mismatch; custom converter for type is not for Bool")
 			}
 		} else if goType.Kind() != reflect.Bool {
@@ -75,7 +75,7 @@ func verifyCompatibility(cfg config, seen map[seenEntry]bool, goType reflect.Typ
 		}
 	case *schema.TypeInt:
 		if customConverter, ok := cfg[goType]; ok {
-			if customConverter.kind != datamodel.Kind_Int {
+			if customConverter.kind != schema.TypeKind_Int {
 				doPanic("kind mismatch; custom converter for type is not for Int")
 			}
 		} else if kind := goType.Kind(); !kindInt[kind] && !kindUint[kind] {
@@ -83,7 +83,7 @@ func verifyCompatibility(cfg config, seen map[seenEntry]bool, goType reflect.Typ
 		}
 	case *schema.TypeFloat:
 		if customConverter, ok := cfg[goType]; ok {
-			if customConverter.kind != datamodel.Kind_Float {
+			if customConverter.kind != schema.TypeKind_Float {
 				doPanic("kind mismatch; custom converter for type is not for Float")
 			}
 		} else {
@@ -96,7 +96,7 @@ func verifyCompatibility(cfg config, seen map[seenEntry]bool, goType reflect.Typ
 	case *schema.TypeString:
 		// TODO: allow []byte?
 		if customConverter, ok := cfg[goType]; ok {
-			if customConverter.kind != datamodel.Kind_String {
+			if customConverter.kind != schema.TypeKind_String {
 				doPanic("kind mismatch; custom converter for type is not for String")
 			}
 		} else if goType.Kind() != reflect.String {
@@ -105,7 +105,7 @@ func verifyCompatibility(cfg config, seen map[seenEntry]bool, goType reflect.Typ
 	case *schema.TypeBytes:
 		// TODO: allow string?
 		if customConverter, ok := cfg[goType]; ok {
-			if customConverter.kind != datamodel.Kind_Bytes {
+			if customConverter.kind != schema.TypeKind_Bytes {
 				doPanic("kind mismatch; custom converter for type is not for Bytes")
 			}
 		} else if goType.Kind() != reflect.Slice {
@@ -231,15 +231,18 @@ func verifyCompatibility(cfg config, seen map[seenEntry]bool, goType reflect.Typ
 		}
 	case *schema.TypeLink:
 		if customConverter, ok := cfg[goType]; ok {
-			if customConverter.kind != datamodel.Kind_Link {
+			if customConverter.kind != schema.TypeKind_Link {
 				doPanic("kind mismatch; custom converter for type is not for Link")
 			}
 		} else if goType != goTypeLink && goType != goTypeCidLink && goType != goTypeCid {
 			doPanic("links in Go must be datamodel.Link, cidlink.Link, or cid.Cid")
 		}
 	case *schema.TypeAny:
-		// TODO: support some other option for Any, such as deferred decode
-		if goType != goTypeNode {
+		if customConverter, ok := cfg[goType]; ok {
+			if customConverter.kind != schema.TypeKind_Any {
+				doPanic("kind mismatch; custom converter for type is not for Any")
+			}
+		} else if goType != goTypeNode {
 			doPanic("Any in Go must be datamodel.Node")
 		}
 	default:

--- a/node/bindnode/infer.go
+++ b/node/bindnode/infer.go
@@ -66,7 +66,7 @@ func verifyCompatibility(cfg config, seen map[seenEntry]bool, goType reflect.Typ
 	}
 	switch schemaType := schemaType.(type) {
 	case *schema.TypeBool:
-		if customConverter, ok := cfg.converterForType(goType); ok {
+		if customConverter := cfg.converterForType(goType); customConverter != nil {
 			if customConverter.kind != schema.TypeKind_Bool {
 				doPanic("kind mismatch; custom converter for type is not for Bool")
 			}
@@ -74,7 +74,7 @@ func verifyCompatibility(cfg config, seen map[seenEntry]bool, goType reflect.Typ
 			doPanic("kind mismatch; need boolean")
 		}
 	case *schema.TypeInt:
-		if customConverter, ok := cfg.converterForType(goType); ok {
+		if customConverter := cfg.converterForType(goType); customConverter != nil {
 			if customConverter.kind != schema.TypeKind_Int {
 				doPanic("kind mismatch; custom converter for type is not for Int")
 			}
@@ -82,7 +82,7 @@ func verifyCompatibility(cfg config, seen map[seenEntry]bool, goType reflect.Typ
 			doPanic("kind mismatch; need integer")
 		}
 	case *schema.TypeFloat:
-		if customConverter, ok := cfg.converterForType(goType); ok {
+		if customConverter := cfg.converterForType(goType); customConverter != nil {
 			if customConverter.kind != schema.TypeKind_Float {
 				doPanic("kind mismatch; custom converter for type is not for Float")
 			}
@@ -95,7 +95,7 @@ func verifyCompatibility(cfg config, seen map[seenEntry]bool, goType reflect.Typ
 		}
 	case *schema.TypeString:
 		// TODO: allow []byte?
-		if customConverter, ok := cfg.converterForType(goType); ok {
+		if customConverter := cfg.converterForType(goType); customConverter != nil {
 			if customConverter.kind != schema.TypeKind_String {
 				doPanic("kind mismatch; custom converter for type is not for String")
 			}
@@ -104,7 +104,7 @@ func verifyCompatibility(cfg config, seen map[seenEntry]bool, goType reflect.Typ
 		}
 	case *schema.TypeBytes:
 		// TODO: allow string?
-		if customConverter, ok := cfg.converterForType(goType); ok {
+		if customConverter := cfg.converterForType(goType); customConverter != nil {
 			if customConverter.kind != schema.TypeKind_Bytes {
 				doPanic("kind mismatch; custom converter for type is not for Bytes")
 			}
@@ -204,7 +204,7 @@ func verifyCompatibility(cfg config, seen map[seenEntry]bool, goType reflect.Typ
 				}
 			case schemaField.IsNullable():
 				if ptr, nilable := ptrOrNilable(goType.Kind()); !nilable {
-					if _, hasConverter := cfg.converterForType(goType); !hasConverter {
+					if customConverter := cfg.converterForType(goType); customConverter == nil {
 						doPanic("nullable fields must be nilable")
 					}
 				} else if ptr {
@@ -233,7 +233,7 @@ func verifyCompatibility(cfg config, seen map[seenEntry]bool, goType reflect.Typ
 			verifyCompatibility(cfg, seen, goType, schemaType)
 		}
 	case *schema.TypeLink:
-		if customConverter, ok := cfg.converterForType(goType); ok {
+		if customConverter := cfg.converterForType(goType); customConverter != nil {
 			if customConverter.kind != schema.TypeKind_Link {
 				doPanic("kind mismatch; custom converter for type is not for Link")
 			}
@@ -241,7 +241,7 @@ func verifyCompatibility(cfg config, seen map[seenEntry]bool, goType reflect.Typ
 			doPanic("links in Go must be datamodel.Link, cidlink.Link, or cid.Cid")
 		}
 	case *schema.TypeAny:
-		if customConverter, ok := cfg.converterForType(goType); ok {
+		if customConverter := cfg.converterForType(goType); customConverter != nil {
 			if customConverter.kind != schema.TypeKind_Any {
 				doPanic("kind mismatch; custom converter for type is not for Any")
 			}

--- a/node/bindnode/infer.go
+++ b/node/bindnode/infer.go
@@ -39,6 +39,11 @@ type seenEntry struct {
 	schemaType schema.Type
 }
 
+// verifyCompatibility is the primary way we check that the schema type(s)
+// matches the Go type(s); so we do this before we can proceed operating on it.
+// verifyCompatibility doesn't return an error, it panics—the errors here are
+// not runtime errors, they're programmer errors because your schema doesn't
+// match your Go type
 func verifyCompatibility(cfg config, seen map[seenEntry]bool, goType reflect.Type, schemaType schema.Type) {
 	// TODO(mvdan): support **T as well?
 	if goType.Kind() == reflect.Ptr {
@@ -278,6 +283,7 @@ const (
 	inferringDone
 )
 
+// inferGoType can build a Go type given a schema
 func inferGoType(typ schema.Type, status map[schema.TypeName]inferredStatus, level int) reflect.Type {
 	if level > maxRecursionLevel {
 		panic(fmt.Sprintf("inferGoType: refusing to recurse past %d levels", maxRecursionLevel))
@@ -407,6 +413,7 @@ func init() {
 // TODO: we should probably avoid re-spawning the same types if the TypeSystem
 // has them, and test that that works as expected
 
+// inferSchema can build a schema from a Go type
 func inferSchema(typ reflect.Type, level int) schema.Type {
 	if level > maxRecursionLevel {
 		panic(fmt.Sprintf("inferSchema: refusing to recurse past %d levels", maxRecursionLevel))

--- a/node/bindnode/node.go
+++ b/node/bindnode/node.go
@@ -432,7 +432,7 @@ func (w *_node) AsBool() (bool, error) {
 	if err := compatibleKind(w.schemaType, datamodel.Kind_Bool); err != nil {
 		return false, err
 	}
-	if customConverter, ok := w.cfg[nonPtrType(w.val)]; ok {
+	if customConverter, ok := w.cfg.converterFor(w.val); ok {
 		return customConverter.customToBool(ptrVal(w.val).Interface())
 	}
 	return nonPtrVal(w.val).Bool(), nil
@@ -442,7 +442,7 @@ func (w *_node) AsInt() (int64, error) {
 	if err := compatibleKind(w.schemaType, datamodel.Kind_Int); err != nil {
 		return 0, err
 	}
-	if customConverter, ok := w.cfg[nonPtrType(w.val)]; ok {
+	if customConverter, ok := w.cfg.converterFor(w.val); ok {
 		return customConverter.customToInt(ptrVal(w.val).Interface())
 	}
 	val := nonPtrVal(w.val)
@@ -457,7 +457,7 @@ func (w *_node) AsFloat() (float64, error) {
 	if err := compatibleKind(w.schemaType, datamodel.Kind_Float); err != nil {
 		return 0, err
 	}
-	if customConverter, ok := w.cfg[nonPtrType(w.val)]; ok {
+	if customConverter, ok := w.cfg.converterFor(w.val); ok {
 		return customConverter.customToFloat(ptrVal(w.val).Interface())
 	}
 	return nonPtrVal(w.val).Float(), nil
@@ -467,7 +467,7 @@ func (w *_node) AsString() (string, error) {
 	if err := compatibleKind(w.schemaType, datamodel.Kind_String); err != nil {
 		return "", err
 	}
-	if customConverter, ok := w.cfg[nonPtrType(w.val)]; ok {
+	if customConverter, ok := w.cfg.converterFor(w.val); ok {
 		return customConverter.customToString(ptrVal(w.val).Interface())
 	}
 	return nonPtrVal(w.val).String(), nil
@@ -477,7 +477,7 @@ func (w *_node) AsBytes() ([]byte, error) {
 	if err := compatibleKind(w.schemaType, datamodel.Kind_Bytes); err != nil {
 		return nil, err
 	}
-	if customConverter, ok := w.cfg[nonPtrType(w.val)]; ok {
+	if customConverter, ok := w.cfg.converterFor(w.val); ok {
 		return customConverter.customToBytes(ptrVal(w.val).Interface())
 	}
 	return nonPtrVal(w.val).Bytes(), nil
@@ -487,7 +487,7 @@ func (w *_node) AsLink() (datamodel.Link, error) {
 	if err := compatibleKind(w.schemaType, datamodel.Kind_Link); err != nil {
 		return nil, err
 	}
-	if customConverter, ok := w.cfg[nonPtrType(w.val)]; ok {
+	if customConverter, ok := w.cfg.converterFor(w.val); ok {
 		cid, err := customConverter.customToLink(ptrVal(w.val).Interface())
 		if err != nil {
 			return nil, err
@@ -596,7 +596,7 @@ func (w *_assembler) BeginMap(sizeHint int64) (datamodel.MapAssembler, error) {
 			return nil, err
 		}
 		var conv *converter = nil
-		if customConverter, ok := w.cfg[nonPtrType(w.val)]; ok {
+		if customConverter, ok := w.cfg.converterFor(w.val); ok {
 			conv = &customConverter
 		}
 		return &basicMapAssembler{MapAssembler: mapAsm, builder: basicBuilder, parent: w, converter: conv}, nil
@@ -680,7 +680,7 @@ func (w *_assembler) BeginList(sizeHint int64) (datamodel.ListAssembler, error) 
 			return nil, err
 		}
 		var conv *converter = nil
-		if customConverter, ok := w.cfg[nonPtrType(w.val)]; ok {
+		if customConverter, ok := w.cfg.converterFor(w.val); ok {
 			conv = &customConverter
 		}
 		return &basicListAssembler{ListAssembler: listAsm, builder: basicBuilder, parent: w, converter: conv}, nil
@@ -709,7 +709,7 @@ func (w *_assembler) AssignNull() error {
 			// TODO
 		}
 	}
-	if customConverter, ok := w.cfg[nonPtrType(w.val)]; ok {
+	if customConverter, ok := w.cfg.converterFor(w.val); ok {
 		typ, err := customConverter.customFromAny(datamodel.Null)
 		if err != nil {
 			return err
@@ -730,7 +730,7 @@ func (w *_assembler) AssignBool(b bool) error {
 	if err := compatibleKind(w.schemaType, datamodel.Kind_Bool); err != nil {
 		return err
 	}
-	customConverter, hasCustomConverter := w.cfg[nonPtrType(w.val)]
+	customConverter, hasCustomConverter := w.cfg.converterFor(w.val)
 	_, isAny := w.schemaType.(*schema.TypeAny)
 	if hasCustomConverter {
 		var typ interface{}
@@ -765,7 +765,7 @@ func (w *_assembler) AssignInt(i int64) error {
 		return err
 	}
 	// TODO: check for overflow
-	customConverter, hasCustomConverter := w.cfg[nonPtrType(w.val)]
+	customConverter, hasCustomConverter := w.cfg.converterFor(w.val)
 	_, isAny := w.schemaType.(*schema.TypeAny)
 	if hasCustomConverter {
 		var typ interface{}
@@ -805,7 +805,7 @@ func (w *_assembler) AssignFloat(f float64) error {
 	if err := compatibleKind(w.schemaType, datamodel.Kind_Float); err != nil {
 		return err
 	}
-	customConverter, hasCustomConverter := w.cfg[nonPtrType(w.val)]
+	customConverter, hasCustomConverter := w.cfg.converterFor(w.val)
 	_, isAny := w.schemaType.(*schema.TypeAny)
 	if hasCustomConverter {
 		var typ interface{}
@@ -839,7 +839,7 @@ func (w *_assembler) AssignString(s string) error {
 	if err := compatibleKind(w.schemaType, datamodel.Kind_String); err != nil {
 		return err
 	}
-	customConverter, hasCustomConverter := w.cfg[nonPtrType(w.val)]
+	customConverter, hasCustomConverter := w.cfg.converterFor(w.val)
 	_, isAny := w.schemaType.(*schema.TypeAny)
 	if hasCustomConverter {
 		var typ interface{}
@@ -873,7 +873,7 @@ func (w *_assembler) AssignBytes(p []byte) error {
 	if err := compatibleKind(w.schemaType, datamodel.Kind_Bytes); err != nil {
 		return err
 	}
-	customConverter, hasCustomConverter := w.cfg[nonPtrType(w.val)]
+	customConverter, hasCustomConverter := w.cfg.converterFor(w.val)
 	_, isAny := w.schemaType.(*schema.TypeAny)
 	if hasCustomConverter {
 		var typ interface{}
@@ -907,7 +907,7 @@ func (w *_assembler) AssignLink(link datamodel.Link) error {
 	val := w.createNonPtrVal()
 	// TODO: newVal.Type() panics if link==nil; add a test and fix.
 	if _, ok := w.schemaType.(*schema.TypeAny); ok {
-		if customConverter, ok := w.cfg[nonPtrType(w.val)]; ok {
+		if customConverter, ok := w.cfg.converterFor(w.val); ok {
 			typ, err := customConverter.customFromAny(basicnode.NewLink(link))
 			if err != nil {
 				return err
@@ -916,7 +916,7 @@ func (w *_assembler) AssignLink(link datamodel.Link) error {
 		} else {
 			val.Set(reflect.ValueOf(basicnode.NewLink(link)))
 		}
-	} else if customConverter, ok := w.cfg[nonPtrType(w.val)]; ok {
+	} else if customConverter, ok := w.cfg.converterFor(w.val); ok {
 		if cl, ok := link.(cidlink.Link); ok {
 			typ, err := customConverter.customFromLink(cl.Cid)
 			if err != nil {
@@ -1317,7 +1317,7 @@ func (w *_structIterator) Next() (key, value datamodel.Node, _ error) {
 		}
 	}
 	if _, ok := field.Type().(*schema.TypeAny); ok {
-		if customConverter, ok := w.cfg[nonPtrType(val)]; ok {
+		if customConverter, ok := w.cfg.converterFor(val); ok {
 			v, err := customConverter.customToAny(ptrVal(val).Interface())
 			if err != nil {
 				return nil, nil, err

--- a/node/bindnode/node.go
+++ b/node/bindnode/node.go
@@ -702,7 +702,8 @@ func (w *_assembler) BeginList(sizeHint int64) (datamodel.ListAssembler, error) 
 }
 
 func (w *_assembler) AssignNull() error {
-	if customConverter, ok := w.cfg.converterFor(w.val); ok {
+	_, isAny := w.schemaType.(*schema.TypeAny)
+	if customConverter, ok := w.cfg.converterFor(w.val); ok && isAny {
 		typ, err := customConverter.customFromAny(datamodel.Null)
 		if err != nil {
 			return err


### PR DESCRIPTION
Continuing #414, this adds a `AddCustomTypeAnyConverter()` option. It can handle maps, lists and all scalar kinds (including Null, which is a weird one since we're talking about `nullable` fields). A receiving Go type that is registered as a CustomTypeAnyConverter will receive a `datamodel.Node` and is expected to return one when converting to and from that custom Go type.

Still need to consider whether these need doing and how best to do it & test for it:

* `_mapIterator#Next()`
* `_listIterator#Next()`
* `_node#LookupByString()`
* `_node#LookupByIndex()`

and unions.. not fully sure about how unions fit into any of this yet.

The tests in here might be worth a look, there's two variations of an `Any` converter - one expects a Map that's of a very particular form and encodes and decodes it manually to and from a struct. The other one receives any `datamodel.Node`, encodes it as dag-cbor and stores those bytes (so it's too not dissimilar to the way selectors work with cbg.Deferred in the fil markets stack), and in the reverse it decodes them and provides a `datamodel.Node`.