### PR TITLE
chore(bindnode): add test for sub-node unwrapping

### DIFF
--- a/node/bindnode/api_test.go
+++ b/node/bindnode/api_test.go
@@ -1,11 +1,14 @@
 package bindnode_test
 
 import (
+	"encoding/hex"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
 	"github.com/ipld/go-ipld-prime"
 	"github.com/ipld/go-ipld-prime/codec/dagcbor"
+	"github.com/ipld/go-ipld-prime/datamodel"
+	"github.com/ipld/go-ipld-prime/node/basicnode"
 	"github.com/ipld/go-ipld-prime/node/bindnode"
 )
 
@@ -35,4 +38,162 @@ func TestEnumError(t *testing.T) {
 	_, err = ipld.Encode(node, dagcbor.Encode)
 	qt.Assert(t, err, qt.IsNotNil)
 	qt.Assert(t, err.Error(), qt.Equals, `AsString: "p" is not a valid member of enum Action (bindnode works at the type level; did you mean "Present"?)`)
+}
+
+func TestSubNodeWalkAndUnwrap(t *testing.T) {
+	type F struct {
+		F bool
+	}
+	type B struct {
+		B int
+	}
+	type A struct {
+		A string
+	}
+	type S struct {
+		F      F
+		B      B
+		A      *A
+		Any    datamodel.Node
+		Bytes  []byte
+		String string
+	}
+
+	schema := `
+		type F struct {
+			F Bool
+		} representation tuple
+		type B struct {
+			B Int
+		} representation tuple
+		type A struct {
+			A String
+		} representation tuple
+		type S struct {
+			F F
+			B B
+			A optional A
+			Any Any
+			Bytes Bytes
+			String String
+		} representation tuple
+	`
+
+	encodedHex := "8681f581186581624141fb4069466666666666430102036f636f6e7374616e7420737472696e67" // [[true],[101],["AA"],202.2,[]byte{1,2,3},"constant string"]
+	byts := []byte{0, 1, 2, 3}
+	const constStr = "constant string"
+
+	expected := S{
+		F:      F{true},
+		B:      B{101},
+		A:      &A{"AAA"[1:]},
+		Any:    basicnode.NewFloat(202.2),
+		Bytes:  byts[1:],
+		String: constStr,
+	}
+
+	typeSystem, err := ipld.LoadSchemaBytes([]byte(schema))
+	qt.Assert(t, err, qt.IsNil)
+	schemaType := typeSystem.TypeByName("S")
+
+	verifyMap := func(node datamodel.Node) {
+		mi := node.MapIterator()
+
+		key, value, err := mi.Next()
+		qt.Assert(t, err, qt.IsNil)
+
+		str, err := key.AsString()
+		qt.Assert(t, err, qt.IsNil)
+		qt.Assert(t, str, qt.Equals, "F")
+
+		typ := bindnode.Unwrap(value)
+		instF, ok := typ.(*F)
+		qt.Assert(t, ok, qt.IsTrue)
+		qt.Assert(t, *instF, qt.Equals, F{true})
+
+		key, value, err = mi.Next()
+		qt.Assert(t, err, qt.IsNil)
+
+		str, err = key.AsString()
+		qt.Assert(t, err, qt.IsNil)
+		qt.Assert(t, str, qt.Equals, "B")
+
+		typ = bindnode.Unwrap(value)
+		instB, ok := typ.(*B)
+		qt.Assert(t, ok, qt.IsTrue)
+		qt.Assert(t, *instB, qt.Equals, B{101})
+
+		key, value, err = mi.Next()
+		qt.Assert(t, err, qt.IsNil)
+
+		str, err = key.AsString()
+		qt.Assert(t, err, qt.IsNil)
+		qt.Assert(t, str, qt.Equals, "A")
+
+		typ = bindnode.Unwrap(value)
+		instA, ok := typ.(*A)
+		qt.Assert(t, ok, qt.IsTrue)
+		qt.Assert(t, *instA, qt.Equals, A{"AA"})
+
+		key, value, err = mi.Next()
+		qt.Assert(t, err, qt.IsNil)
+
+		str, err = key.AsString()
+		qt.Assert(t, err, qt.IsNil)
+		qt.Assert(t, str, qt.Equals, "Any")
+
+		qt.Assert(t, ipld.DeepEqual(basicnode.NewFloat(202.2), value), qt.IsTrue)
+
+		key, value, err = mi.Next()
+		qt.Assert(t, err, qt.IsNil)
+
+		str, err = key.AsString()
+		qt.Assert(t, err, qt.IsNil)
+		qt.Assert(t, str, qt.Equals, "Bytes")
+
+		typ = bindnode.Unwrap(value)
+		instByts, ok := typ.(*[]byte)
+		qt.Assert(t, ok, qt.IsTrue)
+		qt.Assert(t, *instByts, qt.DeepEquals, []byte{1, 2, 3})
+
+		key, value, err = mi.Next()
+		qt.Assert(t, err, qt.IsNil)
+
+		str, err = key.AsString()
+		qt.Assert(t, err, qt.IsNil)
+		qt.Assert(t, str, qt.Equals, "String")
+
+		typ = bindnode.Unwrap(value)
+		instStr, ok := typ.(*string)
+		qt.Assert(t, ok, qt.IsTrue)
+		qt.Assert(t, *instStr, qt.DeepEquals, "constant string")
+	}
+
+	t.Run("decode", func(t *testing.T) {
+		encoded, _ := hex.DecodeString(encodedHex)
+
+		proto := bindnode.Prototype(&S{}, schemaType)
+
+		node, err := ipld.DecodeUsingPrototype([]byte(encoded), dagcbor.Decode, proto)
+		qt.Assert(t, err, qt.IsNil)
+
+		typ := bindnode.Unwrap(node)
+		instS, ok := typ.(*S)
+		qt.Assert(t, ok, qt.IsTrue)
+
+		qt.Assert(t, *instS, qt.DeepEquals, expected)
+
+		verifyMap(node)
+	})
+
+	t.Run("encode", func(t *testing.T) {
+		node := bindnode.Wrap(&expected, schemaType)
+
+		byts, err := ipld.Encode(node, dagcbor.Encode)
+		qt.Assert(t, err, qt.IsNil)
+
+		qt.Assert(t, hex.EncodeToString(byts), qt.Equals, encodedHex)
+
+		verifyMap(node)
+	})
 }


### PR DESCRIPTION
Closes: https://github.com/ipld/go-ipld-prime/issues/339

I can't repro the error in #339, so I'm adding this test and will close the issue. I've also tried it with 0.14.4 which is the version used in the issue and it passes so I'm clearly not hitting it quite right. But without additional information I'm going to have to wait for someone else to stumble across the problem before it can be fixed.

Unless someone else has a good idea for what unaddressable values I can try out, or how I might be able to trigger the problem indicated.