### PR TITLE
fix: make StartAtPath work properly for matching walks

### DIFF
--- a/traversal/walk.go
+++ b/traversal/walk.go
@@ -180,7 +180,7 @@ func (prog Progress) walkAdv(n datamodel.Node, s selector.Selector, fn AdvVisitF
 		n = rn
 	}
 
-	if prog.Path.Len() >= prog.Cfg.StartAtPath.Len() || !prog.PastStartAtPath {
+	if prog.Path.Len() >= prog.Cfg.StartAtPath.Len() || prog.PastStartAtPath {
 		// Decide if this node is matched -- do callbacks as appropriate.
 		if match, err := s.Match(n); match != nil {
 			if err := fn(prog, match, VisitReason_SelectionMatch); err != nil {


### PR DESCRIPTION
The test for this was too easy and doesn't pass if you give it other things to match _prior_ to the `StartAtPath`. New test added for the non-matching case, which is where this functionality is actually used (graphsync), and that works properly already.