### PR TITLE
feat: add EmptyPathSegment, distinct from PathSegment{}

### DIFF
--- a/datamodel/path.go
+++ b/datamodel/path.go
@@ -65,6 +65,9 @@ type Path struct {
 	segments []PathSegment
 }
 
+// EmptyPath is the Path with no segments.
+var EmptyPath = Path{}
+
 // NewPath returns a Path composed of the given segments.
 //
 // This constructor function does a defensive copy,
@@ -195,7 +198,7 @@ func (p Path) AppendSegmentInt(ps int64) Path {
 // the zero path if it's already empty).
 func (p Path) Parent() Path {
 	if len(p.segments) == 0 {
-		return Path{}
+		return EmptyPath
 	}
 	return Path{p.segments[0 : len(p.segments)-1]}
 }
@@ -205,10 +208,11 @@ func (p Path) Truncate(i int) Path {
 	return Path{p.segments[0:i]}
 }
 
-// Last returns the trailing segment of the path.
+// Last returns the trailing segment of the path. Path length should be checked before making use of this value.
+// If the path is empty, EmptyPathSegment is returned which may not be useful.
 func (p Path) Last() PathSegment {
 	if len(p.segments) < 1 {
-		return PathSegment{}
+		return EmptyPathSegment
 	}
 	return p.segments[len(p.segments)-1]
 }
@@ -216,16 +220,17 @@ func (p Path) Last() PathSegment {
 // Pop returns a path with all segments except the last.
 func (p Path) Pop() Path {
 	if len(p.segments) < 1 {
-		return Path{}
+		return EmptyPath
 	}
 	return Path{p.segments[0 : len(p.segments)-1]}
 }
 
 // Shift returns the first segment of the path together with the remaining path after that first segment.
-// If applied to a zero-length path, it returns an empty segment and the same zero-length path.
+// If you intend to use the resulting PathSegment, you should check its length before doing so.
+// If applied to a zero-length path, it returns EmptyPathSegment and the same zero-length path.
 func (p Path) Shift() (PathSegment, Path) {
 	if len(p.segments) < 1 {
-		return PathSegment{}, Path{}
+		return EmptyPathSegment, EmptyPath
 	}
 	return p.segments[0], Path{p.segments[1:]}
 }

--- a/datamodel/pathSegment.go
+++ b/datamodel/pathSegment.go
@@ -69,6 +69,12 @@ type PathSegment struct {
 	i int64
 }
 
+// EmptyPathSegment is the PathSegment with no value. This is not the same as
+// the zero value of PathSegment (PathSegment{}), which will be interpreted to
+// mean "0", as a list index. EmptyPathSegment is equivalent to
+// ParsePathSegment("") or PathSegmentOfString("").
+var EmptyPathSegment = PathSegment{i: -1}
+
 // ParsePathSegment parses a string into a PathSegment,
 // handling any escaping if present.
 // (Note: there is currently no escaping specified for PathSegments,

--- a/datamodel/path_test.go
+++ b/datamodel/path_test.go
@@ -36,4 +36,8 @@ func TestPathSegmentZeroValue(t *testing.T) {
 	i, err := PathSegment{}.Index()
 	qt.Check(t, err, qt.IsNil)
 	qt.Check(t, i, qt.Equals, int64(0))
+
+	qt.Check(t, EmptyPathSegment.String(), qt.Equals, "")
+	_, err = EmptyPathSegment.Index()
+	qt.Check(t, err, qt.IsNotNil)
 }

--- a/traversal/walk.go
+++ b/traversal/walk.go
@@ -318,7 +318,7 @@ func (prog Progress) reify(n datamodel.Node, s selector.Selector) (datamodel.Nod
 		}
 
 		// explore into the `InterpretAs` clause to the child selector.
-		s, err = s.Explore(n, datamodel.PathSegment{})
+		s, err = s.Explore(n, datamodel.EmptyPathSegment)
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
This might require a little bit more thought than I've put into it so far, but this mainly comes from some code that has `var nextSeg datamodel.PathSegment`, then using that naively when it's not initialised, for `String()` in particular. I normally initialise it in a loop using a `path.Shift()` operation but with `Len()==0` I have the zero value. My assumption was that the zero value would just be empty and I could be fine with that. But even if I did a `path.Shift()` on an empty path, I'd get the same thing. Which is, the zero value of a `PathSegment` is a `0` index. This is probably reasonable in some situations but doing a `nextSeg.String()` and seeing `"0"` was certainly not expected.

There is some awkwardness, but it's not new, here's some variations of awkward things you can do, already and with the new thing here:

```go
[]datamodel.PathSegment{{}, {}, {}}).String()
// "0/0/0"
[]datamodel.PathSegment{datamodel.EmptyPathSegment, datamodel.EmptyPathSegment, datamodel.EmptyPathSegment}).String()
// "//"
[]datamodel.PathSegment{datamodel.PathSegmentOfString(""), datamodel.PathSegmentOfString(""), datamodel.PathSegmentOfString("")}).String()
// "//"
```

The two big changes in here are:

* Introduction of `EmptyPathSegment` which is `""` and distinct from the zero-value of `PathSegment`
* Introduction of `EmptyPath` as a matching type, which is the same as the zero-value of `Path`
* Return `EmptyPathSegment` from `Path#Shift()` and `Path#Last()` which currently return the zero-value, which is the `0` index.

This does mean you can't `path.Last() == PathSegment{}`, you'd now have to `path.Last() == EmptyPathSegment`. But I think that maybe you should be checking the length first anyway. I've put that in the docs.

Which is better?

```go
[]datamodel.PathSegment{datamodel.Path{}.Last(), datamodel.Path{}.Last(), datamodel.Path{}.Last()}).String()
// "0/0/0"
```

```go
[]datamodel.PathSegment{datamodel.Path{}.Last(), datamodel.Path{}.Last(), datamodel.Path{}.Last()}).String()
// "//"
```

They both suck, but `Last()` giving you a "zero-index" is a bit more unhelpful than literal `""` I _think_.