### PR TITLE
fix: basicnode.NewInt returns pointer (like others)

### DIFF
--- a/node/basicnode/int.go
+++ b/node/basicnode/int.go
@@ -18,7 +18,8 @@ var (
 )
 
 func NewInt(value int64) datamodel.Node {
-	return plainInt(value)
+	v := plainInt(value)
+	return &v
 }
 
 // NewUint creates a new uint64-backed Node which will behave as a plain Int


### PR DESCRIPTION
`basicnode.NewInt` should return a pointer to `plainInt`, similarly to the other types (string, float, bytes, etc). When writing tests for [this PR](https://github.com/ipfs/boxo/pull/333) and mocking interfaces, I was getting a pretty interesting error: the `Decoded` version of an `int` was returning a `*plainInt`, while the `basicnode.NewInt` was returning `plainInt`, causing the mock to fail.

All the other node types work well. There is an inconsistency between how ints are created and assigned. This does not happen with other types. I assume this was something overlooked. It would be nice if this could get released.

cc @rvagg 