### PR TITLE
basicnode: don't panic on negative index

### DIFF
--- a/node/basicnode/list.go
+++ b/node/basicnode/list.go
@@ -31,6 +31,9 @@ func (plainList) LookupByNode(datamodel.Node) (datamodel.Node, error) {
 	return mixins.List{TypeName: "list"}.LookupByNode(nil)
 }
 func (n *plainList) LookupByIndex(idx int64) (datamodel.Node, error) {
+	if idx < 0 {
+		return nil, datamodel.ErrNotExists{Segment: datamodel.PathSegmentOfInt(idx)}
+	}
 	if n.Length() <= idx {
 		return nil, datamodel.ErrNotExists{Segment: datamodel.PathSegmentOfInt(idx)}
 	}


### PR DESCRIPTION
I'm not too sure what error should be returned, but it's certainly better than a panic(). 