### PR TITLE
fix: return error on LookupBySegment failure

### DIFF
--- a/traversal/walk.go
+++ b/traversal/walk.go
@@ -267,7 +267,7 @@ func (prog Progress) walkAdv(ph phase, n datamodel.Node, s selector.Selector, vi
 	// specific interests, recurse on those.
 	for _, ps := range attn {
 		if v, err := n.LookupBySegment(ps); err != nil {
-			continue
+			return err
 		} else if err := recurse(v, ps); err != nil {
 			return err
 		}


### PR DESCRIPTION
Not quite sure what to do with this yet. This probably isn't the "fix", but I need to get this up before I forget the details of how I landed here.

Testing out selectors for our Trusted Gateway walks, I happen to have a DAG where I know it's incomplete—the wikipedia `/wiki/` directory in fact, I don't have many of the pages and I'm expecting an error to be propagated out of the traversal through the sharded directory where it finds it can't load a block. The error occurs in go-unixfsnode/hamt/shardeddir.go's `LookupBySegment()`, and it's a not-found error from the blockstore, but it gets to here and there's a `continue`. i.e. the selector has an interest in this path segment, but it doesn't happen to be in the node in question.

So, our current Trusted Gateway validator (in Lassie) doesn't even reject the malformed DAG because of this. Where I expect a 5 block DAG, but give it a 3, it'll still pass as if everything's fine.

This goes back to the code that started using `Interests()` here: https://github.com/ipld/go-ipld-prime/commit/31c9bb76cc13be01cb2a761f1afe915236e19a36

And it kind of aligns with the stated intention of `Interests()` as a hint, rather than a directive that it _must_ be explored: https://github.com/ipld/go-ipld-prime/blob/f9fb3bd4c6870657dc21d5c917f438ec7784973f/traversal/selector/selector.go#L39-L51