### PR TITLE
feat(codec): MaxDepth on DecodeOptions & more bounds testing

### DIFF
--- a/codec/dagcbor/unmarshal.go
+++ b/codec/dagcbor/unmarshal.go
@@ -19,6 +19,7 @@ import (
 var (
 	ErrInvalidMultibase         = errors.New("invalid multibase on IPLD link")
 	ErrAllocationBudgetExceeded = errors.New("message structure demanded too many resources to process")
+	ErrDecodeDepthExceeded      = errors.New("message structure exceeded maximum nesting depth")
 	ErrTrailingBytes            = errors.New("unexpected content after end of cbor object")
 )
 
@@ -79,11 +80,19 @@ type DecodeOptions struct {
 	//
 	// When zero, a default of 1024 is used.
 	MaxCollectionPrealloc int64
+
+	// MaxDepth sets the maximum nesting depth for decoded structures. If the
+	// decoder encounters a map or list nested beyond this depth, it returns
+	// ErrDecodeDepthExceeded.
+	//
+	// When zero, a default of 1024 is used.
+	MaxDepth int64
 }
 
 const (
 	defaultAllocationBudget      int64 = 1048576 * 10
 	defaultMaxCollectionPrealloc int64 = 1024
+	defaultMaxDepth              int64 = 1024
 )
 
 // Decode deserializes data from the given io.Reader and feeds it into the given datamodel.NodeAssembler.
@@ -92,6 +101,10 @@ const (
 // The behavior of the decoder can be customized by setting fields in the DecodeOptions struct before calling this method.
 func (cfg DecodeOptions) Decode(na datamodel.NodeAssembler, r io.Reader) error {
 	// Probe for a builtin fast path.  Shortcut to that if possible.
+	// Note: when an assembler implements this interface, it receives only the
+	// reader and none of the fields set on cfg. Implementations are responsible
+	// for enforcing their own equivalents of AllocationBudget,
+	// MaxCollectionPrealloc, MaxDepth and the other DecodeOptions fields.
 	type detectFastPath interface {
 		DecodeDagCbor(io.Reader) error
 	}
@@ -135,7 +148,7 @@ func Unmarshal(na datamodel.NodeAssembler, tokSrc shared.TokenSource, options De
 	if budget == 0 {
 		budget = defaultAllocationBudget
 	}
-	return unmarshal1(na, tokSrc, &budget, options)
+	return unmarshal1(na, tokSrc, &budget, 0, options)
 }
 
 func (cfg DecodeOptions) maxPrealloc() int64 {
@@ -145,7 +158,14 @@ func (cfg DecodeOptions) maxPrealloc() int64 {
 	return defaultMaxCollectionPrealloc
 }
 
-func unmarshal1(na datamodel.NodeAssembler, tokSrc shared.TokenSource, budget *int64, options DecodeOptions) error {
+func (cfg DecodeOptions) maxDepth() int64 {
+	if cfg.MaxDepth > 0 {
+		return cfg.MaxDepth
+	}
+	return defaultMaxDepth
+}
+
+func unmarshal1(na datamodel.NodeAssembler, tokSrc shared.TokenSource, budget *int64, depth int64, options DecodeOptions) error {
 	var tk tok.Token
 	done, err := tokSrc.Step(&tk)
 	if err == io.EOF {
@@ -157,16 +177,19 @@ func unmarshal1(na datamodel.NodeAssembler, tokSrc shared.TokenSource, budget *i
 	if done && !tk.Type.IsValue() && tk.Type != tok.TNull {
 		return fmt.Errorf("unexpected eof")
 	}
-	return unmarshal2(na, tokSrc, &tk, budget, options)
+	return unmarshal2(na, tokSrc, &tk, budget, depth, options)
 }
 
 // starts with the first token already primed.  Necessary to get recursion
 //
 //	to flow right without a peek+unpeek system.
-func unmarshal2(na datamodel.NodeAssembler, tokSrc shared.TokenSource, tk *tok.Token, budget *int64, options DecodeOptions) error {
+func unmarshal2(na datamodel.NodeAssembler, tokSrc shared.TokenSource, tk *tok.Token, budget *int64, depth int64, options DecodeOptions) error {
 	// FUTURE: check for schema.TypedNodeBuilder that's going to parse a Link (they can slurp any token kind they want).
 	switch tk.Type {
 	case tok.TMapOpen:
+		if depth >= options.maxDepth() {
+			return ErrDecodeDepthExceeded
+		}
 		expectLen := int64(tk.Length)
 		allocLen := int64(tk.Length)
 		if tk.Length == -1 {
@@ -221,7 +244,7 @@ func unmarshal2(na datamodel.NodeAssembler, tokSrc shared.TokenSource, tk *tok.T
 			if err != nil { // return in error if the key was rejected
 				return err
 			}
-			err = unmarshal1(mva, tokSrc, budget, options)
+			err = unmarshal1(mva, tokSrc, budget, depth+1, options)
 			if err != nil { // return in error if some part of the recursion errored
 				return err
 			}
@@ -229,6 +252,9 @@ func unmarshal2(na datamodel.NodeAssembler, tokSrc shared.TokenSource, tk *tok.T
 	case tok.TMapClose:
 		return fmt.Errorf("unexpected mapClose token")
 	case tok.TArrOpen:
+		if depth >= options.maxDepth() {
+			return ErrDecodeDepthExceeded
+		}
 		expectLen := int64(tk.Length)
 		allocLen := int64(tk.Length)
 		if tk.Length == -1 {
@@ -268,7 +294,7 @@ func unmarshal2(na datamodel.NodeAssembler, tokSrc shared.TokenSource, tk *tok.T
 				if observedLen > expectLen {
 					return fmt.Errorf("unexpected continuation of array elements beyond declared length")
 				}
-				err := unmarshal2(la.AssembleValue(), tokSrc, tk, budget, options)
+				err := unmarshal2(la.AssembleValue(), tokSrc, tk, budget, depth+1, options)
 				if err != nil { // return in error if some part of the recursion errored
 					return err
 				}

--- a/codec/dagcbor/unmarshal_test.go
+++ b/codec/dagcbor/unmarshal_test.go
@@ -230,3 +230,135 @@ func TestDecodeOptions_MaxCollectionPrealloc(t *testing.T) {
 		qt.Assert(t, node.Length(), qt.Equals, int64(numEntries))
 	})
 }
+
+// TestDecodeOptions_MaxDepth verifies that the configurable nesting-depth
+// limit is respected, both with defaults and custom values.
+func TestDecodeOptions_MaxDepth(t *testing.T) {
+	// buildNestedArrays returns depth `0x81` bytes (array(1)) followed by a
+	// single `0xF6` null, forming `depth` levels of nested single-element
+	// arrays.
+	buildNestedArrays := func(depth int) []byte {
+		buf := make([]byte, 0, depth+1)
+		for i := 0; i < depth; i++ {
+			buf = append(buf, 0x81)
+		}
+		buf = append(buf, 0xF6)
+		return buf
+	}
+
+	t.Run("default depth rejects deeply nested structure", func(t *testing.T) {
+		payload := buildNestedArrays(2000)
+		nb := basicnode.Prototype.Any.NewBuilder()
+		err := Decode(nb, bytes.NewReader(payload))
+		qt.Assert(t, err, qt.Equals, ErrDecodeDepthExceeded)
+	})
+
+	t.Run("structure at default depth decodes", func(t *testing.T) {
+		payload := buildNestedArrays(1024)
+		nb := basicnode.Prototype.Any.NewBuilder()
+		err := Decode(nb, bytes.NewReader(payload))
+		qt.Assert(t, err, qt.IsNil)
+		qt.Assert(t, nb.Build().Kind(), qt.Equals, datamodel.Kind_List)
+	})
+
+	t.Run("custom depth rejects when exceeded", func(t *testing.T) {
+		payload := buildNestedArrays(10)
+		nb := basicnode.Prototype.Any.NewBuilder()
+		err := DecodeOptions{MaxDepth: 5}.Decode(nb, bytes.NewReader(payload))
+		qt.Assert(t, err, qt.Equals, ErrDecodeDepthExceeded)
+	})
+
+	t.Run("custom depth accepts within limit", func(t *testing.T) {
+		payload := buildNestedArrays(5)
+		nb := basicnode.Prototype.Any.NewBuilder()
+		err := DecodeOptions{MaxDepth: 10}.Decode(nb, bytes.NewReader(payload))
+		qt.Assert(t, err, qt.IsNil)
+		qt.Assert(t, nb.Build().Kind(), qt.Equals, datamodel.Kind_List)
+	})
+
+	t.Run("nested maps also limited", func(t *testing.T) {
+		// Build N nested single-entry maps each with key "x" wrapping a null.
+		const depth = 2000
+		buf := make([]byte, 0, 3*depth+1)
+		for i := 0; i < depth; i++ {
+			buf = append(buf, 0xA1) // map(1)
+			buf = append(buf, 0x61) // text(1)
+			buf = append(buf, 'x')
+		}
+		buf = append(buf, 0xF6) // null
+
+		nb := basicnode.Prototype.Any.NewBuilder()
+		err := Decode(nb, bytes.NewReader(buf))
+		qt.Assert(t, err, qt.Equals, ErrDecodeDepthExceeded)
+	})
+
+	t.Run("zero MaxDepth resolves to default", func(t *testing.T) {
+		payload := buildNestedArrays(2000)
+		nb := basicnode.Prototype.Any.NewBuilder()
+		err := DecodeOptions{MaxDepth: 0}.Decode(nb, bytes.NewReader(payload))
+		qt.Assert(t, err, qt.Equals, ErrDecodeDepthExceeded)
+	})
+
+	t.Run("indefinite-length collections also limited", func(t *testing.T) {
+		// Stream of 0x9F (indefinite list open) markers then a null, then
+		// matching 0xFF break bytes. Exercises the indefinite-length branch
+		// of the decoder which has a separate code path to the definite one.
+		const depth = 2000
+		buf := make([]byte, 0, 2*depth+1)
+		for i := 0; i < depth; i++ {
+			buf = append(buf, 0x9F)
+		}
+		buf = append(buf, 0xF6)
+		for i := 0; i < depth; i++ {
+			buf = append(buf, 0xFF)
+		}
+		nb := basicnode.Prototype.Any.NewBuilder()
+		err := Decode(nb, bytes.NewReader(buf))
+		qt.Assert(t, err, qt.Equals, ErrDecodeDepthExceeded)
+	})
+}
+
+// TestDecoderBoundaries asserts that decoder-layer and tokenizer-layer limits
+// behave as expected for unusual or malformed inputs. These are sanity tests
+// around boundaries that callers sometimes need to reason about.
+func TestDecoderBoundaries(t *testing.T) {
+	t.Run("oversized string declaration rejected by tokenizer", func(t *testing.T) {
+		// Text header declaring 1 TiB; no following bytes. The underlying
+		// refmt tokenizer caps string/bytes length before attempting to read.
+		var buf bytes.Buffer
+		buf.WriteByte(0x7B) // text(uint64 length)
+		binary.Write(&buf, binary.BigEndian, uint64(1<<40))
+
+		nb := basicnode.Prototype.Any.NewBuilder()
+		err := Decode(nb, bytes.NewReader(buf.Bytes()))
+		qt.Assert(t, err, qt.Not(qt.IsNil))
+	})
+
+	t.Run("stacked CBOR tags rejected", func(t *testing.T) {
+		// CBOR permits tagging a value, but the tokenizer refuses to stack
+		// multiple tags on a single item. Link handling relies on this.
+		payload := []byte{
+			0xD8, 42, // tag(42)
+			0xD8, 42, // tag(42)
+			0x42, 0x00, 0x01,
+		}
+		nb := basicnode.Prototype.Any.NewBuilder()
+		err := DecodeOptions{AllowLinks: true}.Decode(nb, bytes.NewReader(payload))
+		qt.Assert(t, err, qt.Not(qt.IsNil))
+	})
+
+	t.Run("indefinite collection exceeding budget rejected", func(t *testing.T) {
+		// Indefinite-length arrays have no declared size, but per-entry
+		// budget still applies as entries are read.
+		var buf bytes.Buffer
+		buf.WriteByte(0x9F) // indefinite array
+		for i := 0; i < 3_000_000; i++ {
+			buf.WriteByte(0x00)
+		}
+		buf.WriteByte(0xFF) // break
+
+		nb := basicnode.Prototype.Any.NewBuilder()
+		err := Decode(nb, bytes.NewReader(buf.Bytes()))
+		qt.Assert(t, err, qt.Equals, ErrAllocationBudgetExceeded)
+	})
+}

--- a/codec/dagcbor/unmarshal_test.go
+++ b/codec/dagcbor/unmarshal_test.go
@@ -350,12 +350,12 @@ func TestDecoderBoundaries(t *testing.T) {
 	t.Run("indefinite collection exceeding budget rejected", func(t *testing.T) {
 		// Indefinite-length arrays have no declared size, but per-entry
 		// budget still applies as entries are read.
+		const entries = 3_000_000
 		var buf bytes.Buffer
-		buf.WriteByte(0x9F) // indefinite array
-		for i := 0; i < 3_000_000; i++ {
-			buf.WriteByte(0x00)
-		}
-		buf.WriteByte(0xFF) // break
+		buf.Grow(1 + entries + 1)
+		buf.WriteByte(0x9F)              // indefinite array
+		buf.Write(make([]byte, entries)) // entries zero-valued uints
+		buf.WriteByte(0xFF)              // break
 
 		nb := basicnode.Prototype.Any.NewBuilder()
 		err := Decode(nb, bytes.NewReader(buf.Bytes()))

--- a/codec/dagjson/options_test.go
+++ b/codec/dagjson/options_test.go
@@ -1,0 +1,88 @@
+package dagjson
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/ipld/go-ipld-prime/datamodel"
+	"github.com/ipld/go-ipld-prime/node/basicnode"
+)
+
+// TestDecodeOptions_MaxDepth verifies that the configurable nesting-depth
+// limit is respected, both with defaults and custom values.
+func TestDecodeOptions_MaxDepth(t *testing.T) {
+	nested := func(depth int) []byte {
+		return []byte(strings.Repeat("[", depth) + "null" + strings.Repeat("]", depth))
+	}
+
+	t.Run("default depth rejects deeply nested structure", func(t *testing.T) {
+		nb := basicnode.Prototype.Any.NewBuilder()
+		err := Decode(nb, bytes.NewReader(nested(2000)))
+		qt.Assert(t, err, qt.Equals, ErrDecodeDepthExceeded)
+	})
+
+	t.Run("structure at default depth decodes", func(t *testing.T) {
+		nb := basicnode.Prototype.Any.NewBuilder()
+		err := Decode(nb, bytes.NewReader(nested(1024)))
+		qt.Assert(t, err, qt.IsNil)
+		qt.Assert(t, nb.Build().Kind(), qt.Equals, datamodel.Kind_List)
+	})
+
+	t.Run("custom depth rejects when exceeded", func(t *testing.T) {
+		nb := basicnode.Prototype.Any.NewBuilder()
+		err := DecodeOptions{MaxDepth: 5}.Decode(nb, bytes.NewReader(nested(10)))
+		qt.Assert(t, err, qt.Equals, ErrDecodeDepthExceeded)
+	})
+
+	t.Run("custom depth accepts within limit", func(t *testing.T) {
+		nb := basicnode.Prototype.Any.NewBuilder()
+		err := DecodeOptions{MaxDepth: 10}.Decode(nb, bytes.NewReader(nested(5)))
+		qt.Assert(t, err, qt.IsNil)
+		qt.Assert(t, nb.Build().Kind(), qt.Equals, datamodel.Kind_List)
+	})
+
+	t.Run("nested maps also limited", func(t *testing.T) {
+		const depth = 2000
+		buf := strings.Repeat(`{"x":`, depth) + "null" + strings.Repeat("}", depth)
+		nb := basicnode.Prototype.Any.NewBuilder()
+		err := Decode(nb, bytes.NewReader([]byte(buf)))
+		qt.Assert(t, err, qt.Equals, ErrDecodeDepthExceeded)
+	})
+
+	t.Run("zero MaxDepth resolves to default", func(t *testing.T) {
+		nb := basicnode.Prototype.Any.NewBuilder()
+		err := DecodeOptions{MaxDepth: 0}.Decode(nb, bytes.NewReader(nested(2000)))
+		qt.Assert(t, err, qt.Equals, ErrDecodeDepthExceeded)
+	})
+
+	t.Run("ParseLinks lookahead does not bypass depth", func(t *testing.T) {
+		// A valid DAG-JSON link ({"/":"..."}) wrapped in deep list nesting.
+		// The lookahead path for ParseLinks must still honour the depth limit.
+		const depth = 2000
+		buf := strings.Repeat("[", depth) + `{"/":"bafkqaaa"}` + strings.Repeat("]", depth)
+		nb := basicnode.Prototype.Any.NewBuilder()
+		err := DecodeOptions{ParseLinks: true}.Decode(nb, bytes.NewReader([]byte(buf)))
+		qt.Assert(t, err, qt.Equals, ErrDecodeDepthExceeded)
+	})
+
+	t.Run("ParseBytes lookahead does not bypass depth", func(t *testing.T) {
+		// A valid DAG-JSON bytes object wrapped in deep list nesting.
+		const depth = 2000
+		buf := strings.Repeat("[", depth) + `{"/":{"bytes":"aGVsbG8"}}` + strings.Repeat("]", depth)
+		nb := basicnode.Prototype.Any.NewBuilder()
+		err := DecodeOptions{ParseBytes: true}.Decode(nb, bytes.NewReader([]byte(buf)))
+		qt.Assert(t, err, qt.Equals, ErrDecodeDepthExceeded)
+	})
+
+	t.Run("ParseLinks within limit resolves link correctly", func(t *testing.T) {
+		// Depth 5 well within the default limit; ensure the lookahead path
+		// still yields a Link node when not overflowing.
+		buf := strings.Repeat("[", 5) + `{"/":"bafkqaaa"}` + strings.Repeat("]", 5)
+		nb := basicnode.Prototype.Any.NewBuilder()
+		err := DecodeOptions{ParseLinks: true}.Decode(nb, bytes.NewReader([]byte(buf)))
+		qt.Assert(t, err, qt.IsNil)
+	})
+}

--- a/codec/dagjson/options_test.go
+++ b/codec/dagjson/options_test.go
@@ -84,5 +84,13 @@ func TestDecodeOptions_MaxDepth(t *testing.T) {
 		nb := basicnode.Prototype.Any.NewBuilder()
 		err := DecodeOptions{ParseLinks: true}.Decode(nb, bytes.NewReader([]byte(buf)))
 		qt.Assert(t, err, qt.IsNil)
+
+		n := nb.Build()
+		for i := 0; i < 5; i++ {
+			qt.Assert(t, n.Kind(), qt.Equals, datamodel.Kind_List)
+			n, err = n.LookupByIndex(0)
+			qt.Assert(t, err, qt.IsNil)
+		}
+		qt.Assert(t, n.Kind(), qt.Equals, datamodel.Kind_Link)
 	})
 }

--- a/codec/dagjson/unmarshal.go
+++ b/codec/dagjson/unmarshal.go
@@ -2,6 +2,7 @@ package dagjson
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 
@@ -13,6 +14,12 @@ import (
 	"github.com/ipld/go-ipld-prime/datamodel"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 )
+
+// ErrDecodeDepthExceeded is returned when a decoded structure nests deeper
+// than the configured MaxDepth.
+var ErrDecodeDepthExceeded = errors.New("message structure exceeded maximum nesting depth")
+
+const defaultMaxDepth int64 = 1024
 
 // This drifts pretty far from the general unmarshal in the parent package:
 //   - we know JSON never has length hints, so we ignore that field in tokens;
@@ -39,6 +46,20 @@ type DecodeOptions struct {
 	// part of the JSON structure and will error if there is extraneous
 	// non-whitespace data.
 	DontParseBeyondEnd bool
+
+	// MaxDepth sets the maximum nesting depth for decoded structures. If the
+	// decoder encounters a map or list nested beyond this depth, it returns
+	// ErrDecodeDepthExceeded.
+	//
+	// When zero, a default of 1024 is used.
+	MaxDepth int64
+}
+
+func (cfg DecodeOptions) maxDepth() int64 {
+	if cfg.MaxDepth > 0 {
+		return cfg.MaxDepth
+	}
+	return defaultMaxDepth
 }
 
 // Decode deserializes data from the given io.Reader and feeds it into the given datamodel.NodeAssembler.
@@ -98,7 +119,7 @@ func Unmarshal(na datamodel.NodeAssembler, tokSrc shared.TokenSource, options De
 	if done && !st.tk[0].Type.IsValue() && st.tk[0].Type != tok.TNull {
 		return fmt.Errorf("unexpected eof")
 	}
-	return st.unmarshal(na, tokSrc)
+	return st.unmarshal(na, tokSrc, 0)
 }
 
 type unmarshalState struct {
@@ -298,10 +319,13 @@ func (st *unmarshalState) bytesLookahead(na datamodel.NodeAssembler, tokSrc shar
 // starts with the first token already primed.  Necessary to get recursion
 //
 //	to flow right without a peek+unpeek system.
-func (st *unmarshalState) unmarshal(na datamodel.NodeAssembler, tokSrc shared.TokenSource) error {
+func (st *unmarshalState) unmarshal(na datamodel.NodeAssembler, tokSrc shared.TokenSource, depth int64) error {
 	// FUTURE: check for schema.TypedNodeBuilder that's going to parse a Link (they can slurp any token kind they want).
 	switch st.tk[0].Type {
 	case tok.TMapOpen:
+		if depth >= st.options.maxDepth() {
+			return ErrDecodeDepthExceeded
+		}
 		// dag-json has special needs: we pump a few tokens ahead to look for dag-json's "link" pattern.
 		//  We can't actually call BeginMap until we're sure it's not gonna turn out to be a link.
 		if st.options.ParseLinks {
@@ -351,7 +375,7 @@ func (st *unmarshalState) unmarshal(na datamodel.NodeAssembler, tokSrc shared.To
 			if err != nil { // return in error if next token unreadable
 				return err
 			}
-			err = st.unmarshal(mva, tokSrc)
+			err = st.unmarshal(mva, tokSrc, depth+1)
 			if err != nil { // return in error if some part of the recursion errored
 				return err
 			}
@@ -359,6 +383,9 @@ func (st *unmarshalState) unmarshal(na datamodel.NodeAssembler, tokSrc shared.To
 	case tok.TMapClose:
 		return fmt.Errorf("unexpected mapClose token")
 	case tok.TArrOpen:
+		if depth >= st.options.maxDepth() {
+			return ErrDecodeDepthExceeded
+		}
 		la, err := na.BeginList(-1)
 		if err != nil {
 			return err
@@ -372,7 +399,7 @@ func (st *unmarshalState) unmarshal(na datamodel.NodeAssembler, tokSrc shared.To
 			case tok.TArrClose:
 				return la.Finish()
 			default:
-				err := st.unmarshal(la.AssembleValue(), tokSrc)
+				err := st.unmarshal(la.AssembleValue(), tokSrc, depth+1)
 				if err != nil { // return in error if some part of the recursion errored
 					return err
 				}


### PR DESCRIPTION
* Adds more bounds testing following up from #611.
* Adds a `MaxDepth` field to `dagcbor.DecodeOptions` and `dagjson.DecodeOptions` that caps the nesting depth of decoded structures. Exceeding the limit returns a new `ErrDecodeDepthExceeded` error. Defaults to 1024.