### PR TITLE
feat(selectors): negative values for slice matcher's From and To

### DIFF
--- a/testutil/simplebytes.go
+++ b/testutil/simplebytes.go
@@ -1,0 +1,75 @@
+package testutil
+
+import (
+	"github.com/ipld/go-ipld-prime/datamodel"
+	"github.com/ipld/go-ipld-prime/node/basicnode"
+	"github.com/ipld/go-ipld-prime/node/mixins"
+)
+
+var _ datamodel.Node = simpleBytes(nil)
+
+// simpleBytes is like basicnode's plainBytes but it doesn't implement
+// LargeBytesNode so we can exercise the non-LBN case.
+type simpleBytes []byte
+
+// NewSimpleBytes is identical to basicnode.NewBytes but the returned node
+// doesn't implement LargeBytesNode, which can be useful for testing cases
+// where we want to exercise non-LBN code paths.
+func NewSimpleBytes(value []byte) datamodel.Node {
+	v := simpleBytes(value)
+	return &v
+}
+
+// -- Node interface methods -->
+
+func (simpleBytes) Kind() datamodel.Kind {
+	return datamodel.Kind_Bytes
+}
+func (simpleBytes) LookupByString(string) (datamodel.Node, error) {
+	return mixins.Bytes{TypeName: "bytes"}.LookupByString("")
+}
+func (simpleBytes) LookupByNode(key datamodel.Node) (datamodel.Node, error) {
+	return mixins.Bytes{TypeName: "bytes"}.LookupByNode(nil)
+}
+func (simpleBytes) LookupByIndex(idx int64) (datamodel.Node, error) {
+	return mixins.Bytes{TypeName: "bytes"}.LookupByIndex(0)
+}
+func (simpleBytes) LookupBySegment(seg datamodel.PathSegment) (datamodel.Node, error) {
+	return mixins.Bytes{TypeName: "bytes"}.LookupBySegment(seg)
+}
+func (simpleBytes) MapIterator() datamodel.MapIterator {
+	return nil
+}
+func (simpleBytes) ListIterator() datamodel.ListIterator {
+	return nil
+}
+func (simpleBytes) Length() int64 {
+	return -1
+}
+func (simpleBytes) IsAbsent() bool {
+	return false
+}
+func (simpleBytes) IsNull() bool {
+	return false
+}
+func (simpleBytes) AsBool() (bool, error) {
+	return mixins.Bytes{TypeName: "bytes"}.AsBool()
+}
+func (simpleBytes) AsInt() (int64, error) {
+	return mixins.Bytes{TypeName: "bytes"}.AsInt()
+}
+func (simpleBytes) AsFloat() (float64, error) {
+	return mixins.Bytes{TypeName: "bytes"}.AsFloat()
+}
+func (simpleBytes) AsString() (string, error) {
+	return mixins.Bytes{TypeName: "bytes"}.AsString()
+}
+func (n simpleBytes) AsBytes() ([]byte, error) {
+	return []byte(n), nil
+}
+func (simpleBytes) AsLink() (datamodel.Link, error) {
+	return mixins.Bytes{TypeName: "bytes"}.AsLink()
+}
+func (simpleBytes) Prototype() datamodel.NodePrototype {
+	return basicnode.Prototype__Bytes{}
+}

--- a/traversal/selector/matcher.go
+++ b/traversal/selector/matcher.go
@@ -27,6 +27,12 @@ type Matcher struct {
 // The returned node will be limited based on slicing the specified range of the
 // node into a new node, or making use of the `AsLargeBytes` io.ReadSeeker to
 // restrict response with a SectionReader.
+//
+// Slice supports [From,To) ranges, where From is inclusive and To is exclusive.
+// Negative values for From and To are interpreted as offsets from the end of
+// the node. If To is greater than the node length, it will be truncated to the
+// node length. If From is greater than the node length or greater than To, the
+// result will be a non-match.
 type Slice struct {
 	From int64
 	To   int64

--- a/traversal/selector/matcher_test.go
+++ b/traversal/selector/matcher_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ipld/go-ipld-prime/datamodel"
 	"github.com/ipld/go-ipld-prime/fluent/qp"
 	"github.com/ipld/go-ipld-prime/node/basicnode"
+	"github.com/ipld/go-ipld-prime/node/mixins"
 	"github.com/ipld/go-ipld-prime/testutil"
 	"github.com/ipld/go-ipld-prime/traversal"
 	"github.com/ipld/go-ipld-prime/traversal/selector"
@@ -22,7 +23,7 @@ func TestSubsetMatch(t *testing.T) {
 		node datamodel.Node
 	}{
 		{"stringNode", basicnode.NewString(expectedString)},
-		{"bytesNode", basicnode.NewBytes([]byte(expectedString))},
+		{"bytesNode", simpleBytes([]byte(expectedString))},
 		{"largeBytesNode", testutil.NewMultiByteNode(
 			[]byte("foo"),
 			[]byte("bar"),
@@ -50,26 +51,37 @@ func TestSubsetMatch(t *testing.T) {
 	}
 
 	for _, tc := range []struct {
-		from int64
-		to   int64
-		exp  string
+		from  int64
+		to    int64
+		exp   string
+		match bool
 	}{
-		{0, math.MaxInt64, expectedString},
-		{0, int64(len(expectedString)), expectedString},
-		{0, 0, ""},
-		{0, 1, "f"},
-		{0, 2, "fo"},
-		{0, 3, "foo"},
-		{0, 4, "foob"},
-		{1, 4, "oob"},
-		{2, 4, "ob"},
-		{3, 4, "b"},
-		{4, 4, ""},
-		{4, math.MaxInt64, "arbaz!"},
-		{4, int64(len(expectedString)), "arbaz!"},
-		{4, int64(len(expectedString) - 1), "arbaz"},
-		{0, int64(len(expectedString) - 1), expectedString[0 : len(expectedString)-1]},
-		{0, int64(len(expectedString) - 2), expectedString[0 : len(expectedString)-2]},
+		{0, math.MaxInt64, expectedString, true},
+		{0, int64(len(expectedString)), expectedString, true},
+		{0, 0, "", true},
+		{0, 1, "f", true},
+		{0, 2, "fo", true},
+		{0, 3, "foo", true},
+		{0, 4, "foob", true},
+		{1, 4, "oob", true},
+		{2, 4, "ob", true},
+		{3, 4, "b", true},
+		{4, 4, "", true},
+		{4, math.MaxInt64, "arbaz!", true},
+		{4, int64(len(expectedString)), "arbaz!", true},
+		{4, int64(len(expectedString) - 1), "arbaz", true},
+		{0, int64(len(expectedString) - 1), expectedString[0 : len(expectedString)-1], true},
+		{0, int64(len(expectedString) - 2), expectedString[0 : len(expectedString)-2], true},
+		{0, -1, expectedString[0 : len(expectedString)-1], true},
+		{0, -2, expectedString[0 : len(expectedString)-2], true},
+		{-2, -1, "z", true},
+		{-1, math.MaxInt64, "!", true},
+		{-int64(len(expectedString)), math.MaxInt64, expectedString, true},
+		{math.MaxInt64 - 1, math.MaxInt64, "", false},
+		{int64(len(expectedString)), math.MaxInt64, "", false},
+		{-1000, -100, "", false},
+		{-1, -2, "", false},
+		{-1, -1, "", true}, // matches empty node
 	} {
 		for _, variant := range nodes {
 			t.Run(fmt.Sprintf("%s[%d:%d]", variant.name, tc.from, tc.to), func(t *testing.T) {
@@ -92,20 +104,84 @@ func TestSubsetMatch(t *testing.T) {
 				})
 				qt.Assert(t, err, qt.IsNil)
 
-				qt.Assert(t, got, qt.IsNotNil)
-				qt.Assert(t, got.Kind(), qt.Equals, variant.node.Kind())
-				var gotString string
-				switch got.Kind() {
-				case datamodel.Kind_String:
-					gotString, err = got.AsString()
-					qt.Assert(t, err, qt.IsNil)
-				case datamodel.Kind_Bytes:
-					byts, err := got.AsBytes()
-					qt.Assert(t, err, qt.IsNil)
-					gotString = string(byts)
+				if tc.match {
+					qt.Assert(t, got, qt.IsNotNil)
+					qt.Assert(t, got.Kind(), qt.Equals, variant.node.Kind())
+					var gotString string
+					switch got.Kind() {
+					case datamodel.Kind_String:
+						gotString, err = got.AsString()
+						qt.Assert(t, err, qt.IsNil)
+					case datamodel.Kind_Bytes:
+						byts, err := got.AsBytes()
+						qt.Assert(t, err, qt.IsNil)
+						gotString = string(byts)
+					}
+					qt.Assert(t, gotString, qt.DeepEquals, tc.exp)
+				} else {
+					qt.Assert(t, got, qt.IsNil)
 				}
-				qt.Assert(t, gotString, qt.DeepEquals, tc.exp)
 			})
 		}
 	}
+}
+
+var _ datamodel.Node = simpleBytes{}
+
+// simpleBytes is like basicnode's plainBytes but it doesn't implement
+// LargeBytesNode so we can exercise the non-LBN case.
+type simpleBytes []byte
+
+// -- Node interface methods -->
+
+func (simpleBytes) Kind() datamodel.Kind {
+	return datamodel.Kind_Bytes
+}
+func (simpleBytes) LookupByString(string) (datamodel.Node, error) {
+	return mixins.Bytes{TypeName: "bytes"}.LookupByString("")
+}
+func (simpleBytes) LookupByNode(key datamodel.Node) (datamodel.Node, error) {
+	return mixins.Bytes{TypeName: "bytes"}.LookupByNode(nil)
+}
+func (simpleBytes) LookupByIndex(idx int64) (datamodel.Node, error) {
+	return mixins.Bytes{TypeName: "bytes"}.LookupByIndex(0)
+}
+func (simpleBytes) LookupBySegment(seg datamodel.PathSegment) (datamodel.Node, error) {
+	return mixins.Bytes{TypeName: "bytes"}.LookupBySegment(seg)
+}
+func (simpleBytes) MapIterator() datamodel.MapIterator {
+	return nil
+}
+func (simpleBytes) ListIterator() datamodel.ListIterator {
+	return nil
+}
+func (simpleBytes) Length() int64 {
+	return -1
+}
+func (simpleBytes) IsAbsent() bool {
+	return false
+}
+func (simpleBytes) IsNull() bool {
+	return false
+}
+func (simpleBytes) AsBool() (bool, error) {
+	return mixins.Bytes{TypeName: "bytes"}.AsBool()
+}
+func (simpleBytes) AsInt() (int64, error) {
+	return mixins.Bytes{TypeName: "bytes"}.AsInt()
+}
+func (simpleBytes) AsFloat() (float64, error) {
+	return mixins.Bytes{TypeName: "bytes"}.AsFloat()
+}
+func (simpleBytes) AsString() (string, error) {
+	return mixins.Bytes{TypeName: "bytes"}.AsString()
+}
+func (n simpleBytes) AsBytes() ([]byte, error) {
+	return []byte(n), nil
+}
+func (simpleBytes) AsLink() (datamodel.Link, error) {
+	return mixins.Bytes{TypeName: "bytes"}.AsLink()
+}
+func (simpleBytes) Prototype() datamodel.NodePrototype {
+	return basicnode.Prototype__Bytes{}
 }

--- a/traversal/selector/matcher_test.go
+++ b/traversal/selector/matcher_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ipld/go-ipld-prime/datamodel"
 	"github.com/ipld/go-ipld-prime/fluent/qp"
 	"github.com/ipld/go-ipld-prime/node/basicnode"
-	"github.com/ipld/go-ipld-prime/node/mixins"
 	"github.com/ipld/go-ipld-prime/testutil"
 	"github.com/ipld/go-ipld-prime/traversal"
 	"github.com/ipld/go-ipld-prime/traversal/selector"
@@ -23,7 +22,7 @@ func TestSubsetMatch(t *testing.T) {
 		node datamodel.Node
 	}{
 		{"stringNode", basicnode.NewString(expectedString)},
-		{"bytesNode", simpleBytes([]byte(expectedString))},
+		{"bytesNode", testutil.NewSimpleBytes([]byte(expectedString))},
 		{"largeBytesNode", testutil.NewMultiByteNode(
 			[]byte("foo"),
 			[]byte("bar"),
@@ -124,64 +123,4 @@ func TestSubsetMatch(t *testing.T) {
 			})
 		}
 	}
-}
-
-var _ datamodel.Node = simpleBytes{}
-
-// simpleBytes is like basicnode's plainBytes but it doesn't implement
-// LargeBytesNode so we can exercise the non-LBN case.
-type simpleBytes []byte
-
-// -- Node interface methods -->
-
-func (simpleBytes) Kind() datamodel.Kind {
-	return datamodel.Kind_Bytes
-}
-func (simpleBytes) LookupByString(string) (datamodel.Node, error) {
-	return mixins.Bytes{TypeName: "bytes"}.LookupByString("")
-}
-func (simpleBytes) LookupByNode(key datamodel.Node) (datamodel.Node, error) {
-	return mixins.Bytes{TypeName: "bytes"}.LookupByNode(nil)
-}
-func (simpleBytes) LookupByIndex(idx int64) (datamodel.Node, error) {
-	return mixins.Bytes{TypeName: "bytes"}.LookupByIndex(0)
-}
-func (simpleBytes) LookupBySegment(seg datamodel.PathSegment) (datamodel.Node, error) {
-	return mixins.Bytes{TypeName: "bytes"}.LookupBySegment(seg)
-}
-func (simpleBytes) MapIterator() datamodel.MapIterator {
-	return nil
-}
-func (simpleBytes) ListIterator() datamodel.ListIterator {
-	return nil
-}
-func (simpleBytes) Length() int64 {
-	return -1
-}
-func (simpleBytes) IsAbsent() bool {
-	return false
-}
-func (simpleBytes) IsNull() bool {
-	return false
-}
-func (simpleBytes) AsBool() (bool, error) {
-	return mixins.Bytes{TypeName: "bytes"}.AsBool()
-}
-func (simpleBytes) AsInt() (int64, error) {
-	return mixins.Bytes{TypeName: "bytes"}.AsInt()
-}
-func (simpleBytes) AsFloat() (float64, error) {
-	return mixins.Bytes{TypeName: "bytes"}.AsFloat()
-}
-func (simpleBytes) AsString() (string, error) {
-	return mixins.Bytes{TypeName: "bytes"}.AsString()
-}
-func (n simpleBytes) AsBytes() ([]byte, error) {
-	return []byte(n), nil
-}
-func (simpleBytes) AsLink() (datamodel.Link, error) {
-	return mixins.Bytes{TypeName: "bytes"}.AsLink()
-}
-func (simpleBytes) Prototype() datamodel.NodePrototype {
-	return basicnode.Prototype__Bytes{}
 }


### PR DESCRIPTION
Ref: https://github.com/ipld/ipld/pull/289

Builds on the basic fixes and tests in: https://github.com/ipld/go-ipld-prime/pull/529

Note particularly the nuances in the test cases for negative values as they relate to what I outlined in https://github.com/ipld/ipld/pull/289.

One implication of the way this is implemented is that we can't do the "your range didn't match, so we'll give you the full file". We end up with "didn't match, you get nothing (just the root)". Which seems like logical behaviour to me, but @willscott you did bring up the http spec saying that you could return the whole lot if your range is OOB or invalid in some way.