### PR TITLE
Make printer more flexible, allow very-compact forms

### DIFF
--- a/printer/printer.go
+++ b/printer/printer.go
@@ -221,9 +221,8 @@ func (z *printBuf) doString(indentLevel int, printState uint8, n datamodel.Node)
 			// Also, because it's possible for structs to be keys in a map themselves, they potentially need oneline emission.
 			// Or, to customize emission in another direction if being a key in a map that's printing in "complex" mode.
 			// FUTURE: there should also probably be some way to configure instructions to use their representation form instead.
-			oneline :=
-				printState == printState_isCmplxValue ||
-					printState != printState_isCmplxKey && z.Config.oneline(tn.Type(), printState == printState_isKey)
+			oneline := printState == printState_isCmplxValue ||
+				printState != printState_isCmplxKey && z.Config.oneline(tn.Type(), printState == printState_isKey)
 			deepen := 1
 			if printState == printState_isCmplxKey {
 				deepen = 2
@@ -245,11 +244,13 @@ func (z *printBuf) doString(indentLevel int, printState uint8, n datamodel.Node)
 				z.writeString(fn)
 				z.writeString(": ")
 				z.doString(indentLevel+deepen, childState, v)
-				if oneline {
-					if !itr.Done() {
-						z.writeString(", ")
+				if !itr.Done() {
+					z.writeString(",")
+					if oneline {
+						z.writeString(" ")
 					}
-				} else {
+				}
+				if !oneline {
 					z.writeString("\n")
 				}
 			}
@@ -312,6 +313,9 @@ func (z *printBuf) doString(indentLevel int, printState uint8, n datamodel.Node)
 			z.doString(indentLevel+1, childKeyState, k)
 			z.writeString(": ")
 			z.doString(indentLevel+1, printState_isValue, v)
+			if !itr.Done() {
+				z.writeString(",")
+			}
 			z.writeString("\n")
 		}
 		z.doIndent(indentLevel)
@@ -337,6 +341,9 @@ func (z *printBuf) doString(indentLevel int, printState uint8, n datamodel.Node)
 			z.writeString(strconv.FormatInt(idx, 10))
 			z.writeString(": ")
 			z.doString(indentLevel+1, printState_isValue, v)
+			if !itr.Done() {
+				z.writeString(",")
+			}
 			z.writeString("\n")
 		}
 		z.doIndent(indentLevel)

--- a/printer/printer.go
+++ b/printer/printer.go
@@ -67,17 +67,9 @@ type Config struct {
 	// If set, the string to use for the start of each line.
 	StartingIndent []byte
 
-	// Set to true if you like verbosity, I guess.
-	// If false, strings will only have kind+type markings if they're typed.
-	//
-	// Not yet supported.
-	AlwaysMarkStrings bool
-
-	// Set to true if you want type info to be skipped for any type that's in the Prelude
-	// (e.g. instead of `string<String>{` seeing only `string{` is preferred, etc).
-	//
-	// Not yet supported.
-	ElidePreludeTypeInfo bool
+	// If set to true, scalar values will be omitted from the output. This is useful for representing
+	// the structure of a graph without the data.
+	OmitScalarValues bool
 
 	// Set to true if you want maps to use "complex"-style printouts:
 	// meaning they will print their keys on separate lines than their values,
@@ -356,31 +348,41 @@ func (z *printBuf) doString(indentLevel int, printState uint8, n datamodel.Node)
 		}
 		z.writeString("}")
 	case datamodel.Kind_Int:
-		x, _ := n.AsInt()
-		z.writeString("{")
-		z.writeString(strconv.FormatInt(x, 10))
-		z.writeString("}")
+		if !z.Config.OmitScalarValues {
+			x, _ := n.AsInt()
+			z.writeString("{")
+			z.writeString(strconv.FormatInt(x, 10))
+			z.writeString("}")
+		}
 	case datamodel.Kind_Float:
-		x, _ := n.AsFloat()
-		z.writeString("{")
-		z.writeString(strconv.FormatFloat(x, 'f', -1, 64))
-		z.writeString("}")
+		if !z.Config.OmitScalarValues {
+			x, _ := n.AsFloat()
+			z.writeString("{")
+			z.writeString(strconv.FormatFloat(x, 'f', -1, 64))
+			z.writeString("}")
+		}
 	case datamodel.Kind_String:
-		x, _ := n.AsString()
-		z.writeString("{")
-		z.writeString(strconv.QuoteToGraphic(x))
-		z.writeString("}")
+		if !z.Config.OmitScalarValues {
+			x, _ := n.AsString()
+			z.writeString("{")
+			z.writeString(strconv.QuoteToGraphic(x))
+			z.writeString("}")
+		}
 	case datamodel.Kind_Bytes:
-		x, _ := n.AsBytes()
-		z.writeString("{")
-		dst := make([]byte, hex.EncodedLen(len(x)))
-		hex.Encode(dst, x)
-		z.writeString(string(dst))
-		z.writeString("}")
+		if !z.Config.OmitScalarValues {
+			x, _ := n.AsBytes()
+			z.writeString("{")
+			dst := make([]byte, hex.EncodedLen(len(x)))
+			hex.Encode(dst, x)
+			z.writeString(string(dst))
+			z.writeString("}")
+		}
 	case datamodel.Kind_Link:
-		x, _ := n.AsLink()
-		z.writeString("{")
-		z.writeString(x.String())
-		z.writeString("}")
+		if !z.Config.OmitScalarValues {
+			x, _ := n.AsLink()
+			z.writeString("{")
+			z.writeString(x.String())
+			z.writeString("}")
+		}
 	}
 }

--- a/printer/printer_test.go
+++ b/printer/printer_test.go
@@ -39,21 +39,62 @@ func TestSimpleData(t *testing.T) {
 		})
 		qt.Check(t, Sprint(n), qt.CmpEquals(), testutil.Dedent(`
 		map{
-			string{"some key"}: string{"some value"},
-			string{"another key"}: string{"another value"},
-			string{"nested map"}: map{
-				string{"deeper entries"}: string{"deeper values"},
-				string{"more deeper entries"}: string{"more deeper values"}
+			string{"some key"}:string{"some value"},
+			string{"another key"}:string{"another value"},
+			string{"nested map"}:map{
+				string{"deeper entries"}:string{"deeper values"},
+				string{"more deeper entries"}:string{"more deeper values"}
 			},
-			string{"nested list"}: list{
-				0: int{1},
-				1: int{2}
+			string{"nested list"}:list{
+				0:int{1},
+				1:int{2}
 			},
-			string{"list with float"}: list{
-				0: float{3.4}
+			string{"list with float"}:list{
+				0:float{3.4}
 			}
 		}`,
 		))
+		t.Run("compact-form", func(t *testing.T) {
+			qt.Check(t, Config{}.Sprint(n), qt.CmpEquals(), `map{string{"some key"}:string{"some value"},string{"another key"}:string{"another value"},string{"nested map"}:map{string{"deeper entries"}:string{"deeper values"},string{"more deeper entries"}:string{"more deeper values"}},string{"nested list"}:list{0:int{1},1:int{2}},string{"list with float"}:list{0:float{3.4}}}`)
+		})
+		t.Run("custom-indentation", func(t *testing.T) {
+			qt.Check(t, Config{Indentation: []byte("==>")}.Sprint(n), qt.CmpEquals(), testutil.Dedent(`
+			map{
+			==>string{"some key"}:string{"some value"},
+			==>string{"another key"}:string{"another value"},
+			==>string{"nested map"}:map{
+			==>==>string{"deeper entries"}:string{"deeper values"},
+			==>==>string{"more deeper entries"}:string{"more deeper values"}
+			==>},
+			==>string{"nested list"}:list{
+			==>==>0:int{1},
+			==>==>1:int{2}
+			==>},
+			==>string{"list with float"}:list{
+			==>==>0:float{3.4}
+			==>}
+			}`,
+			))
+		})
+		t.Run("line-prefix-indentation", func(t *testing.T) {
+			qt.Check(t, Config{StartingIndent: []byte("->"), Indentation: []byte{'*'}}.Sprint(n), qt.CmpEquals(), testutil.Dedent(`
+				->map{
+				->*string{"some key"}:string{"some value"},
+				->*string{"another key"}:string{"another value"},
+				->*string{"nested map"}:map{
+				->**string{"deeper entries"}:string{"deeper values"},
+				->**string{"more deeper entries"}:string{"more deeper values"}
+				->*},
+				->*string{"nested list"}:list{
+				->**0:int{1},
+				->**1:int{2}
+				->*},
+				->*string{"list with float"}:list{
+				->**0:float{3.4}
+				->*}
+				->}`,
+			))
+		})
 	})
 
 	t.Run("map-with-link-and-bytes", func(t *testing.T) {
@@ -73,17 +114,17 @@ func TestSimpleData(t *testing.T) {
 		})
 		qt.Check(t, Sprint(n), qt.CmpEquals(), testutil.Dedent(`
 		map{
-			string{"some key"}: link{bafkqabiaaebagba},
-			string{"another key"}: string{"another value"},
-			string{"nested map"}: map{
-				string{"deeper entries"}: string{"deeper values"},
-				string{"more deeper entries"}: link{bafkqabiaaebagba},
-				string{"yet another deeper entries"}: bytes{66697368}
+			string{"some key"}:link{bafkqabiaaebagba},
+			string{"another key"}:string{"another value"},
+			string{"nested map"}:map{
+				string{"deeper entries"}:string{"deeper values"},
+				string{"more deeper entries"}:link{bafkqabiaaebagba},
+				string{"yet another deeper entries"}:bytes{66697368}
 			},
-			string{"nested list"}: list{
-				0: bytes{67686f7469},
-				1: int{1},
-				2: link{bafkqabiaaebagba}
+			string{"nested list"}:list{
+				0:bytes{67686f7469},
+				1:int{1},
+				2:link{bafkqabiaaebagba}
 			}
 		}`,
 		))
@@ -112,10 +153,10 @@ func TestTypedData(t *testing.T) {
 		n := bindnode.Wrap(&FooBar{"x", "y", []byte("zed"), testLink}, ts.TypeByName("FooBar"))
 		qt.Check(t, Sprint(n), qt.CmpEquals(), testutil.Dedent(`
 			struct<FooBar>{
-				foo: string<String>{"x"},
-				bar: string<String>{"y"},
-				baz: bytes<Bytes>{7a6564},
-				jazz: link<Link>{bafkqabiaaebagba}
+				foo:string<String>{"x"},
+				bar:string<String>{"y"},
+				baz:bytes<Bytes>{7a6564},
+				jazz:link<Link>{bafkqabiaaebagba}
 			}`,
 		))
 	})
@@ -145,8 +186,8 @@ func TestTypedData(t *testing.T) {
 		}, ts.TypeByName("WowMap"))
 		qt.Check(t, Sprint(n), qt.CmpEquals(), testutil.Dedent(`
 			map<WowMap>{
-				struct<FooBar>{foo: string<String>{"x"}, bar: string<String>{"y"}}: string<String>{"a"},
-				struct<FooBar>{foo: string<String>{"z"}, bar: string<String>{"z"}}: string<String>{"b"}
+				struct<FooBar>{foo:string<String>{"x"},bar:string<String>{"y"}}:string<String>{"a"},
+				struct<FooBar>{foo:string<String>{"z"},bar:string<String>{"z"}}:string<String>{"b"}
 			}`,
 		))
 	})
@@ -184,48 +225,50 @@ func TestTypedData(t *testing.T) {
 		}, ts.TypeByName("WowMap"))
 		t.Run("complex-keys-in-effect", func(t *testing.T) {
 			cfg := Config{
+				Indentation:              []byte{'\t'},
 				UseMapComplexStyleAlways: true,
 			}
 			qt.Check(t, cfg.Sprint(n), qt.CmpEquals(), testutil.Dedent(`
 				map<WowMap>{
 					struct<FooBar>{
-							foo: string<String>{"x"},
-							bar: struct<Baz>{
-								baz: string<String>{"y"}
+							foo:string<String>{"x"},
+							bar:struct<Baz>{
+								baz:string<String>{"y"}
 							},
-							baz: struct<Baz>{
-								baz: string<String>{"y"}
+							baz:struct<Baz>{
+								baz:string<String>{"y"}
 							}
-					}: struct<Baz>{
-						baz: string<String>{"a"}
+					}:struct<Baz>{
+						baz:string<String>{"a"}
 					},
 					struct<FooBar>{
-							foo: string<String>{"z"},
-							bar: struct<Baz>{
-								baz: string<String>{"z"}
+							foo:string<String>{"z"},
+							bar:struct<Baz>{
+								baz:string<String>{"z"}
 							},
-							baz: struct<Baz>{
-								baz: string<String>{"z"}
+							baz:struct<Baz>{
+								baz:string<String>{"z"}
 							}
-					}: struct<Baz>{
-						baz: string<String>{"b"}
+					}:struct<Baz>{
+						baz:string<String>{"b"}
 					}
 				}`,
 			))
 		})
 		t.Run("complex-keys-in-disabled", func(t *testing.T) {
 			cfg := Config{
+				Indentation: []byte{'\t'},
 				UseMapComplexStyleOnType: map[schema.TypeName]bool{
 					"WowMap": false,
 				},
 			}
 			qt.Check(t, cfg.Sprint(n), qt.CmpEquals(), testutil.Dedent(`
 				map<WowMap>{
-					struct<FooBar>{foo: string<String>{"x"}, bar: struct<Baz>{baz: string<String>{"y"}}, baz: struct<Baz>{baz: string<String>{"y"}}}: struct<Baz>{
-						baz: string<String>{"a"}
+					struct<FooBar>{foo:string<String>{"x"},bar:struct<Baz>{baz:string<String>{"y"}},baz:struct<Baz>{baz:string<String>{"y"}}}:struct<Baz>{
+						baz:string<String>{"a"}
 					},
-					struct<FooBar>{foo: string<String>{"z"}, bar: struct<Baz>{baz: string<String>{"z"}}, baz: struct<Baz>{baz: string<String>{"z"}}}: struct<Baz>{
-						baz: string<String>{"b"}
+					struct<FooBar>{foo:string<String>{"z"},bar:struct<Baz>{baz:string<String>{"z"}},baz:struct<Baz>{baz:string<String>{"z"}}}:struct<Baz>{
+						baz:string<String>{"b"}
 					}
 				}`,
 			))

--- a/printer/printer_test.go
+++ b/printer/printer_test.go
@@ -39,16 +39,16 @@ func TestSimpleData(t *testing.T) {
 		})
 		qt.Check(t, Sprint(n), qt.CmpEquals(), testutil.Dedent(`
 		map{
-			string{"some key"}: string{"some value"}
-			string{"another key"}: string{"another value"}
+			string{"some key"}: string{"some value"},
+			string{"another key"}: string{"another value"},
 			string{"nested map"}: map{
-				string{"deeper entries"}: string{"deeper values"}
+				string{"deeper entries"}: string{"deeper values"},
 				string{"more deeper entries"}: string{"more deeper values"}
-			}
+			},
 			string{"nested list"}: list{
-				0: int{1}
+				0: int{1},
 				1: int{2}
-			}
+			},
 			string{"list with float"}: list{
 				0: float{3.4}
 			}
@@ -73,16 +73,16 @@ func TestSimpleData(t *testing.T) {
 		})
 		qt.Check(t, Sprint(n), qt.CmpEquals(), testutil.Dedent(`
 		map{
-			string{"some key"}: link{bafkqabiaaebagba}
-			string{"another key"}: string{"another value"}
+			string{"some key"}: link{bafkqabiaaebagba},
+			string{"another key"}: string{"another value"},
 			string{"nested map"}: map{
-				string{"deeper entries"}: string{"deeper values"}
-				string{"more deeper entries"}: link{bafkqabiaaebagba}
+				string{"deeper entries"}: string{"deeper values"},
+				string{"more deeper entries"}: link{bafkqabiaaebagba},
 				string{"yet another deeper entries"}: bytes{66697368}
-			}
+			},
 			string{"nested list"}: list{
-				0: bytes{67686f7469}
-				1: int{1}
+				0: bytes{67686f7469},
+				1: int{1},
 				2: link{bafkqabiaaebagba}
 			}
 		}`,
@@ -112,9 +112,9 @@ func TestTypedData(t *testing.T) {
 		n := bindnode.Wrap(&FooBar{"x", "y", []byte("zed"), testLink}, ts.TypeByName("FooBar"))
 		qt.Check(t, Sprint(n), qt.CmpEquals(), testutil.Dedent(`
 			struct<FooBar>{
-				foo: string<String>{"x"}
-				bar: string<String>{"y"}
-				baz: bytes<Bytes>{7a6564}
+				foo: string<String>{"x"},
+				bar: string<String>{"y"},
+				baz: bytes<Bytes>{7a6564},
 				jazz: link<Link>{bafkqabiaaebagba}
 			}`,
 		))
@@ -145,7 +145,7 @@ func TestTypedData(t *testing.T) {
 		}, ts.TypeByName("WowMap"))
 		qt.Check(t, Sprint(n), qt.CmpEquals(), testutil.Dedent(`
 			map<WowMap>{
-				struct<FooBar>{foo: string<String>{"x"}, bar: string<String>{"y"}}: string<String>{"a"}
+				struct<FooBar>{foo: string<String>{"x"}, bar: string<String>{"y"}}: string<String>{"a"},
 				struct<FooBar>{foo: string<String>{"z"}, bar: string<String>{"z"}}: string<String>{"b"}
 			}`,
 		))
@@ -189,21 +189,21 @@ func TestTypedData(t *testing.T) {
 			qt.Check(t, cfg.Sprint(n), qt.CmpEquals(), testutil.Dedent(`
 				map<WowMap>{
 					struct<FooBar>{
-							foo: string<String>{"x"}
+							foo: string<String>{"x"},
 							bar: struct<Baz>{
 								baz: string<String>{"y"}
-							}
+							},
 							baz: struct<Baz>{
 								baz: string<String>{"y"}
 							}
 					}: struct<Baz>{
 						baz: string<String>{"a"}
-					}
+					},
 					struct<FooBar>{
-							foo: string<String>{"z"}
+							foo: string<String>{"z"},
 							bar: struct<Baz>{
 								baz: string<String>{"z"}
-							}
+							},
 							baz: struct<Baz>{
 								baz: string<String>{"z"}
 							}
@@ -223,7 +223,7 @@ func TestTypedData(t *testing.T) {
 				map<WowMap>{
 					struct<FooBar>{foo: string<String>{"x"}, bar: struct<Baz>{baz: string<String>{"y"}}, baz: struct<Baz>{baz: string<String>{"y"}}}: struct<Baz>{
 						baz: string<String>{"a"}
-					}
+					},
 					struct<FooBar>{foo: string<String>{"z"}, bar: struct<Baz>{baz: string<String>{"z"}}, baz: struct<Baz>{baz: string<String>{"z"}}}: struct<Baz>{
 						baz: string<String>{"b"}
 					}

--- a/printer/printer_test.go
+++ b/printer/printer_test.go
@@ -95,6 +95,10 @@ func TestSimpleData(t *testing.T) {
 				->}`,
 			))
 		})
+
+		t.Run("omit-scalars", func(t *testing.T) {
+			qt.Check(t, Config{OmitScalarValues: true}.Sprint(n), qt.CmpEquals(), `map{string:string,string:string,string:map{string:string,string:string},string:list{0:int,1:int},string:list{0:float}}`)
+		})
 	})
 
 	t.Run("map-with-link-and-bytes", func(t *testing.T) {


### PR DESCRIPTION
I'm attempting here to make something that lets me _see_ the forms of a block without looking at the matrix and without it getting too out of hand when the block is complex.

See printer/printer_test.go for examples of what this is doing. There's some breakage here, however, so @warpfork you might want to weigh in if you still care about the `printer` package:

* Always add commas between list/map items (except for the last one)
* Remove the space between the index/key and the value (so it's always like `foo:string{"bar"}` or `10:string{"bar"}`)
* Don't change `Indentation` if it's left `nil`, it just means there's no indentation, you have to set it. The default package-exposed functions set it to `\t` though.
* If `Indentation` is `nil`, then we also don't print newlines; similar to the behaviour of encoding/json and also the JS `JSON.stringify`.
* Add an `OmitScalarValues` option

As per test example, a basic `Config{OmitScalarValues: true}` would give you the most compact form:

`map{string:string,string:string,string:map{string:string,string:string},string:list{0:int,1:int},string:list{0:float}}`

So far, the most complex thing I've printed with this is a Filecoin HAMT root with embedded [`SectorPreCommitOnChainInfo`](https://github.com/filecoin-project/go-state-types/blob/126d7cfaebc91a8eea739ef6fd28b67a3e903a53/builtin/v16/miner/miner_state.go#L155-L160) (tuple representation) values in it:

`list{0:bytes,1:list{0:list{0:list{0:bytes,1:list{0:list{0:int,1:int,2:link,3:int,4:list{},5:int,6:link},1:bytes,2:int}},1:list{0:bytes,1:list{0:list{0:int,1:int,2:link,3:int,4:list{},5:int,6:link},1:bytes,2:int}}},1:list{0:list{0:bytes,1:list{0:list{0:int,1:int,2:link,3:int,4:list{},5:int,6:link},1:bytes,2:int}},1:list{0:bytes,1:list{0:list{0:int,1:int,2:link,3:int,4:list{},5:int,6:link},1:bytes,2:int}}},2:list{0:list{0:bytes,1:list{0:list{0:int,1:int,2:link,3:int,4:list{},5:int,6:link},1:bytes,2:int}}},3:list{0:list{0:bytes,1:list{0:list{0:int,1:int,2:link,3:int,4:list{},5:int,6:link},1:bytes,2:int}}},4:list{0:list{0:bytes,1:list{0:list{0:int,1:int,2:link,3:int,4:list{},5:int,6:link},1:bytes,2:int}}}}}`

It's still a little bit like looking in the matrix but it's more helpful than printing out CBOR diagnostic output and I'm yet to properly build a set of schemas to match these against.