### PR TITLE
fix(codecs): coerce cid.Undef to null in dag{json,cbor} output

### DIFF
--- a/codec/dagcbor/marshal.go
+++ b/codec/dagcbor/marshal.go
@@ -144,6 +144,9 @@ func marshal(n datamodel.Node, tk *tok.Token, sink shared.TokenSink, options Enc
 		}
 		switch lnk := v.(type) {
 		case cidlink.Link:
+			if !lnk.Cid.Defined() {
+				return fmt.Errorf("encoding undefined CIDs are not supported by this codec")
+			}
 			tk.Type = tok.TBytes
 			tk.Bytes = append([]byte{0}, lnk.Bytes()...)
 			tk.Tagged = true

--- a/codec/dagcbor/marshal_test.go
+++ b/codec/dagcbor/marshal_test.go
@@ -7,7 +7,11 @@ import (
 	"time"
 
 	qt "github.com/frankban/quicktest"
+	"github.com/ipfs/go-cid"
+	"github.com/ipld/go-ipld-prime"
 	"github.com/ipld/go-ipld-prime/datamodel"
+	"github.com/ipld/go-ipld-prime/fluent/qp"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	basicnode "github.com/ipld/go-ipld-prime/node/basic"
 	"github.com/ipld/go-ipld-prime/testutil/garbage"
 )
@@ -67,4 +71,16 @@ func TestEncodedLength(t *testing.T) {
 			verifyEstimatedSize(t, gbg)
 		}
 	})
+}
+
+func TestMarshalUndefCid(t *testing.T) {
+	link, err := cid.Decode("bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi")
+	qt.Assert(t, err, qt.IsNil)
+	node, err := qp.BuildMap(basicnode.Prototype.Any, -1, func(ma datamodel.MapAssembler) {
+		qp.MapEntry(ma, "UndefCid", qp.Link(cidlink.Link{Cid: cid.Undef}))
+		qp.MapEntry(ma, "DefCid", qp.Link(cidlink.Link{Cid: link}))
+	})
+	qt.Assert(t, err, qt.IsNil)
+	_, err = ipld.Encode(node, Encode)
+	qt.Assert(t, err, qt.ErrorMatches, "encoding undefined CIDs are not supported by this codec")
 }

--- a/codec/dagjson/marshal.go
+++ b/codec/dagjson/marshal.go
@@ -257,6 +257,9 @@ func Marshal(n datamodel.Node, sink shared.TokenSink, options EncodeOptions) err
 		}
 		switch lnk := v.(type) {
 		case cidlink.Link:
+			if !lnk.Cid.Defined() {
+				return fmt.Errorf("encoding undefined CIDs are not supported by this codec")
+			}
 			// Precisely four tokens to emit:
 			tk.Type = tok.TMapOpen
 			tk.Length = 1

--- a/codec/dagjson/marshal_test.go
+++ b/codec/dagjson/marshal_test.go
@@ -1,0 +1,25 @@
+package dagjson
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	cid "github.com/ipfs/go-cid"
+	"github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/datamodel"
+	"github.com/ipld/go-ipld-prime/fluent/qp"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/ipld/go-ipld-prime/node/basicnode"
+)
+
+func TestMarshalUndefCid(t *testing.T) {
+	link, err := cid.Decode("bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi")
+	qt.Assert(t, err, qt.IsNil)
+	node, err := qp.BuildMap(basicnode.Prototype.Any, -1, func(ma datamodel.MapAssembler) {
+		qp.MapEntry(ma, "UndefCid", qp.Link(cidlink.Link{Cid: cid.Undef}))
+		qp.MapEntry(ma, "DefCid", qp.Link(cidlink.Link{Cid: link}))
+	})
+	qt.Assert(t, err, qt.IsNil)
+	_, err = ipld.Encode(node, Encode)
+	qt.Assert(t, err, qt.ErrorMatches, "encoding undefined CIDs are not supported by this codec")
+}


### PR DESCRIPTION
Otherwise we end up with invalid output like this:

dag-cbor: `0xd82a4100`

```
  d8 2a                                           #   tag(42)
    41                                            #     bytes(1)
      00                                          #       "\x00"
```

dag-json: `{"/":"b"}`

Fixes: https://github.com/ipld/go-ipld-prime/issues/246

---

@aschmahmann @willscott I'd appreciate your 👍 on this as it's a coercion rather than an error or other funky behaviour. But this probably isn't that simple:

* Unlike string, or int, the zero-value of CID doesn't have a round-trippable form that we've come up with for any of our codecs, so we're essentially making one up here, `null`. The alternative may be to define a null CID for both of these codecs - we could just use the values above and make it work across our current codec implementations (currently in JS, both of these result in errors because it can't decode a varint where it expects, IIRC round-tripping in Go does essentially the same thing).
* For typed nodes, this coercion could have blow-back if you have a link field that's not `nullable` or `optional`, then a round-trip with a `cid.Undef` is going to result in a `null` in that position which might be a problem. But we could push that problem up the stack and make it a concern for bindnode and friends to figure out. They could even use `cid.Undef` for non-nullable non-optional fields that come out as `null`.
* We have the option of erroring on this if we want - make it a user problem, don't give us `cid.Undef`, it's not allowed.

_(Related discussion in https://github.com/ipld/go-ipld-prime/issues/191 and the currently rejected PR that would error on `Absent` fields: https://github.com/ipld/go-ipld-prime/pull/196)._

@Stebalien @vmx you might want to weigh in too because we're talking possible codec behaviour changes.