### PR TITLE
feat(bindnode): support listpairs struct representation

### DIFF
--- a/node/bindnode/node.go
+++ b/node/bindnode/node.go
@@ -36,6 +36,8 @@ var (
 	_ datamodel.NodeBuilder   = (*_builderRepr)(nil)
 	_ datamodel.NodeAssembler = (*_assembler)(nil)
 	_ datamodel.NodeAssembler = (*_assemblerRepr)(nil)
+	_ datamodel.NodeAssembler = (*_errorAssembler)(nil)
+	_ datamodel.NodeAssembler = (*_listpairsFieldAssemblerRepr)(nil)
 
 	_ datamodel.MapAssembler = (*_structAssembler)(nil)
 	_ datamodel.MapAssembler = (*_structAssemblerRepr)(nil)
@@ -45,6 +47,7 @@ var (
 	_ datamodel.ListAssembler = (*_listAssembler)(nil)
 	_ datamodel.ListAssembler = (*_listAssemblerRepr)(nil)
 	_ datamodel.ListAssembler = (*_listStructAssemblerRepr)(nil)
+	_ datamodel.ListAssembler = (*_listpairsFieldListAssemblerRepr)(nil)
 	_ datamodel.ListIterator  = (*_listIterator)(nil)
 	_ datamodel.ListIterator  = (*_tupleIteratorRepr)(nil)
 	_ datamodel.ListIterator  = (*_listpairsIteratorRepr)(nil)

--- a/node/bindnode/node.go
+++ b/node/bindnode/node.go
@@ -44,8 +44,10 @@ var (
 
 	_ datamodel.ListAssembler = (*_listAssembler)(nil)
 	_ datamodel.ListAssembler = (*_listAssemblerRepr)(nil)
+	_ datamodel.ListAssembler = (*_listStructAssemblerRepr)(nil)
 	_ datamodel.ListIterator  = (*_listIterator)(nil)
 	_ datamodel.ListIterator  = (*_tupleIteratorRepr)(nil)
+	_ datamodel.ListIterator  = (*_listpairsIteratorRepr)(nil)
 
 	_ datamodel.MapAssembler = (*_unionAssembler)(nil)
 	_ datamodel.MapAssembler = (*_unionAssemblerRepr)(nil)

--- a/node/bindnode/repr.go
+++ b/node/bindnode/repr.go
@@ -53,7 +53,7 @@ func (w *_nodeRepr) Kind() datamodel.Kind {
 		return datamodel.Kind_String
 	case schema.StructRepresentation_Map:
 		return datamodel.Kind_Map
-	case schema.StructRepresentation_Tuple:
+	case schema.StructRepresentation_Tuple, schema.StructRepresentation_ListPairs:
 		return datamodel.Kind_List
 	case schema.UnionRepresentation_Keyed:
 		return datamodel.Kind_Map
@@ -174,6 +174,31 @@ func (w *_nodeRepr) LookupByIndex(idx int64) (datamodel.Node, error) {
 			return nil, err
 		}
 		return reprNode(v), nil
+	case schema.StructRepresentation_ListPairs:
+		fields := w.schemaType.(*schema.TypeStruct).Fields()
+		if idx < 0 || int(idx) >= len(fields)*2 {
+			return nil, datamodel.ErrNotExists{Segment: datamodel.PathSegmentOfInt(idx)}
+		}
+		isName := idx%2 == 0
+		idx = idx / 2
+		var curField int64
+		for _, field := range fields {
+			value, err := (*_node)(w).LookupByString(field.Name())
+			if err != nil {
+				return nil, err
+			}
+			if value.IsAbsent() {
+				continue
+			}
+			if curField == idx {
+				if isName {
+					return basicnode.NewString(field.Name()), nil
+				}
+				return reprNode(value), nil
+			}
+			curField++
+		}
+		return nil, datamodel.ErrNotExists{Segment: datamodel.PathSegmentOfInt(idx)}
 	default:
 		v, err := (*_node)(w).LookupByIndex(idx)
 		if err != nil {
@@ -272,6 +297,11 @@ func (w *_nodeRepr) ListIterator() datamodel.ListIterator {
 		iter := _tupleIteratorRepr{cfg: w.cfg, schemaType: typ, fields: typ.Fields(), val: w.val}
 		iter.reprEnd = int(w.lengthMinusTrailingAbsents())
 		return &iter
+	case schema.StructRepresentation_ListPairs:
+		typ := w.schemaType.(*schema.TypeStruct)
+		iter := _listpairsIteratorRepr{cfg: w.cfg, schemaType: typ, fields: typ.Fields(), val: w.val}
+		iter.reprEnd = int(w.lengthMinusTrailingAbsents()) * 2
+		return &iter
 	default:
 		iter, _ := (*_node)(w).ListIterator().(*_listIterator)
 		if iter == nil {
@@ -320,6 +350,7 @@ type _tupleIteratorRepr struct {
 
 func (w *_tupleIteratorRepr) Next() (index int64, value datamodel.Node, _ error) {
 _skipAbsent:
+	idx := w.nextIndex
 	_, value, err := (*_structIterator)(w).Next()
 	if err != nil {
 		return 0, nil, err
@@ -327,10 +358,58 @@ _skipAbsent:
 	if w.nextIndex > w.reprEnd {
 		goto _skipAbsent
 	}
-	return int64(w.nextIndex), reprNode(value), nil
+	return int64(idx), reprNode(value), nil
 }
 
 func (w *_tupleIteratorRepr) Done() bool {
+	return w.nextIndex >= w.reprEnd
+}
+
+type _listpairsIteratorRepr struct {
+	cfg        config
+	schemaType *schema.TypeStruct
+	fields     []schema.StructField
+	val        reflect.Value // non-pointer
+	nextIndex  int
+
+	// these are only used in repr.go
+	reprEnd int
+}
+
+func (w *_listpairsIteratorRepr) Next() (index int64, value datamodel.Node, _ error) {
+_skipAbsent:
+	idx := w.nextIndex
+	if w.nextIndex%2 == 0 {
+		// field name
+		if w.Done() {
+			return 0, nil, datamodel.ErrIteratorOverread{}
+		}
+		field := w.fields[w.nextIndex/2]
+		w.nextIndex++
+		if field.IsOptional() {
+			val := w.val.Field(w.nextIndex)
+			if val.IsNil() {
+				goto _skipAbsent
+			}
+		}
+		key := basicnode.NewString(field.Name())
+		return int64(idx), key, nil
+	}
+	// field value
+	// set nextIndex to a value that will be correct for a _structIterator#Next() call.
+	w.nextIndex = (idx - 1) / 2
+	_, value, err := (*_structIterator)(w).Next()
+	w.nextIndex = idx + 1
+	if err != nil {
+		return 0, nil, err
+	}
+	if value.IsAbsent() || w.nextIndex > w.reprEnd {
+		goto _skipAbsent
+	}
+	return int64(idx), reprNode(value), nil
+}
+
+func (w *_listpairsIteratorRepr) Done() bool {
 	return w.nextIndex >= w.reprEnd
 }
 
@@ -353,6 +432,8 @@ func (w *_nodeRepr) Length() int64 {
 		return w.lengthMinusAbsents()
 	case schema.StructRepresentation_Tuple:
 		return w.lengthMinusTrailingAbsents()
+	case schema.StructRepresentation_ListPairs:
+		return w.lengthMinusAbsents() * 2
 	case schema.UnionRepresentation_Keyed:
 		return (*_node)(w).Length()
 	case schema.UnionRepresentation_Kinded:
@@ -625,7 +706,7 @@ func (w *_assemblerRepr) BeginList(sizeHint int64) (datamodel.ListAssembler, err
 	switch stg := reprStrategy(w.schemaType).(type) {
 	case schema.UnionRepresentation_Kinded:
 		return w.asKinded(stg, datamodel.Kind_List).BeginList(sizeHint)
-	case schema.StructRepresentation_Tuple:
+	case schema.StructRepresentation_Tuple, schema.StructRepresentation_ListPairs:
 		asm, err := (*_assembler)(w).BeginMap(sizeHint)
 		if err != nil {
 			return nil, err
@@ -860,7 +941,7 @@ func (w *_structAssemblerRepr) AssembleKey() datamodel.NodeAssembler {
 			AppropriateKind: datamodel.KindSet_JustMap,
 			ActualKind:      datamodel.Kind_String,
 		}}
-	case schema.StructRepresentation_Tuple:
+	case schema.StructRepresentation_Tuple, schema.StructRepresentation_ListPairs:
 		return _errorAssembler{datamodel.ErrWrongKind{
 			TypeName:        w.schemaType.Name() + ".Repr",
 			MethodName:      "AssembleKey",
@@ -974,6 +1055,16 @@ func (w *_listStructAssemblerRepr) AssembleValue() datamodel.NodeAssembler {
 		}
 		entryAsm = assemblerRepr(entryAsm)
 		return entryAsm
+	case schema.StructRepresentation_ListPairs:
+		idx := w.nextIndex
+		w.nextIndex++
+		if idx%2 == 0 {
+			asm := (*_structAssembler)(w).AssembleKey()
+			// ???
+			return (*_assemblerRepr)(asm.(*_assembler))
+		}
+		asm := (*_structAssembler)(w).AssembleValue()
+		return (*_assemblerRepr)(asm.(*_assembler))
 	default:
 		return _errorAssembler{fmt.Errorf("bindnode AssembleValue TODO: %T", stg)}
 	}
@@ -981,7 +1072,7 @@ func (w *_listStructAssemblerRepr) AssembleValue() datamodel.NodeAssembler {
 
 func (w *_listStructAssemblerRepr) Finish() error {
 	switch stg := reprStrategy(w.schemaType).(type) {
-	case schema.StructRepresentation_Tuple:
+	case schema.StructRepresentation_Tuple, schema.StructRepresentation_ListPairs:
 		return (*_structAssembler)(w).Finish()
 	default:
 		return fmt.Errorf("bindnode Finish TODO: %T", stg)

--- a/node/bindnode/repr.go
+++ b/node/bindnode/repr.go
@@ -1148,15 +1148,10 @@ func (w _listpairsFieldAssemblerRepr) AssignLink(datamodel.Link) error {
 	}
 }
 
-// TODO: support this if it's a list?
-func (w _listpairsFieldAssemblerRepr) AssignNode(datamodel.Node) error {
-	return datamodel.ErrWrongKind{
-		TypeName:        w.parent.schemaType.Name(),
-		MethodName:      "AssignNode",
-		AppropriateKind: datamodel.KindSet_JustList,
-		ActualKind:      datamodel.Kind_Map,
-	}
+func (w *_listpairsFieldAssemblerRepr) AssignNode(n datamodel.Node) error {
+	return datamodel.Copy(n, w)
 }
+
 func (w _listpairsFieldAssemblerRepr) Prototype() datamodel.NodePrototype {
 	panic("bindnode TODO: listpairs field Prototype")
 }

--- a/node/bindnode/repr.go
+++ b/node/bindnode/repr.go
@@ -189,7 +189,7 @@ func (w *_nodeRepr) LookupByIndex(idx int64) (datamodel.Node, error) {
 				continue
 			}
 			if curField == idx {
-				return buildListpairsField(basicnode.NewString(field.Name()), value)
+				return buildListpairsField(basicnode.NewString(field.Name()), reprNode(value))
 			}
 			curField++
 		}
@@ -384,7 +384,7 @@ func (w *_listpairsIteratorRepr) Next() (index int64, value datamodel.Node, _ er
 		if value.IsAbsent() || w.nextIndex > w.reprEnd {
 			continue
 		}
-		field, err := buildListpairsField(key, value)
+		field, err := buildListpairsField(key, reprNode(value))
 		if err != nil {
 			return 0, nil, err
 		}
@@ -1167,7 +1167,8 @@ func (w *_listpairsFieldListAssemblerRepr) AssembleValue() datamodel.NodeAssembl
 	case 1:
 		return w.parent.AssembleKey()
 	case 2:
-		return w.parent.AssembleValue()
+		asm := w.parent.AssembleValue()
+		return assemblerRepr(asm.(*_assembler))
 	default:
 		return _errorAssembler{fmt.Errorf("bindnode: too many values in listpairs field")}
 	}

--- a/node/tests/schema.go
+++ b/node/tests/schema.go
@@ -19,6 +19,7 @@ var allSchemaTests = []struct {
 	{"StructNesting", SchemaTestStructNesting},
 	{"StructReprStringjoin", SchemaTestStructReprStringjoin},
 	{"StructReprTuple", SchemaTestStructReprTuple},
+	{"StructReprListPairs", SchemaTestStructReprListPairs},
 	{"StructsContainingMaybe", SchemaTestStructsContainingMaybe},
 	{"UnionKeyed", SchemaTestUnionKeyed},
 	{"UnionKeyedComplexChildren", SchemaTestUnionKeyedComplexChildren},

--- a/node/tests/schemaStructReprListpairs.go
+++ b/node/tests/schemaStructReprListpairs.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ipld/go-ipld-prime/datamodel"
 	"github.com/ipld/go-ipld-prime/fluent"
 	"github.com/ipld/go-ipld-prime/must"
+	"github.com/ipld/go-ipld-prime/node/basicnode"
 	"github.com/ipld/go-ipld-prime/schema"
 )
 
@@ -234,6 +235,26 @@ func SchemaTestStructReprListPairs(t *testing.T, engine Engine) {
 				})
 			})
 			qt.Check(t, n, NodeContentEquals, nr)
+		})
+		t.Run("repr-create with AssignNode", func(t *testing.T) {
+			nr := fluent.MustBuildList(basicnode.Prototype.Any, 2, func(la fluent.ListAssembler) {
+				la.AssembleValue().CreateList(2, func(la fluent.ListAssembler) {
+					la.AssembleValue().AssignString("foo")
+					la.AssembleValue().AssignNull()
+				})
+				la.AssembleValue().CreateList(2, func(la fluent.ListAssembler) {
+					la.AssembleValue().AssignString("qux")
+					la.AssembleValue().CreateList(2, func(la fluent.ListAssembler) {
+						la.AssembleValue().AssignString("1")
+						la.AssembleValue().AssignString("2")
+					})
+				})
+			})
+			builder := nrp.NewBuilder()
+			err := builder.AssignNode(nr)
+			qt.Assert(t, err, qt.IsNil)
+			anr := builder.Build()
+			qt.Check(t, n, NodeContentEquals, anr)
 		})
 	})
 }

--- a/node/tests/schemaStructReprListpairs.go
+++ b/node/tests/schemaStructReprListpairs.go
@@ -1,0 +1,163 @@
+package tests
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/ipld/go-ipld-prime/datamodel"
+	"github.com/ipld/go-ipld-prime/fluent"
+	"github.com/ipld/go-ipld-prime/must"
+	"github.com/ipld/go-ipld-prime/schema"
+)
+
+func SchemaTestStructReprListPairs(t *testing.T, engine Engine) {
+	ts := schema.TypeSystem{}
+	ts.Init()
+	ts.Accumulate(schema.SpawnString("String"))
+	ts.Accumulate(schema.SpawnStruct("OneListPair",
+		[]schema.StructField{
+			schema.SpawnStructField("field", "String", false, false),
+		},
+		schema.SpawnStructRepresentationListPairs(),
+	))
+	ts.Accumulate(schema.SpawnStruct("FourListPairs",
+		[]schema.StructField{
+			schema.SpawnStructField("foo", "String", false, true),
+			schema.SpawnStructField("bar", "String", true, true),
+			schema.SpawnStructField("baz", "String", true, false),
+			schema.SpawnStructField("qux", "String", false, false),
+		},
+		schema.SpawnStructRepresentationListPairs(),
+	))
+	engine.Init(t, ts)
+
+	t.Run("onelistpair works", func(t *testing.T) {
+		np := engine.PrototypeByName("OneListPair")
+		nrp := engine.PrototypeByName("OneListPair.Repr")
+		var n schema.TypedNode
+		t.Run("typed-create", func(t *testing.T) {
+			n = fluent.MustBuildMap(np, 1, func(ma fluent.MapAssembler) {
+				ma.AssembleEntry("field").AssignString("valoo")
+			}).(schema.TypedNode)
+			t.Run("typed-read", func(t *testing.T) {
+				qt.Assert(t, n.Kind(), qt.Equals, datamodel.Kind_Map)
+				qt.Check(t, n.Length(), qt.Equals, int64(1))
+				qt.Check(t, must.String(must.Node(n.LookupByString("field"))), qt.Equals, "valoo")
+			})
+			t.Run("repr-read", func(t *testing.T) {
+				nr := n.Representation()
+				qt.Assert(t, nr.Kind(), qt.Equals, datamodel.Kind_List)
+				qt.Check(t, nr.Length(), qt.Equals, int64(2))
+				qt.Check(t, must.String(must.Node(nr.LookupByIndex(0))), qt.Equals, "field")
+				qt.Check(t, must.String(must.Node(nr.LookupByIndex(1))), qt.Equals, "valoo")
+			})
+		})
+		t.Run("repr-create", func(t *testing.T) {
+			nr := fluent.MustBuildList(nrp, 2, func(la fluent.ListAssembler) {
+				la.AssembleValue().AssignString("field")
+				la.AssembleValue().AssignString("valoo")
+			})
+			qt.Check(t, n, NodeContentEquals, nr)
+		})
+	})
+
+	t.Run("fourlistpairs works", func(t *testing.T) {
+		np := engine.PrototypeByName("FourListPairs")
+		nrp := engine.PrototypeByName("FourListPairs.Repr")
+		var n schema.TypedNode
+		t.Run("typed-create", func(t *testing.T) {
+			n = fluent.MustBuildMap(np, 4, func(ma fluent.MapAssembler) {
+				ma.AssembleEntry("foo").AssignString("0")
+				ma.AssembleEntry("bar").AssignString("1")
+				ma.AssembleEntry("baz").AssignString("2")
+				ma.AssembleEntry("qux").AssignString("3")
+			}).(schema.TypedNode)
+			t.Run("typed-read", func(t *testing.T) {
+				qt.Assert(t, n.Kind(), qt.Equals, datamodel.Kind_Map)
+				qt.Check(t, n.Length(), qt.Equals, int64(4))
+				qt.Check(t, must.String(must.Node(n.LookupByString("foo"))), qt.Equals, "0")
+				qt.Check(t, must.String(must.Node(n.LookupByString("bar"))), qt.Equals, "1")
+				qt.Check(t, must.String(must.Node(n.LookupByString("baz"))), qt.Equals, "2")
+				qt.Check(t, must.String(must.Node(n.LookupByString("qux"))), qt.Equals, "3")
+			})
+			t.Run("repr-read", func(t *testing.T) {
+				nr := n.Representation()
+				qt.Assert(t, nr.Kind(), qt.Equals, datamodel.Kind_List)
+				qt.Check(t, nr.Length(), qt.Equals, int64(8))
+				qt.Check(t, must.String(must.Node(nr.LookupByIndex(0))), qt.Equals, "foo")
+				qt.Check(t, must.String(must.Node(nr.LookupByIndex(1))), qt.Equals, "0")
+				qt.Check(t, must.String(must.Node(nr.LookupByIndex(2))), qt.Equals, "bar")
+				qt.Check(t, must.String(must.Node(nr.LookupByIndex(3))), qt.Equals, "1")
+				qt.Check(t, must.String(must.Node(nr.LookupByIndex(4))), qt.Equals, "baz")
+				qt.Check(t, must.String(must.Node(nr.LookupByIndex(5))), qt.Equals, "2")
+				qt.Check(t, must.String(must.Node(nr.LookupByIndex(6))), qt.Equals, "qux")
+				qt.Check(t, must.String(must.Node(nr.LookupByIndex(7))), qt.Equals, "3")
+			})
+		})
+		t.Run("repr-create", func(t *testing.T) {
+			nr := fluent.MustBuildList(nrp, 8, func(la fluent.ListAssembler) {
+				la.AssembleValue().AssignString("foo")
+				la.AssembleValue().AssignString("0")
+				la.AssembleValue().AssignString("bar")
+				la.AssembleValue().AssignString("1")
+				la.AssembleValue().AssignString("baz")
+				la.AssembleValue().AssignString("2")
+				la.AssembleValue().AssignString("qux")
+				la.AssembleValue().AssignString("3")
+			})
+			qt.Check(t, n, NodeContentEquals, nr)
+		})
+		t.Run("repr-create out-of-order", func(t *testing.T) {
+			nr := fluent.MustBuildList(nrp, 8, func(la fluent.ListAssembler) {
+				la.AssembleValue().AssignString("bar")
+				la.AssembleValue().AssignString("1")
+				la.AssembleValue().AssignString("foo")
+				la.AssembleValue().AssignString("0")
+				la.AssembleValue().AssignString("qux")
+				la.AssembleValue().AssignString("3")
+				la.AssembleValue().AssignString("baz")
+				la.AssembleValue().AssignString("2")
+			})
+			qt.Check(t, n, NodeContentEquals, nr)
+		})
+	})
+
+	t.Run("fourlistpairs with absents", func(t *testing.T) {
+		np := engine.PrototypeByName("FourListPairs")
+		nrp := engine.PrototypeByName("FourListPairs.Repr")
+		var n schema.TypedNode
+		t.Run("typed-create", func(t *testing.T) {
+			n = fluent.MustBuildMap(np, 2, func(ma fluent.MapAssembler) {
+				ma.AssembleEntry("foo").AssignNull()
+				ma.AssembleEntry("qux").AssignString("3")
+			}).(schema.TypedNode)
+			t.Run("typed-read", func(t *testing.T) {
+				qt.Assert(t, n.Kind(), qt.Equals, datamodel.Kind_Map)
+				qt.Check(t, n.Length(), qt.Equals, int64(4))
+				qt.Check(t, must.Node(n.LookupByString("foo")), qt.Equals, datamodel.Null)
+				qt.Check(t, must.Node(n.LookupByString("bar")), qt.Equals, datamodel.Absent)
+				qt.Check(t, must.Node(n.LookupByString("baz")), qt.Equals, datamodel.Absent)
+				qt.Check(t, must.String(must.Node(n.LookupByString("qux"))), qt.Equals, "3")
+			})
+			t.Run("repr-read", func(t *testing.T) {
+				nr := n.Representation()
+				qt.Assert(t, nr.Kind(), qt.Equals, datamodel.Kind_List)
+				qt.Check(t, nr.Length(), qt.Equals, int64(4))
+				qt.Check(t, must.String(must.Node(nr.LookupByIndex(0))), qt.Equals, "foo")
+				qt.Check(t, must.Node(nr.LookupByIndex(1)), qt.Equals, datamodel.Null)
+				qt.Check(t, must.String(must.Node(nr.LookupByIndex(2))), qt.Equals, "qux")
+				qt.Check(t, must.String(must.Node(nr.LookupByIndex(3))), qt.Equals, "3")
+			})
+		})
+		t.Run("repr-create", func(t *testing.T) {
+			nr := fluent.MustBuildList(nrp, 4, func(la fluent.ListAssembler) {
+				la.AssembleValue().AssignString("foo")
+				la.AssembleValue().AssignNull()
+				la.AssembleValue().AssignString("qux")
+				la.AssembleValue().AssignString("3")
+			})
+			qt.Check(t, n, NodeContentEquals, nr)
+		})
+	})
+}

--- a/schema/dmt/compile.go
+++ b/schema/dmt/compile.go
@@ -277,6 +277,8 @@ func spawnType(ts *schema.TypeSystem, name schema.TypeName, defn TypeDefn) (sche
 				return nil, fmt.Errorf("stringjoin has empty join value")
 			}
 			repr = schema.SpawnStructRepresentationStringjoin(join)
+		case typ.Representation.StructRepresentation_Listpairs != nil:
+			repr = schema.SpawnStructRepresentationListPairs()
 		default:
 			return nil, fmt.Errorf("TODO: support other struct repr in schema package")
 		}

--- a/schema/dsl/parse.go
+++ b/schema/dsl/parse.go
@@ -467,6 +467,9 @@ func (p *parser) typeStruct() (*dmt.TypeDefnStruct, error) {
 			Join: join,
 		}
 		return defn, nil
+	case "listpairs":
+		defn.Representation.StructRepresentation_Listpairs = &dmt.StructRepresentation_Listpairs{}
+		return defn, nil
 	default:
 		return nil, p.errf("unknown struct repr: %q", reprName)
 	}

--- a/schema/tmpBuilders.go
+++ b/schema/tmpBuilders.go
@@ -122,6 +122,9 @@ func SpawnStructRepresentationMap2(renames map[string]string, implicits map[stri
 func SpawnStructRepresentationTuple() StructRepresentation_Tuple {
 	return StructRepresentation_Tuple{}
 }
+func SpawnStructRepresentationListPairs() StructRepresentation_ListPairs {
+	return StructRepresentation_ListPairs{}
+}
 func SpawnStructRepresentationStringjoin(delim string) StructRepresentation_Stringjoin {
 	return StructRepresentation_Stringjoin{delim}
 }

--- a/schema/type.go
+++ b/schema/type.go
@@ -224,6 +224,7 @@ type StructRepresentation interface{ _StructRepresentation() }
 
 func (StructRepresentation_Map) _StructRepresentation()         {}
 func (StructRepresentation_Tuple) _StructRepresentation()       {}
+func (StructRepresentation_ListPairs) _StructRepresentation()   {}
 func (StructRepresentation_StringPairs) _StructRepresentation() {}
 func (StructRepresentation_Stringjoin) _StructRepresentation()  {}
 
@@ -232,6 +233,7 @@ type StructRepresentation_Map struct {
 	implicits map[string]ImplicitValue
 }
 type StructRepresentation_Tuple struct{}
+type StructRepresentation_ListPairs struct{}
 
 //lint:ignore U1000 implementation TODO
 type StructRepresentation_StringPairs struct{ sep1, sep2 string }

--- a/schema/typeMethods.go
+++ b/schema/typeMethods.go
@@ -55,6 +55,8 @@ func (t TypeStruct) RepresentationBehavior() datamodel.Kind {
 		return datamodel.Kind_Map
 	case StructRepresentation_Tuple:
 		return datamodel.Kind_List
+	case StructRepresentation_ListPairs:
+		return datamodel.Kind_List
 	case StructRepresentation_StringPairs:
 		return datamodel.Kind_String
 	case StructRepresentation_Stringjoin:


### PR DESCRIPTION
I want order-preserving structs without a pre-defined strict order (tuple), so this implements listpairs which is in the schema spec but has sparse support through go-ipld-prime.

```ipldsch
type Blop struct {
  foo optional Int
  bar optional String
  baz optional String
} representation listpairs
```

```go
type Blop struct {
  Foo *int
  Bar  *string
  Baz *string
}
```

```json
[ "foo", 100, "baz", "bing" ]
```

_(edit: actually should be this:)_

```json
[ [ "foo", 100 ], [ "baz", "bing" ] ]
```

But also this should decode to the same struct (see `out-of-order` test):

```json
[ "baz", "bing", "foo", 100 ]
```

_(edit: actually should be this:)_

```json
[ [ "baz", "bing" ], [ "foo", 100 ] ]
```
