### PR TITLE
gengo: add placeholders for Any

### DIFF
--- a/schema/gen/go/genAny.go
+++ b/schema/gen/go/genAny.go
@@ -1,0 +1,177 @@
+package gengo
+
+import (
+	"io"
+
+	"github.com/ipld/go-ipld-prime/datamodel"
+	"github.com/ipld/go-ipld-prime/schema"
+)
+
+type anyGenerator struct {
+	AdjCfg  *AdjunctCfg
+	PkgName string
+	Type    *schema.TypeAny
+}
+
+func (anyGenerator) IsRepr() any { return false } // hint used in some generalized templates.
+
+// --- native content and specializations --->
+
+func (g anyGenerator) EmitNativeType(w io.Writer) {
+	doTemplate(`
+		type {{ .Type | TypeSymbol }} = *_{{ .Type | TypeSymbol }}
+		type _{{ .Type | TypeSymbol }} struct{ x datamodel.Node }
+	`, w, g.AdjCfg, g)
+}
+func (g anyGenerator) EmitNativeAccessors(w io.Writer) {
+}
+func (g anyGenerator) EmitNativeBuilder(w io.Writer) {
+}
+func (g anyGenerator) EmitNativeMaybe(w io.Writer) {
+	emitNativeMaybe(w, g.AdjCfg, g)
+}
+
+// --- type info --->
+
+func (g anyGenerator) EmitTypeConst(w io.Writer) {
+}
+
+// --- TypedNode interface satisfaction --->
+
+func (g anyGenerator) EmitTypedNodeMethodType(w io.Writer) {
+	doTemplate(`
+		func ({{ .Type | TypeSymbol }}) Type() schema.Type {
+			return nil /*TODO:typelit*/
+		}
+	`, w, g.AdjCfg, g)
+}
+
+func (g anyGenerator) EmitTypedNodeMethodRepresentation(w io.Writer) {
+	emitTypicalTypedNodeMethodRepresentation(w, g.AdjCfg, g)
+}
+
+// --- Node interface satisfaction --->
+
+func (g anyGenerator) EmitNodeType(w io.Writer) {
+}
+func (g anyGenerator) EmitNodeTypeAssertions(w io.Writer) {
+}
+func (g anyGenerator) EmitNodeMethodPrototype(w io.Writer) {
+	emitNodeMethodPrototype_typical(w, g.AdjCfg, g)
+}
+func (g anyGenerator) EmitNodePrototypeType(w io.Writer) {
+	emitNodePrototypeType_typical(w, g.AdjCfg, g)
+}
+
+// --- NodeBuilder and NodeAssembler --->
+
+func (g anyGenerator) GetNodeBuilderGenerator() NodeBuilderGenerator {
+	return anyBuilderGenerator{
+		g.AdjCfg,
+		g.PkgName,
+		g.Type,
+	}
+}
+
+type anyBuilderGenerator struct {
+	AdjCfg  *AdjunctCfg
+	PkgName string
+	Type    *schema.TypeAny
+}
+
+func (anyBuilderGenerator) IsRepr() any { return false } // hint used in some generalized templates.
+
+func (anyBuilderGenerator) Kind() datamodel.Kind { return datamodel.Kind_Invalid }
+
+func (g anyBuilderGenerator) EmitNodeBuilderType(w io.Writer) {
+	emitEmitNodeBuilderType_typical(w, g.AdjCfg, g)
+}
+func (g anyBuilderGenerator) EmitNodeBuilderMethods(w io.Writer) {
+	emitNodeBuilderMethods_typical(w, g.AdjCfg, g)
+}
+func (g anyBuilderGenerator) EmitNodeAssemblerType(w io.Writer) {
+	emitNodeAssemblerType_scalar(w, g.AdjCfg, g)
+}
+func (g anyBuilderGenerator) EmitNodeAssemblerMethodAssignNull(w io.Writer) {
+	doTemplate(`
+		func (na *_{{ .Type | TypeSymbol }}__{{ if .IsRepr }}Repr{{end}}Assembler) AssignNull() error {
+			panic("not implemented")
+		}
+	`, w, g.AdjCfg, g)
+}
+func (g anyBuilderGenerator) EmitNodeAssemblerMethodAssignBool(w io.Writer) {
+	doTemplate(`
+		func (na *_{{ .Type | TypeSymbol }}__{{ if .IsRepr }}Repr{{end}}Assembler) AssignBool(bool) error {
+			panic("not implemented")
+		}
+	`, w, g.AdjCfg, g)
+}
+func (g anyBuilderGenerator) EmitNodeAssemblerMethodAssignNode(w io.Writer) {
+	doTemplate(`
+		func (na *_{{ .Type | TypeSymbol }}__{{ if .IsRepr }}Repr{{end}}Assembler) AssignNode(v datamodel.Node) error {
+			na.w.x = v
+			*na.m = schema.Maybe_Value
+			return nil
+		}
+	`, w, g.AdjCfg, g)
+}
+func (g anyBuilderGenerator) EmitNodeAssemblerOtherBits(w io.Writer) {
+	// Nothing needed here for any kinds.
+}
+
+func (g anyBuilderGenerator) EmitNodeAssemblerMethodBeginMap(w io.Writer) {
+	doTemplate(`
+		func (na *_{{ .Type | TypeSymbol }}__{{ if .IsRepr }}Repr{{end}}Assembler) BeginMap(sizeHint int64) (datamodel.MapAssembler, error) {
+			panic("not implemented")
+		}
+	`, w, g.AdjCfg, g)
+}
+func (g anyBuilderGenerator) EmitNodeAssemblerMethodBeginList(w io.Writer) {
+	doTemplate(`
+		func (na *_{{ .Type | TypeSymbol }}__{{ if .IsRepr }}Repr{{end}}Assembler) BeginList(sizeHint int64) (datamodel.ListAssembler, error) {
+			panic("not implemented")
+		}
+	`, w, g.AdjCfg, g)
+}
+func (g anyBuilderGenerator) EmitNodeAssemblerMethodAssignInt(w io.Writer) {
+	doTemplate(`
+		func (na *_{{ .Type | TypeSymbol }}__{{ if .IsRepr }}Repr{{end}}Assembler) AssignInt(int64) error {
+			panic("not implemented")
+		}
+	`, w, g.AdjCfg, g)
+}
+func (g anyBuilderGenerator) EmitNodeAssemblerMethodAssignFloat(w io.Writer) {
+	doTemplate(`
+		func (na *_{{ .Type | TypeSymbol }}__{{ if .IsRepr }}Repr{{end}}Assembler) AssignFloat(float64) error {
+			panic("not implemented")
+		}
+	`, w, g.AdjCfg, g)
+}
+func (g anyBuilderGenerator) EmitNodeAssemblerMethodAssignString(w io.Writer) {
+	doTemplate(`
+		func (na *_{{ .Type | TypeSymbol }}__{{ if .IsRepr }}Repr{{end}}Assembler) AssignString(string) error {
+			panic("not implemented")
+		}
+	`, w, g.AdjCfg, g)
+}
+func (g anyBuilderGenerator) EmitNodeAssemblerMethodAssignBytes(w io.Writer) {
+	doTemplate(`
+		func (na *_{{ .Type | TypeSymbol }}__{{ if .IsRepr }}Repr{{end}}Assembler) AssignBytes([]byte) error {
+			panic("not implemented")
+		}
+	`, w, g.AdjCfg, g)
+}
+func (g anyBuilderGenerator) EmitNodeAssemblerMethodAssignLink(w io.Writer) {
+	doTemplate(`
+		func (na *_{{ .Type | TypeSymbol }}__{{ if .IsRepr }}Repr{{end}}Assembler) AssignLink(datamodel.Link) error {
+			panic("not implemented")
+		}
+	`, w, g.AdjCfg, g)
+}
+func (g anyBuilderGenerator) EmitNodeAssemblerMethodPrototype(w io.Writer) {
+	doTemplate(`
+		func (_{{ .Type | TypeSymbol }}__{{ if .IsRepr }}Repr{{end}}Assembler) Prototype() datamodel.NodePrototype {
+			return _{{ .Type | TypeSymbol }}__{{ if .IsRepr }}Repr{{end}}Prototype{}
+		}
+	`, w, g.AdjCfg, g)
+}

--- a/schema/gen/go/genAnyReprAny.go
+++ b/schema/gen/go/genAnyReprAny.go
@@ -1,0 +1,230 @@
+package gengo
+
+import (
+	"io"
+
+	"github.com/ipld/go-ipld-prime/schema"
+)
+
+var _ TypeGenerator = &anyReprAnyGenerator{}
+
+func NewAnyReprAnyGenerator(pkgName string, typ *schema.TypeAny, adjCfg *AdjunctCfg) TypeGenerator {
+	return anyReprAnyGenerator{
+		anyGenerator{
+			adjCfg,
+			pkgName,
+			typ,
+		},
+	}
+}
+
+type anyReprAnyGenerator struct {
+	anyGenerator
+}
+
+func (g anyReprAnyGenerator) EmitNodeMethodKind(w io.Writer) {
+	doTemplate(`
+		func ({{ .Type | TypeSymbol }}) Kind() datamodel.Kind {
+			return datamodel.Kind_Invalid
+		}
+	`, w, g.AdjCfg, g)
+}
+
+func (g anyReprAnyGenerator) EmitNodeMethodLookupByString(w io.Writer) {
+	doTemplate(`
+		func ({{ .Type | TypeSymbol }}) LookupByString(string) (datamodel.Node, error) {
+			panic("not implemented")
+		}
+	`, w, g.AdjCfg, g)
+}
+
+func (g anyReprAnyGenerator) EmitNodeMethodLookupByNode(w io.Writer) {
+	doTemplate(`
+		func ({{ .Type | TypeSymbol }}) LookupByNode(datamodel.Node) (datamodel.Node, error) {
+			panic("not implemented")
+		}
+	`, w, g.AdjCfg, g)
+}
+
+func (g anyReprAnyGenerator) EmitNodeMethodLookupByIndex(w io.Writer) {
+	doTemplate(`
+		func ({{ .Type | TypeSymbol }}) LookupByIndex(idx int64) (datamodel.Node, error) {
+			panic("not implemented")
+		}
+	`, w, g.AdjCfg, g)
+}
+
+func (g anyReprAnyGenerator) EmitNodeMethodLookupBySegment(w io.Writer) {
+	doTemplate(`
+		func ({{ .Type | TypeSymbol }}) LookupBySegment(seg datamodel.PathSegment) (datamodel.Node, error) {
+			panic("not implemented")
+		}
+	`, w, g.AdjCfg, g)
+}
+
+func (g anyReprAnyGenerator) EmitNodeMethodMapIterator(w io.Writer) {
+	doTemplate(`
+		func ({{ .Type | TypeSymbol }}) MapIterator() datamodel.MapIterator {
+			panic("not implemented")
+		}
+	`, w, g.AdjCfg, g)
+}
+
+func (g anyReprAnyGenerator) EmitNodeMethodListIterator(w io.Writer) {
+	doTemplate(`
+		func ({{ .Type | TypeSymbol }}) ListIterator() datamodel.ListIterator {
+			panic("not implemented")
+		}
+	`, w, g.AdjCfg, g)
+}
+
+func (g anyReprAnyGenerator) EmitNodeMethodLength(w io.Writer) {
+	doTemplate(`
+		func ({{ .Type | TypeSymbol }}) Length() int64 {
+			panic("not implemented")
+		}
+	`, w, g.AdjCfg, g)
+}
+
+func (g anyReprAnyGenerator) EmitNodeMethodIsAbsent(w io.Writer) {
+	doTemplate(`
+		func ({{ .Type | TypeSymbol }}) IsAbsent() bool {
+			panic("not implemented")
+		}
+	`, w, g.AdjCfg, g)
+}
+
+func (g anyReprAnyGenerator) EmitNodeMethodIsNull(w io.Writer) {
+	doTemplate(`
+		func ({{ .Type | TypeSymbol }}) IsNull() bool {
+			panic("not implemented")
+		}
+	`, w, g.AdjCfg, g)
+}
+
+func (g anyReprAnyGenerator) EmitNodeMethodAsInt(w io.Writer) {
+	doTemplate(`
+		func ({{ .Type | TypeSymbol }}) AsInt() (int64, error) {
+			panic("not implemented")
+		}
+	`, w, g.AdjCfg, g)
+}
+
+func (g anyReprAnyGenerator) EmitNodeMethodAsFloat(w io.Writer) {
+	doTemplate(`
+		func ({{ .Type | TypeSymbol }}) AsFloat() (float64, error) {
+			panic("not implemented")
+		}
+	`, w, g.AdjCfg, g)
+}
+
+func (g anyReprAnyGenerator) EmitNodeMethodAsString(w io.Writer) {
+	doTemplate(`
+		func ({{ .Type | TypeSymbol }}) AsString() (string, error) {
+			panic("not implemented")
+		}
+	`, w, g.AdjCfg, g)
+}
+
+func (g anyReprAnyGenerator) EmitNodeMethodAsBytes(w io.Writer) {
+	doTemplate(`
+		func ({{ .Type | TypeSymbol }}) AsBytes() ([]byte, error) {
+			panic("not implemented")
+		}
+	`, w, g.AdjCfg, g)
+}
+
+func (g anyReprAnyGenerator) EmitNodeMethodAsLink(w io.Writer) {
+	doTemplate(`
+		func ({{ .Type | TypeSymbol }}) AsLink() (datamodel.Link, error) {
+			panic("not implemented")
+		}
+	`, w, g.AdjCfg, g)
+}
+
+func (g anyReprAnyGenerator) EmitNodeMethodAsBool(w io.Writer) {
+	doTemplate(`
+		func ({{ .Type | TypeSymbol }}) AsBool() (bool, error) {
+			panic("not implemented")
+		}
+	`, w, g.AdjCfg, g)
+}
+
+func (g anyReprAnyGenerator) GetRepresentationNodeGen() NodeGenerator {
+	return anyReprAnyReprGenerator{
+		g.AdjCfg,
+		g.Type,
+	}
+}
+
+type anyReprAnyReprGenerator struct {
+	AdjCfg *AdjunctCfg
+	Type   *schema.TypeAny
+}
+
+func (g anyReprAnyReprGenerator) EmitNodeType(w io.Writer) {
+	// Since this is a "natural" representation... there's just a type alias here.
+	//  No new functions are necessary.
+	doTemplate(`
+		type _{{ .Type | TypeSymbol }}__Repr = _{{ .Type | TypeSymbol }}
+	`, w, g.AdjCfg, g)
+}
+func (g anyReprAnyReprGenerator) EmitNodeTypeAssertions(w io.Writer) {
+	doTemplate(`
+		var _ datamodel.Node = &_{{ .Type | TypeSymbol }}__Repr{}
+	`, w, g.AdjCfg, g)
+}
+func (anyReprAnyReprGenerator) EmitNodeMethodKind(io.Writer)            {}
+func (anyReprAnyReprGenerator) EmitNodeMethodLookupByString(io.Writer)  {}
+func (anyReprAnyReprGenerator) EmitNodeMethodLookupByNode(io.Writer)    {}
+func (anyReprAnyReprGenerator) EmitNodeMethodLookupByIndex(io.Writer)   {}
+func (anyReprAnyReprGenerator) EmitNodeMethodLookupBySegment(io.Writer) {}
+func (anyReprAnyReprGenerator) EmitNodeMethodMapIterator(io.Writer)     {}
+func (anyReprAnyReprGenerator) EmitNodeMethodListIterator(io.Writer)    {}
+func (anyReprAnyReprGenerator) EmitNodeMethodLength(io.Writer)          {}
+func (anyReprAnyReprGenerator) EmitNodeMethodIsAbsent(io.Writer)        {}
+func (anyReprAnyReprGenerator) EmitNodeMethodIsNull(io.Writer)          {}
+func (anyReprAnyReprGenerator) EmitNodeMethodAsBool(io.Writer)          {}
+func (anyReprAnyReprGenerator) EmitNodeMethodAsInt(io.Writer)           {}
+func (anyReprAnyReprGenerator) EmitNodeMethodAsFloat(io.Writer)         {}
+func (anyReprAnyReprGenerator) EmitNodeMethodAsString(io.Writer)        {}
+func (anyReprAnyReprGenerator) EmitNodeMethodAsBytes(io.Writer)         {}
+func (anyReprAnyReprGenerator) EmitNodeMethodAsLink(io.Writer)          {}
+func (anyReprAnyReprGenerator) EmitNodeMethodPrototype(io.Writer)       {}
+func (g anyReprAnyReprGenerator) EmitNodePrototypeType(w io.Writer) {
+	// Since this is a "natural" representation... there's just a type alias here.
+	//  No new functions are necessary.
+	doTemplate(`
+		type _{{ .Type | TypeSymbol }}__ReprPrototype = _{{ .Type | TypeSymbol }}__Prototype
+	`, w, g.AdjCfg, g)
+}
+func (g anyReprAnyReprGenerator) GetNodeBuilderGenerator() NodeBuilderGenerator {
+	return anyReprAnyReprBuilderGenerator(g)
+}
+
+type anyReprAnyReprBuilderGenerator struct {
+	AdjCfg *AdjunctCfg
+	Type   *schema.TypeAny
+}
+
+func (anyReprAnyReprBuilderGenerator) EmitNodeBuilderType(io.Writer)    {}
+func (anyReprAnyReprBuilderGenerator) EmitNodeBuilderMethods(io.Writer) {}
+func (g anyReprAnyReprBuilderGenerator) EmitNodeAssemblerType(w io.Writer) {
+	// Since this is a "natural" representation... there's just a type alias here.
+	//  No new functions are necessary.
+	doTemplate(`
+		type _{{ .Type | TypeSymbol }}__ReprAssembler = _{{ .Type | TypeSymbol }}__Assembler
+	`, w, g.AdjCfg, g)
+}
+func (anyReprAnyReprBuilderGenerator) EmitNodeAssemblerMethodBeginMap(io.Writer)     {}
+func (anyReprAnyReprBuilderGenerator) EmitNodeAssemblerMethodBeginList(io.Writer)    {}
+func (anyReprAnyReprBuilderGenerator) EmitNodeAssemblerMethodAssignNull(io.Writer)   {}
+func (anyReprAnyReprBuilderGenerator) EmitNodeAssemblerMethodAssignBool(io.Writer)   {}
+func (anyReprAnyReprBuilderGenerator) EmitNodeAssemblerMethodAssignInt(io.Writer)    {}
+func (anyReprAnyReprBuilderGenerator) EmitNodeAssemblerMethodAssignFloat(io.Writer)  {}
+func (anyReprAnyReprBuilderGenerator) EmitNodeAssemblerMethodAssignString(io.Writer) {}
+func (anyReprAnyReprBuilderGenerator) EmitNodeAssemblerMethodAssignBytes(io.Writer)  {}
+func (anyReprAnyReprBuilderGenerator) EmitNodeAssemblerMethodAssignLink(io.Writer)   {}
+func (anyReprAnyReprBuilderGenerator) EmitNodeAssemblerMethodAssignNode(io.Writer)   {}
+func (anyReprAnyReprBuilderGenerator) EmitNodeAssemblerMethodPrototype(io.Writer)    {}
+func (anyReprAnyReprBuilderGenerator) EmitNodeAssemblerOtherBits(io.Writer)          {}

--- a/schema/gen/go/generate.go
+++ b/schema/gen/go/generate.go
@@ -81,6 +81,8 @@ func Generate(pth string, pkgName string, ts schema.TypeSystem, adjCfg *AdjunctC
 				default:
 					panic("unrecognized union representation strategy")
 				}
+			case *schema.TypeAny:
+				fn(NewAnyReprAnyGenerator(pkgName, t2, adjCfg), f)
 			default:
 				panic(fmt.Sprintf("add more type switches here :), failed at type %s", tn))
 			}


### PR DESCRIPTION
### Problem

go-ipldtool hasn't updated its go-ipld-prime dependency in over a year.
This patch fixes go-ipld-prime so it works in go-ipldtool again.

### Description

Fixes gengo compatibility with schemadmt, which generates Any.

Adds placeholders for Any which panic on use at runtime for most functions.