### PR TITLE
Additional access to schema/dmt package; schema concatenation feature

### DIFF
--- a/node/bindnode/fuzz_test.go
+++ b/node/bindnode/fuzz_test.go
@@ -149,7 +149,7 @@ func FuzzBindnodeViaDagCBOR(f *testing.F) {
 		if err != nil {
 			f.Fatal(err)
 		}
-		schemaNode := bindnode.Wrap(schemaDMT, schemadmt.Type.Schema.Type())
+		schemaNode := bindnode.Wrap(schemaDMT, schemadmt.Prototypes.Schema.Type())
 		schemaDagCBOR := marshalDagCBOR(f, schemaNode.Representation())
 
 		nodeBuilder := basicnode.Prototype.Any.NewBuilder()
@@ -178,7 +178,7 @@ func FuzzBindnodeViaDagCBOR(f *testing.F) {
 		}
 	}
 	f.Fuzz(func(t *testing.T, schemaDagCBOR, nodeDagCBOR []byte) {
-		schemaBuilder := schemadmt.Type.Schema.Representation().NewBuilder()
+		schemaBuilder := schemadmt.Prototypes.Schema.Representation().NewBuilder()
 
 		if err := dagcbor.Decode(schemaBuilder, bytes.NewReader(schemaDagCBOR)); err != nil {
 			t.Skipf("invalid schema-schema dag-cbor: %v", err)

--- a/schema/dmt/operations.go
+++ b/schema/dmt/operations.go
@@ -1,0 +1,27 @@
+package schemadmt
+
+import (
+	"github.com/ipld/go-ipld-prime/datamodel"
+	"github.com/ipld/go-ipld-prime/node/bindnode"
+)
+
+// ConcatenateSchemas returns a new schema DMT object containing the
+// type declarations from both.
+//
+// As is usual for DMT form data, there is no check about the validity
+// of the result yet; you'll need to apply `Compile` on the produced value
+// to produce a usable compiled typesystem or to become certain that
+// all references in the DMT are satisfied, etc.
+func ConcatenateSchemas(a, b *Schema) *Schema {
+	// The joy of having an intermediate form that's just regular data model:
+	// we can implement this by simply using data model "copy" operations,
+	// and the result is correct.
+	nb := Type.Schema.NewBuilder()
+	if err := datamodel.Copy(bindnode.Wrap(a, Type.Schema.Type()), nb); err != nil {
+		panic(err)
+	}
+	if err := datamodel.Copy(bindnode.Wrap(b, Type.Schema.Type()), nb); err != nil {
+		panic(err)
+	}
+	return bindnode.Unwrap(nb.Build()).(*Schema)
+}

--- a/schema/dmt/operations.go
+++ b/schema/dmt/operations.go
@@ -16,11 +16,11 @@ func ConcatenateSchemas(a, b *Schema) *Schema {
 	// The joy of having an intermediate form that's just regular data model:
 	// we can implement this by simply using data model "copy" operations,
 	// and the result is correct.
-	nb := Type.Schema.NewBuilder()
-	if err := datamodel.Copy(bindnode.Wrap(a, Type.Schema.Type()), nb); err != nil {
+	nb := Prototypes.Schema.NewBuilder()
+	if err := datamodel.Copy(bindnode.Wrap(a, Prototypes.Schema.Type()), nb); err != nil {
 		panic(err)
 	}
-	if err := datamodel.Copy(bindnode.Wrap(b, Type.Schema.Type()), nb); err != nil {
+	if err := datamodel.Copy(bindnode.Wrap(b, Prototypes.Schema.Type()), nb); err != nil {
 		panic(err)
 	}
 	return bindnode.Unwrap(nb.Build()).(*Schema)

--- a/schema/dmt/roundtrip_test.go
+++ b/schema/dmt/roundtrip_test.go
@@ -33,7 +33,7 @@ func testRoundtrip(t *testing.T, want string, updateFn func(string)) {
 
 	crre := regexp.MustCompile(`\r?\n`)
 	want = crre.ReplaceAllString(want, "\n")
-	nb := schemadmt.Type.Schema.Representation().NewBuilder()
+	nb := schemadmt.Prototypes.Schema.Representation().NewBuilder()
 	err := ipldjson.Decode(nb, strings.NewReader(want))
 	qt.Assert(t, err, qt.IsNil)
 	node := nb.Build().(schema.TypedNode)

--- a/schema/dmt/schema.go
+++ b/schema/dmt/schema.go
@@ -16,7 +16,7 @@ var Type struct {
 
 //go:generate go run -tags=schemadmtgen gen.go
 
-var schemaTypeSystem schema.TypeSystem
+var TypeSystem schema.TypeSystem
 
 func init() {
 	var ts schema.TypeSystem
@@ -433,10 +433,10 @@ func init() {
 		panic("not happening")
 	}
 
-	schemaTypeSystem = ts
+	TypeSystem = ts
 
 	Type.Schema = bindnode.Prototype(
 		(*Schema)(nil),
-		schemaTypeSystem.TypeByName("Schema"),
+		TypeSystem.TypeByName("Schema"),
 	)
 }

--- a/schema/dmt/schema.go
+++ b/schema/dmt/schema.go
@@ -10,7 +10,7 @@ import (
 
 // This schema follows https://ipld.io/specs/schemas/schema-schema.ipldsch.
 
-var Type struct {
+var Prototypes struct {
 	Schema schema.TypedPrototype
 }
 
@@ -435,7 +435,7 @@ func init() {
 
 	TypeSystem = ts
 
-	Type.Schema = bindnode.Prototype(
+	Prototypes.Schema = bindnode.Prototype(
 		(*Schema)(nil),
 		TypeSystem.TypeByName("Schema"),
 	)

--- a/schema/dsl/parse_test.go
+++ b/schema/dsl/parse_test.go
@@ -116,7 +116,7 @@ func testParse(t *testing.T, inSchema, inJSON string, updateFn func(string)) {
 	// Ensure we can encode the schema as the json codec,
 	// and that it results in the same bytes as the ipldsch.json file.
 	{
-		node := bindnode.Wrap(sch, schemadmt.Type.Schema.Type())
+		node := bindnode.Wrap(sch, schemadmt.Prototypes.Schema.Type())
 
 		var buf bytes.Buffer
 		err := ipldjson.Encode(node.Representation(), &buf)


### PR DESCRIPTION
This is a small diff which introduces a bit more ability to introspect and operate on `schema/dmt` data.

Making the type system accessible makes it easier to manipulate the schema DMT _as IPLD_, which is a very neat thing to be able to do.  (Some of this is already possible because `schemadmt.Type.Schema` is exported specifically; but I see no reason not to export the entire typesystem.)

Then, a function is introduced which can conjoin two parsed schema DMT documents.  (This stops just shy of introducing an "include" syntax to IPLD Schemas, but one can see how it could easily be involved in producing such a feature.)