### PR TITLE
chore: remove dependabot groups for updatability

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,3 @@ updates:
       interval: "monthly"
     cooldown:
       default-days: 5
-    groups:
-      shared-dependencies:
-        group-by: "dependency-name"


### PR DESCRIPTION
Ran into this and it's annoying: https://github.com/dependabot/dependabot-core/issues/14780